### PR TITLE
[T03] Implement Ed25519 keypair generation and sign/verify utilities

### DIFF
--- a/packages/sdk/AGENTS.md
+++ b/packages/sdk/AGENTS.md
@@ -10,14 +10,19 @@
 - `datetime`: UTC-only helpers for expiry and date arithmetic.
 - `config`: schema-validated runtime config parsing.
 - `request-context`: request ID extraction/generation and propagation.
+- `crypto/ed25519`: byte-first keypair/sign/verify helpers for PoP and token workflows.
 
 ## Design Rules
 - Keep helpers Cloudflare-compatible and local-runtime-compatible.
 - Prefer small wrappers with explicit contracts over heavy framework abstractions.
 - Avoid leaking secrets in logs and error payloads.
 - Keep all parse/validation errors explicit and deterministic.
+- Keep cryptography APIs byte-first (`Uint8Array`) and runtime-portable.
+- Reuse protocol base64url helpers as the single source of truth; do not duplicate encoding logic in SDK.
+- Never log secret keys or raw signature material.
 
 ## Testing Rules
 - Unit test each shared module.
 - Validate error codes/envelopes and request ID behavior.
 - Keep tests deterministic and offline.
+- Crypto tests must include explicit negative verification cases (wrong message/signature/key).

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@clawdentity/protocol": "workspace:*",
+    "@noble/ed25519": "^3.0.0",
     "hono": "^4.11.9",
     "zod": "^4.1.12"
   }

--- a/packages/sdk/src/crypto/ed25519.test.ts
+++ b/packages/sdk/src/crypto/ed25519.test.ts
@@ -1,0 +1,110 @@
+import { ProtocolParseError } from "@clawdentity/protocol";
+import { describe, expect, it } from "vitest";
+import {
+  decodeEd25519KeypairBase64url,
+  decodeEd25519SignatureBase64url,
+  encodeEd25519KeypairBase64url,
+  encodeEd25519SignatureBase64url,
+  generateEd25519Keypair,
+  signEd25519,
+  verifyEd25519,
+} from "./ed25519.js";
+
+const encoder = new TextEncoder();
+
+describe("ed25519 crypto helpers", () => {
+  it("generates keypairs with expected key lengths", async () => {
+    const keypair = await generateEd25519Keypair();
+
+    expect(keypair.publicKey).toBeInstanceOf(Uint8Array);
+    expect(keypair.secretKey).toBeInstanceOf(Uint8Array);
+    expect(keypair.publicKey).toHaveLength(32);
+    expect(keypair.secretKey).toHaveLength(32);
+  });
+
+  it("signs and verifies successfully with matching message and keypair", async () => {
+    const keypair = await generateEd25519Keypair();
+    const message = encoder.encode("t03-happy-path");
+
+    const signature = await signEd25519(message, keypair.secretKey);
+    const isValid = await verifyEd25519(signature, message, keypair.publicKey);
+
+    expect(isValid).toBe(true);
+  });
+
+  it("fails verification with the wrong message", async () => {
+    const keypair = await generateEd25519Keypair();
+    const message = encoder.encode("t03-original-message");
+    const wrongMessage = encoder.encode("t03-tampered-message");
+    const signature = await signEd25519(message, keypair.secretKey);
+
+    const isValid = await verifyEd25519(
+      signature,
+      wrongMessage,
+      keypair.publicKey,
+    );
+
+    expect(isValid).toBe(false);
+  });
+
+  it("fails verification with a tampered signature", async () => {
+    const keypair = await generateEd25519Keypair();
+    const message = encoder.encode("t03-signature-tamper");
+    const signature = await signEd25519(message, keypair.secretKey);
+    const tamperedSignature = Uint8Array.from(signature);
+    tamperedSignature[0] ^= 0xff;
+
+    const isValid = await verifyEd25519(
+      tamperedSignature,
+      message,
+      keypair.publicKey,
+    );
+
+    expect(isValid).toBe(false);
+  });
+
+  it("fails verification with a different public key", async () => {
+    const keypair = await generateEd25519Keypair();
+    const otherKeypair = await generateEd25519Keypair();
+    const message = encoder.encode("t03-wrong-public-key");
+    const signature = await signEd25519(message, keypair.secretKey);
+
+    const isValid = await verifyEd25519(
+      signature,
+      message,
+      otherKeypair.publicKey,
+    );
+
+    expect(isValid).toBe(false);
+  });
+
+  it("roundtrips keypairs and signatures through base64url wrappers", async () => {
+    const keypair = await generateEd25519Keypair();
+    const message = encoder.encode("t03-base64url-roundtrip");
+    const signature = await signEd25519(message, keypair.secretKey);
+
+    const encodedKeypair = encodeEd25519KeypairBase64url(keypair);
+    const decodedKeypair = decodeEd25519KeypairBase64url(encodedKeypair);
+
+    expect(Array.from(decodedKeypair.publicKey)).toEqual(
+      Array.from(keypair.publicKey),
+    );
+    expect(Array.from(decodedKeypair.secretKey)).toEqual(
+      Array.from(keypair.secretKey),
+    );
+
+    const encodedSignature = encodeEd25519SignatureBase64url(signature);
+    const decodedSignature = decodeEd25519SignatureBase64url(encodedSignature);
+    expect(Array.from(decodedSignature)).toEqual(Array.from(signature));
+  });
+
+  it("throws protocol parse errors when decoding invalid base64url signature", () => {
+    try {
+      decodeEd25519SignatureBase64url("invalid+base64url");
+      throw new Error("expected decode to throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ProtocolParseError);
+      expect((error as ProtocolParseError).code).toBe("INVALID_BASE64URL");
+    }
+  });
+});

--- a/packages/sdk/src/crypto/ed25519.ts
+++ b/packages/sdk/src/crypto/ed25519.ts
@@ -1,0 +1,61 @@
+import { decodeBase64url, encodeBase64url } from "@clawdentity/protocol";
+import * as ed25519 from "@noble/ed25519";
+
+export type Ed25519KeypairBytes = {
+  publicKey: Uint8Array;
+  secretKey: Uint8Array;
+};
+
+export type Ed25519KeypairBase64url = {
+  publicKey: string;
+  secretKey: string;
+};
+
+export async function generateEd25519Keypair(): Promise<Ed25519KeypairBytes> {
+  const keypair = await ed25519.keygenAsync();
+  return {
+    publicKey: keypair.publicKey,
+    secretKey: keypair.secretKey,
+  };
+}
+
+export async function signEd25519(
+  message: Uint8Array,
+  secretKey: Uint8Array,
+): Promise<Uint8Array> {
+  return ed25519.signAsync(message, secretKey);
+}
+
+export async function verifyEd25519(
+  signature: Uint8Array,
+  message: Uint8Array,
+  publicKey: Uint8Array,
+): Promise<boolean> {
+  return ed25519.verifyAsync(signature, message, publicKey);
+}
+
+export function encodeEd25519KeypairBase64url(
+  keypair: Ed25519KeypairBytes,
+): Ed25519KeypairBase64url {
+  return {
+    publicKey: encodeBase64url(keypair.publicKey),
+    secretKey: encodeBase64url(keypair.secretKey),
+  };
+}
+
+export function decodeEd25519KeypairBase64url(
+  keypair: Ed25519KeypairBase64url,
+): Ed25519KeypairBytes {
+  return {
+    publicKey: decodeBase64url(keypair.publicKey),
+    secretKey: decodeBase64url(keypair.secretKey),
+  };
+}
+
+export function encodeEd25519SignatureBase64url(signature: Uint8Array): string {
+  return encodeBase64url(signature);
+}
+
+export function decodeEd25519SignatureBase64url(signature: string): Uint8Array {
+  return decodeBase64url(signature);
+}

--- a/packages/sdk/src/index.test.ts
+++ b/packages/sdk/src/index.test.ts
@@ -2,10 +2,17 @@ import { describe, expect, it } from "vitest";
 import {
   AppError,
   addSeconds,
+  decodeEd25519KeypairBase64url,
+  decodeEd25519SignatureBase64url,
+  encodeEd25519KeypairBase64url,
+  encodeEd25519SignatureBase64url,
+  generateEd25519Keypair,
   parseRegistryConfig,
   REQUEST_ID_HEADER,
   resolveRequestId,
   SDK_VERSION,
+  signEd25519,
+  verifyEd25519,
 } from "./index.js";
 
 describe("sdk", () => {
@@ -23,5 +30,25 @@ describe("sdk", () => {
     );
     expect(REQUEST_ID_HEADER).toBe("x-request-id");
     expect(AppError).toBeTypeOf("function");
+  });
+
+  it("exports Ed25519 helpers from package root", async () => {
+    const keypair = await generateEd25519Keypair();
+    const message = new TextEncoder().encode("root-export-crypto-test");
+    const signature = await signEd25519(message, keypair.secretKey);
+
+    expect(await verifyEd25519(signature, message, keypair.publicKey)).toBe(
+      true,
+    );
+
+    const encodedKeypair = encodeEd25519KeypairBase64url(keypair);
+    const decodedKeypair = decodeEd25519KeypairBase64url(encodedKeypair);
+    expect(Array.from(decodedKeypair.publicKey)).toEqual(
+      Array.from(keypair.publicKey),
+    );
+
+    const encodedSignature = encodeEd25519SignatureBase64url(signature);
+    const decodedSignature = decodeEd25519SignatureBase64url(encodedSignature);
+    expect(Array.from(decodedSignature)).toEqual(Array.from(signature));
   });
 });

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -2,6 +2,19 @@ export const SDK_VERSION = "0.0.0";
 
 export type { RegistryConfig } from "./config.js";
 export { parseRegistryConfig, registryConfigSchema } from "./config.js";
+export type {
+  Ed25519KeypairBase64url,
+  Ed25519KeypairBytes,
+} from "./crypto/ed25519.js";
+export {
+  decodeEd25519KeypairBase64url,
+  decodeEd25519SignatureBase64url,
+  encodeEd25519KeypairBase64url,
+  encodeEd25519SignatureBase64url,
+  generateEd25519Keypair,
+  signEd25519,
+  verifyEd25519,
+} from "./crypto/ed25519.js";
 export { addSeconds, isExpired, nowIso } from "./datetime.js";
 export {
   AppError,

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "lib": ["ES2022", "DOM"],
-    "outDir": "./dist",
-    "rootDir": "./src"
+    "outDir": "./dist"
   },
   "include": ["src"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ importers:
       '@clawdentity/protocol':
         specifier: workspace:*
         version: link:../protocol
+      '@noble/ed25519':
+        specifier: ^3.0.0
+        version: 3.0.0
       hono:
         specifier: ^4.11.9
         version: 4.11.9
@@ -838,6 +841,9 @@ packages:
 
   '@napi-rs/wasm-runtime@0.2.4':
     resolution: {integrity: sha512-9zESzOO5aDByvhIAsOy9TbpZ0Ur2AJbUI7UT73kcUTS2mxAMHOBaa1st/jAymNoCtvrit99kkzT1FZuXVcgfIQ==}
+
+  '@noble/ed25519@3.0.0':
+    resolution: {integrity: sha512-QyteqMNm0GLqfa5SoYbSC3+Pvykwpn95Zgth4MFVSMKBB75ELl9tX1LAVsN4c3HXOrakHsF2gL4zWDAYCcsnzg==}
 
   '@nx/nx-darwin-arm64@22.5.0':
     resolution: {integrity: sha512-MHnzv6tzucvLsh4oS9FTepj+ct/o8/DPXrQow+9Jid7GSgY59xrDX/8CleJOrwL5lqKEyGW7vv8TR+4wGtEWTA==}
@@ -2727,6 +2733,8 @@ snapshots:
       '@emnapi/core': 1.8.1
       '@emnapi/runtime': 1.8.1
       '@tybys/wasm-util': 0.9.0
+
+  '@noble/ed25519@3.0.0': {}
 
   '@nx/nx-darwin-arm64@22.5.0':
     optional: true


### PR DESCRIPTION
## Summary
- add `packages/sdk/src/crypto/ed25519.ts` with byte-first Ed25519 keypair/sign/verify helpers
- add base64url convenience wrappers for keypairs/signatures that reuse `@clawdentity/protocol` helpers (no duplicated codec logic)
- export new crypto APIs from `packages/sdk/src/index.ts` and add root export coverage in `packages/sdk/src/index.test.ts`
- add dedicated crypto unit tests for happy path and negative verification cases
- add `@noble/ed25519` dependency and update SDK AGENTS guidance for crypto/base64 rules
- update SDK tsconfig to allow workspace path-mapped protocol imports during typecheck

## Validation
- `pnpm lint`
- `pnpm -r typecheck`
- `pnpm -r test`
- `pnpm -r build`
- pre-push hook: `pnpm affected:test:local` (nx affected lint/format/typecheck/test)

Closes #5
