### PR TITLE
[T05] Implement AIT JWS sign/verify utilities in SDK

### DIFF
--- a/packages/sdk/AGENTS.md
+++ b/packages/sdk/AGENTS.md
@@ -11,6 +11,7 @@
 - `config`: schema-validated runtime config parsing.
 - `request-context`: request ID extraction/generation and propagation.
 - `crypto/ed25519`: byte-first keypair/sign/verify helpers for PoP and token workflows.
+- `jwt/ait-jwt`: AIT JWS signing and verification with strict header and issuer checks.
 
 ## Design Rules
 - Keep helpers Cloudflare-compatible and local-runtime-compatible.
@@ -20,9 +21,11 @@
 - Keep cryptography APIs byte-first (`Uint8Array`) and runtime-portable.
 - Reuse protocol base64url helpers as the single source of truth; do not duplicate encoding logic in SDK.
 - Never log secret keys or raw signature material.
+- Enforce AIT JWT security invariants in verification: `alg=EdDSA`, `typ=AIT`, and `kid` lookup against registry keys.
 
 ## Testing Rules
 - Unit test each shared module.
 - Validate error codes/envelopes and request ID behavior.
 - Keep tests deterministic and offline.
 - Crypto tests must include explicit negative verification cases (wrong message/signature/key).
+- JWT tests must include sign/verify happy path and failure paths for issuer mismatch and missing/unknown `kid`.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -22,6 +22,7 @@
     "@clawdentity/protocol": "workspace:*",
     "@noble/ed25519": "^3.0.0",
     "hono": "^4.11.9",
+    "jose": "^6.1.3",
     "zod": "^4.1.12"
   }
 }

--- a/packages/sdk/src/index.test.ts
+++ b/packages/sdk/src/index.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  AitJwtError,
   AppError,
   addSeconds,
   decodeEd25519KeypairBase64url,
@@ -11,7 +12,9 @@ import {
   REQUEST_ID_HEADER,
   resolveRequestId,
   SDK_VERSION,
+  signAIT,
   signEd25519,
+  verifyAIT,
   verifyEd25519,
 } from "./index.js";
 
@@ -50,5 +53,49 @@ describe("sdk", () => {
     const encodedSignature = encodeEd25519SignatureBase64url(signature);
     const decodedSignature = decodeEd25519SignatureBase64url(encodedSignature);
     expect(Array.from(decodedSignature)).toEqual(Array.from(signature));
+  });
+
+  it("exports AIT JWT helpers from package root", async () => {
+    const keypair = await generateEd25519Keypair();
+    const token = await signAIT({
+      claims: {
+        iss: "https://registry.clawdentity.dev",
+        sub: "did:claw:agent:01HF7YAT00W6W7CM7N3W5FDXT4",
+        ownerDid: "did:claw:human:01HF7YAT31JZHSMW1CG6Q6MHB7",
+        name: "jwt-root-test",
+        framework: "openclaw",
+        cnf: {
+          jwk: {
+            kty: "OKP",
+            crv: "Ed25519",
+            x: encodeEd25519KeypairBase64url(keypair).publicKey,
+          },
+        },
+        iat: 1700100000,
+        nbf: 1700099995,
+        exp: 4700100000,
+        jti: "01HF7YAT4TXP6AW5QNXA2Y9K43",
+      },
+      signerKid: "reg-key-root",
+      signerKeypair: keypair,
+    });
+
+    const verified = await verifyAIT({
+      token,
+      registryKeys: [
+        {
+          kid: "reg-key-root",
+          jwk: {
+            kty: "OKP",
+            crv: "Ed25519",
+            x: encodeEd25519KeypairBase64url(keypair).publicKey,
+          },
+        },
+      ],
+      expectedIssuer: "https://registry.clawdentity.dev",
+    });
+
+    expect(verified.name).toBe("jwt-root-test");
+    expect(AitJwtError).toBeTypeOf("function");
   });
 });

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -21,6 +21,12 @@ export {
   createHonoErrorHandler,
   toErrorEnvelope,
 } from "./exceptions.js";
+export type {
+  RegistryAitVerificationKey,
+  SignAitInput,
+  VerifyAitInput,
+} from "./jwt/ait-jwt.js";
+export { AitJwtError, signAIT, verifyAIT } from "./jwt/ait-jwt.js";
 export type { Logger } from "./logging.js";
 export { createLogger, createRequestLoggingMiddleware } from "./logging.js";
 export type { RequestContextVariables } from "./request-context.js";

--- a/packages/sdk/src/jwt/ait-jwt.test.ts
+++ b/packages/sdk/src/jwt/ait-jwt.test.ts
@@ -1,0 +1,121 @@
+import {
+  type AitClaims,
+  encodeBase64url,
+  generateUlid,
+  makeAgentDid,
+  makeHumanDid,
+} from "@clawdentity/protocol";
+import { describe, expect, it } from "vitest";
+import { generateEd25519Keypair } from "../crypto/ed25519.js";
+import { signAIT, verifyAIT } from "./ait-jwt.js";
+
+function makeClaims(overrides: Partial<AitClaims> = {}): AitClaims {
+  const agentUlid = generateUlid(1700100000000);
+  const ownerUlid = generateUlid(1700100001000);
+  const now = Math.floor(Date.now() / 1000);
+
+  return {
+    iss: "https://registry.clawdentity.dev",
+    sub: makeAgentDid(agentUlid),
+    ownerDid: makeHumanDid(ownerUlid),
+    name: "agent-jwt-01",
+    framework: "openclaw",
+    description: "AIT JWT test payload",
+    cnf: {
+      jwk: {
+        kty: "OKP",
+        crv: "Ed25519",
+        x: encodeBase64url(
+          Uint8Array.from({ length: 32 }, (_, index) => index + 1),
+        ),
+      },
+    },
+    iat: now,
+    nbf: now - 5,
+    exp: now + 3600,
+    jti: generateUlid(1700100002000),
+    ...overrides,
+  };
+}
+
+describe("AIT JWT helpers", () => {
+  it("signs and verifies an AIT with matching registry key + kid", async () => {
+    const keypair = await generateEd25519Keypair();
+    const claims = makeClaims();
+    const token = await signAIT({
+      claims,
+      signerKid: "reg-key-1",
+      signerKeypair: keypair,
+    });
+
+    const verified = await verifyAIT({
+      token,
+      registryKeys: [
+        {
+          kid: "reg-key-1",
+          jwk: {
+            kty: "OKP",
+            crv: "Ed25519",
+            x: encodeBase64url(keypair.publicKey),
+          },
+        },
+      ],
+      expectedIssuer: claims.iss,
+    });
+
+    expect(verified).toEqual(claims);
+  });
+
+  it("fails verification when issuer does not match expected issuer", async () => {
+    const keypair = await generateEd25519Keypair();
+    const claims = makeClaims();
+    const token = await signAIT({
+      claims,
+      signerKid: "reg-key-1",
+      signerKeypair: keypair,
+    });
+
+    await expect(
+      verifyAIT({
+        token,
+        registryKeys: [
+          {
+            kid: "reg-key-1",
+            jwk: {
+              kty: "OKP",
+              crv: "Ed25519",
+              x: encodeBase64url(keypair.publicKey),
+            },
+          },
+        ],
+        expectedIssuer: "https://wrong-issuer.example",
+      }),
+    ).rejects.toThrow();
+  });
+
+  it("fails verification when token kid cannot be found in registry key set", async () => {
+    const keypair = await generateEd25519Keypair();
+    const claims = makeClaims();
+    const token = await signAIT({
+      claims,
+      signerKid: "reg-key-1",
+      signerKeypair: keypair,
+    });
+
+    await expect(
+      verifyAIT({
+        token,
+        registryKeys: [
+          {
+            kid: "reg-key-2",
+            jwk: {
+              kty: "OKP",
+              crv: "Ed25519",
+              x: encodeBase64url(keypair.publicKey),
+            },
+          },
+        ],
+      }),
+    ).rejects.toThrow(/kid/i);
+  });
+});

--- a/packages/sdk/src/jwt/ait-jwt.ts
+++ b/packages/sdk/src/jwt/ait-jwt.ts
@@ -1,0 +1,100 @@
+import type { AitClaims, AitCnfJwk } from "@clawdentity/protocol";
+import { parseAitClaims } from "@clawdentity/protocol";
+import type { JWTVerifyOptions } from "jose";
+import { decodeProtectedHeader, importJWK, jwtVerify, SignJWT } from "jose";
+import {
+  type Ed25519KeypairBytes,
+  encodeEd25519KeypairBase64url,
+} from "../crypto/ed25519.js";
+
+type AitPrivateJwk = AitCnfJwk & {
+  d: string;
+};
+
+export type RegistryAitVerificationKey = {
+  kid: string;
+  jwk: AitCnfJwk;
+};
+
+export type SignAitInput = {
+  claims: AitClaims;
+  signerKid: string;
+  signerKeypair: Ed25519KeypairBytes;
+};
+
+export type VerifyAitInput = {
+  token: string;
+  registryKeys: RegistryAitVerificationKey[];
+  expectedIssuer?: string;
+};
+
+export class AitJwtError extends Error {
+  readonly code: "INVALID_AIT_HEADER" | "UNKNOWN_AIT_KID";
+
+  constructor(code: "INVALID_AIT_HEADER" | "UNKNOWN_AIT_KID", message: string) {
+    super(message);
+    this.name = "AitJwtError";
+    this.code = code;
+  }
+}
+
+function invalidAitHeader(message: string): AitJwtError {
+  return new AitJwtError("INVALID_AIT_HEADER", message);
+}
+
+function unknownAitKid(kid: string): AitJwtError {
+  return new AitJwtError("UNKNOWN_AIT_KID", `Unknown AIT signing kid: ${kid}`);
+}
+
+export async function signAIT(input: SignAitInput): Promise<string> {
+  const claims = parseAitClaims(input.claims);
+  const encodedKeypair = encodeEd25519KeypairBase64url(input.signerKeypair);
+  const privateJwk: AitPrivateJwk = {
+    kty: "OKP",
+    crv: "Ed25519",
+    x: encodedKeypair.publicKey,
+    d: encodedKeypair.secretKey,
+  };
+  const privateKey = await importJWK(privateJwk, "EdDSA");
+
+  return new SignJWT(claims)
+    .setProtectedHeader({
+      alg: "EdDSA",
+      typ: "AIT",
+      kid: input.signerKid,
+    })
+    .sign(privateKey);
+}
+
+export async function verifyAIT(input: VerifyAitInput): Promise<AitClaims> {
+  const header = decodeProtectedHeader(input.token);
+  if (header.alg !== "EdDSA") {
+    throw invalidAitHeader("AIT token must use alg=EdDSA");
+  }
+
+  if (header.typ !== "AIT") {
+    throw invalidAitHeader("AIT token must use typ=AIT");
+  }
+
+  if (typeof header.kid !== "string" || header.kid.length === 0) {
+    throw invalidAitHeader("AIT token missing protected kid header");
+  }
+
+  const key = input.registryKeys.find((item) => item.kid === header.kid);
+  if (!key) {
+    throw unknownAitKid(header.kid);
+  }
+
+  const publicKey = await importJWK(key.jwk, "EdDSA");
+  const options: JWTVerifyOptions = {
+    algorithms: ["EdDSA"],
+    typ: "AIT",
+  };
+
+  if (input.expectedIssuer !== undefined) {
+    options.issuer = input.expectedIssuer;
+  }
+
+  const { payload } = await jwtVerify(input.token, publicKey, options);
+  return parseAitClaims(payload);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,9 @@ importers:
       hono:
         specifier: ^4.11.9
         version: 4.11.9
+      jose:
+        specifier: ^6.1.3
+        version: 6.1.3
       zod:
         specifier: ^4.1.12
         version: 4.3.6
@@ -1662,6 +1665,9 @@ packages:
   jest-diff@30.2.0:
     resolution: {integrity: sha512-dQHFo3Pt4/NLlG5z4PxZ/3yZTZ1C7s9hveiOj+GCN+uT109NC2QgsoVZsVOAvbJ3RgKkvyLGXZV9+piDpWbm6A==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jose@6.1.3:
+    resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
 
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
@@ -3401,6 +3407,8 @@ snapshots:
       '@jest/get-type': 30.1.0
       chalk: 4.1.2
       pretty-format: 30.2.0
+
+  jose@6.1.3: {}
 
   joycon@3.1.1: {}
 


### PR DESCRIPTION
## Summary
- add `packages/sdk/src/jwt/ait-jwt.ts` with `signAIT` and `verifyAIT` built on `jose`
- enforce header contract for AIT tokens (`alg=EdDSA`, `typ=AIT`, required `kid`) and `kid` key lookup
- validate claims using protocol `parseAitClaims` both before sign and after verify
- export all new JWT APIs from SDK root and extend SDK tests
- add SDK AGENTS guidance for JWT/crypto best practices

## Files changed
- `packages/sdk/src/jwt/ait-jwt.ts` (new)
- `packages/sdk/src/jwt/ait-jwt.test.ts` (new)
- `packages/sdk/src/index.ts`
- `packages/sdk/src/index.test.ts`
- `packages/sdk/package.json`
- `packages/sdk/AGENTS.md`
- `pnpm-lock.yaml`

## Validation
- `pnpm lint`
- `pnpm -r typecheck`
- `pnpm -r test`
- `pnpm -r build`

## Issue
- Refs #7
