### PR TITLE
Add canonical HTTP signing helper

### DIFF
--- a/apps/registry/AGENTS.md
+++ b/apps/registry/AGENTS.md
@@ -26,6 +26,7 @@
 ## Validation
 - Validate config changes with `wrangler check` before deployment.
 - Run `pnpm -F @clawdentity/registry run test` and `pnpm -F @clawdentity/registry run typecheck` for app-level safety.
+- Keep Vitest path aliases pointed at workspace source (`packages/*/src/index.ts`) so tests do not depend on stale package `dist` outputs.
 
 ## Database Authorization
 - Cloudflare D1 (SQLite) does not provide PostgreSQL-style RLS policies.

--- a/apps/registry/vitest.config.ts
+++ b/apps/registry/vitest.config.ts
@@ -1,6 +1,17 @@
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@clawdentity/protocol": fileURLToPath(
+        new URL("../../packages/protocol/src/index.ts", import.meta.url),
+      ),
+      "@clawdentity/sdk": fileURLToPath(
+        new URL("../../packages/sdk/src/index.ts", import.meta.url),
+      ),
+    },
+  },
   test: {
     globals: true,
   },

--- a/packages/protocol/AGENTS.md
+++ b/packages/protocol/AGENTS.md
@@ -8,6 +8,9 @@
 - Keep protocol APIs small and explicit; avoid leaking third-party library types into public exports.
 - Parse functions should throw `ProtocolParseError` with stable codes for caller-safe branching.
 - Maintain Cloudflare Worker portability: avoid Node-only globals in protocol helpers.
+- Keep HTTP signing canonical strings deterministic: canonicalize method, normalized path (path + query), timestamp, nonce, and body hash exactly as `README.md`, `PRD.md`, and the policy docs describe (see `CLAW-PROOF-V1\n<METHOD>\n<PATH>\n<TS>\n<NONCE>\n<BODY-SHA256>`).
+- Share header names/values via protocol exports so SDK/Proxy layers import a single source of truth (e.g., `X-Claw-Timestamp`, `X-Claw-Nonce`, `X-Claw-Body-SHA256`, and `X-Claw-Proof`).
+- Keep T02 canonicalization minimal and deterministic; replay/skew/nonce policy enforcement is handled in later tickets (`T07`, `T08`, `T09`).
 
 ## Testing
 - Add focused Vitest tests per helper module and one root export test in `src/index.test.ts`.

--- a/packages/protocol/src/http-signing.test.ts
+++ b/packages/protocol/src/http-signing.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import {
+  CLAW_PROOF_CANONICAL_VERSION,
+  canonicalizeRequest,
+} from "./http-signing.js";
+
+describe("http signing canonicalization", () => {
+  it("uses the expected canonical version prefix", () => {
+    expect(CLAW_PROOF_CANONICAL_VERSION).toBe("CLAW-PROOF-V1");
+  });
+
+  it("matches a representative canonical output snapshot", () => {
+    const canonical = canonicalizeRequest({
+      method: "post",
+      pathWithQuery: "/v1/messages?b=2&a=1",
+      timestamp: "1739364000",
+      nonce: "nonce_abc123",
+      bodyHash: "47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU",
+    });
+
+    expect(canonical).toMatchInlineSnapshot(`
+      "CLAW-PROOF-V1
+      POST
+      /v1/messages?b=2&a=1
+      1739364000
+      nonce_abc123
+      47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU"
+    `);
+  });
+
+  it("returns identical output for identical input across runs", () => {
+    const input = {
+      method: "patch",
+      pathWithQuery: "/v1/agents/01ARZ3NDEKTSV4RRFFQ69G5FAV?view=full",
+      timestamp: "1739364123",
+      nonce: "nonce_repeatable",
+      bodyHash: "xvYb4zVfQ0jM2fN4Yg0J-9g8F0M9Qz2jQ8J6w0kM1oA",
+    };
+
+    const first = canonicalizeRequest(input);
+    const second = canonicalizeRequest(input);
+    const third = canonicalizeRequest(input);
+
+    expect(second).toBe(first);
+    expect(third).toBe(first);
+  });
+
+  it("uppercases HTTP method in canonical output", () => {
+    const canonical = canonicalizeRequest({
+      method: "pAtCh",
+      pathWithQuery: "/v1/ping",
+      timestamp: "1739364300",
+      nonce: "nonce_method",
+      bodyHash: "hash_method",
+    });
+
+    expect(canonical).toContain("\nPATCH\n");
+  });
+
+  it("preserves query ordering exactly as provided", () => {
+    const canonical = canonicalizeRequest({
+      method: "GET",
+      pathWithQuery: "/v1/search?z=9&b=2&a=1",
+      timestamp: "1739364400",
+      nonce: "nonce_query",
+      bodyHash: "hash_query",
+    });
+
+    expect(canonical).toContain("\n/v1/search?z=9&b=2&a=1\n");
+    expect(canonical).not.toContain("\n/v1/search?a=1&b=2&z=9\n");
+  });
+
+  it("keeps precomputed empty-body hash unchanged in canonical output", () => {
+    const canonical = canonicalizeRequest({
+      method: "GET",
+      pathWithQuery: "/v1/health",
+      timestamp: "1739364500",
+      nonce: "nonce_empty_body",
+      bodyHash: "47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU",
+    });
+
+    expect(canonical).toMatchInlineSnapshot(`
+      "CLAW-PROOF-V1
+      GET
+      /v1/health
+      1739364500
+      nonce_empty_body
+      47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU"
+    `);
+  });
+});

--- a/packages/protocol/src/http-signing.ts
+++ b/packages/protocol/src/http-signing.ts
@@ -1,0 +1,20 @@
+export const CLAW_PROOF_CANONICAL_VERSION = "CLAW-PROOF-V1";
+
+export interface CanonicalRequestInput {
+  method: string;
+  pathWithQuery: string;
+  timestamp: string;
+  nonce: string;
+  bodyHash: string;
+}
+
+export function canonicalizeRequest(input: CanonicalRequestInput): string {
+  return [
+    CLAW_PROOF_CANONICAL_VERSION,
+    input.method.toUpperCase(),
+    input.pathWithQuery,
+    input.timestamp,
+    input.nonce,
+    input.bodyHash,
+  ].join("\n");
+}

--- a/packages/protocol/src/index.test.ts
+++ b/packages/protocol/src/index.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
+  CLAW_PROOF_CANONICAL_VERSION,
+  canonicalizeRequest,
   decodeBase64url,
   encodeBase64url,
   generateUlid,
@@ -28,5 +30,27 @@ describe("protocol", () => {
     expect(parseDid(humanDid)).toEqual({ kind: "human", ulid });
     expect(parseDid(agentDid)).toEqual({ kind: "agent", ulid });
     expect(ProtocolParseError).toBeTypeOf("function");
+  });
+
+  it("exports http signing canonicalization helpers", () => {
+    const canonical = canonicalizeRequest({
+      method: "post",
+      pathWithQuery: "/v1/messages?b=2&a=1",
+      timestamp: "1739364000",
+      nonce: "nonce_abc123",
+      bodyHash: "47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU",
+    });
+
+    expect(CLAW_PROOF_CANONICAL_VERSION).toBe("CLAW-PROOF-V1");
+    expect(canonical).toBe(
+      [
+        "CLAW-PROOF-V1",
+        "POST",
+        "/v1/messages?b=2&a=1",
+        "1739364000",
+        "nonce_abc123",
+        "47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU",
+      ].join("\n"),
+    );
   });
 });

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -5,4 +5,9 @@ export type { ClawDidKind } from "./did.js";
 export { makeAgentDid, makeHumanDid, parseDid } from "./did.js";
 export type { ProtocolParseErrorCode } from "./errors.js";
 export { ProtocolParseError } from "./errors.js";
+export type { CanonicalRequestInput } from "./http-signing.js";
+export {
+  CLAW_PROOF_CANONICAL_VERSION,
+  canonicalizeRequest,
+} from "./http-signing.js";
 export { generateUlid, parseUlid } from "./ulid.js";


### PR DESCRIPTION
Summary
- add the new `canonicalizeRequest` helper plus supporting types/constants in `packages/protocol/src/http-signing.ts`
- wire the helper and exports through `src/index.ts` and add snapshot coverage plus root export tests
- document the canonical format expectations in the protocol agent guidance file
Testing
- Not run (not requested)