### PR TITLE
[T06] Define signed CRL format and verification logic

### DIFF
--- a/packages/protocol/AGENTS.md
+++ b/packages/protocol/AGENTS.md
@@ -12,6 +12,8 @@
 - Validate risky identity fields (`name`, `description`) with explicit allowlists/length caps; never pass through raw control characters.
 - Reuse existing protocol validators/parsers (`parseDid`, `parseUlid`, base64url helpers) instead of duplicating claim validation logic.
 - Keep HTTP signing canonical strings deterministic: canonicalize method, normalized path (path + query), timestamp, nonce, and body hash exactly as `README.md`, `PRD.md`, and the policy docs describe (see `CLAW-PROOF-V1\n<METHOD>\n<PATH>\n<TS>\n<NONCE>\n<BODY-SHA256>`).
+- Mirror the AIT guardrails for CRL payloads: `crl.ts` keeps `.strict()` definitions, requires at least one revocation entry, enforces `agentDid` is a `did:claw:agent`, `revocation.jti` is a ULID, `exp > iat`, and surfaces `INVALID_CRL_CLAIMS` via `ProtocolParseError`.
+- Reuse cross-module helpers (e.g., `text.ts`’s `hasControlChars`) so control-character checks stay consistent across AIT and CRL validation.
 - Share header names/values via protocol exports so SDK/Proxy layers import a single source of truth (e.g., `X-Claw-Timestamp`, `X-Claw-Nonce`, `X-Claw-Body-SHA256`, and `X-Claw-Proof`).
 - Keep T02 canonicalization minimal and deterministic; replay/skew/nonce policy enforcement is handled in later tickets (`T07`, `T08`, `T09`).
 
@@ -19,3 +21,4 @@
 - Add focused Vitest tests per helper module and one root export test in `src/index.test.ts`.
 - Roundtrip tests must cover empty inputs, known vectors, and invalid inputs for parse failures.
 - Error tests must assert `ProtocolParseError` code values, not just message strings.
+- CRL helpers specifically need coverage for valid payloads, missing or empty revocation entries, invalid `agentDid`/`jti` values, and `exp <= iat`, all verifying the `INVALID_CRL_CLAIMS` code.

--- a/packages/protocol/src/ait.ts
+++ b/packages/protocol/src/ait.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { decodeBase64url } from "./base64url.js";
 import { parseDid } from "./did.js";
 import { ProtocolParseError } from "./errors.js";
+import { hasControlChars } from "./text.js";
 import { parseUlid } from "./ulid.js";
 
 export const MAX_AGENT_NAME_LENGTH = 64;
@@ -15,16 +16,6 @@ export type AitCnfJwk = {
   crv: "Ed25519";
   x: string;
 };
-
-function hasControlChars(value: string): boolean {
-  for (const char of value) {
-    const code = char.charCodeAt(0);
-    if (code <= 0x1f || code === 0x7f) {
-      return true;
-    }
-  }
-  return false;
-}
 
 function invalidAitClaims(message: string): ProtocolParseError {
   return new ProtocolParseError("INVALID_AIT_CLAIMS", message);

--- a/packages/protocol/src/crl.test.ts
+++ b/packages/protocol/src/crl.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { parseCrlClaims } from "./crl.js";
+import { makeAgentDid, makeHumanDid } from "./did.js";
+import { ProtocolParseError } from "./errors.js";
+import { generateUlid } from "./ulid.js";
+
+function makeValidCrlClaims() {
+  const now = 1700000000;
+  const agentUlid = generateUlid(1700000000000);
+
+  return {
+    iss: "https://registry.clawdentity.dev",
+    jti: generateUlid(1700000100000),
+    iat: now,
+    exp: now + 3600,
+    revocations: [
+      {
+        jti: generateUlid(1700000200000),
+        agentDid: makeAgentDid(agentUlid),
+        reason: "key compromise",
+        revokedAt: now + 1000,
+      },
+    ],
+  };
+}
+
+function expectInvalidCrl(payload: unknown) {
+  try {
+    parseCrlClaims(payload);
+    throw new Error("parseCrlClaims was expected to throw");
+  } catch (error) {
+    expect(error).toBeInstanceOf(ProtocolParseError);
+    if (error instanceof ProtocolParseError) {
+      expect(error.code).toBe("INVALID_CRL_CLAIMS");
+    }
+  }
+}
+
+describe("CRL claims schema", () => {
+  it("accepts valid CRL payloads", () => {
+    const parsed = parseCrlClaims(makeValidCrlClaims());
+    expect(parsed.revocations).toHaveLength(1);
+    expect(parsed.revocations[0].agentDid).toMatch(/^did:claw:agent:/);
+  });
+
+  it("rejects missing required fields", () => {
+    const claims = makeValidCrlClaims();
+    delete (claims as Record<string, unknown>).revocations;
+
+    expectInvalidCrl(claims);
+  });
+
+  it("rejects empty revocation arrays", () => {
+    const claims = makeValidCrlClaims();
+    claims.revocations = [];
+
+    expectInvalidCrl(claims);
+  });
+
+  it("rejects non-agent DIDs for revocations", () => {
+    const claims = makeValidCrlClaims();
+    claims.revocations[0].agentDid = makeHumanDid(generateUlid(1700000000000));
+
+    expectInvalidCrl(claims);
+  });
+
+  it("rejects invalid ULIDs in revocation entries", () => {
+    const claims = makeValidCrlClaims();
+    claims.revocations[0].jti = "not-a-ulid";
+
+    expectInvalidCrl(claims);
+  });
+
+  it("rejects exp <= iat", () => {
+    const claims = makeValidCrlClaims();
+    claims.exp = claims.iat;
+
+    expectInvalidCrl(claims);
+  });
+
+  it("rejects unknown top-level claims", () => {
+    const claims = makeValidCrlClaims() as Record<string, unknown>;
+    claims.extra = "unexpected";
+
+    expectInvalidCrl(claims);
+  });
+});

--- a/packages/protocol/src/crl.ts
+++ b/packages/protocol/src/crl.ts
@@ -1,0 +1,91 @@
+import { z } from "zod";
+import { parseDid } from "./did.js";
+import { ProtocolParseError } from "./errors.js";
+import { hasControlChars } from "./text.js";
+import { parseUlid } from "./ulid.js";
+
+const INVALID_CRL_CLAIMS = "INVALID_CRL_CLAIMS" as const;
+
+export const crlClaimsSchema = z
+  .object({
+    iss: z.string().min(1, "iss is required"),
+    jti: z.string().min(1, "jti is required"),
+    iat: z.number().int().nonnegative(),
+    exp: z.number().int().nonnegative(),
+    revocations: z
+      .array(
+        z
+          .object({
+            jti: z.string().min(1, "revocation.jti is required"),
+            agentDid: z.string().min(1, "agentDid is required"),
+            reason: z.string().max(280).optional(),
+            revokedAt: z.number().int().nonnegative(),
+          })
+          .strict()
+          .superRefine((revocation, ctx) => {
+            if (hasControlChars(revocation.agentDid)) {
+              ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                message: "revocation.agentDid contains control characters",
+                path: ["agentDid"],
+              });
+            }
+          }),
+      )
+      .min(1, "revocations must include at least one entry"),
+  })
+  .strict()
+  .superRefine((claims, ctx) => {
+    if (claims.exp <= claims.iat) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "exp must be greater than iat",
+        path: ["exp"],
+      });
+    }
+
+    for (const [index, revocation] of claims.revocations.entries()) {
+      try {
+        const parsedAgentDid = parseDid(revocation.agentDid);
+        if (parsedAgentDid.kind !== "agent") {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: "revocation.agentDid must refer to an agent DID",
+            path: ["revocations", index, "agentDid"],
+          });
+        }
+      } catch {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "revocation.agentDid must be a valid DID",
+          path: ["revocations", index, "agentDid"],
+        });
+      }
+
+      try {
+        parseUlid(revocation.jti);
+      } catch {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "revocation.jti must be a valid ULID",
+          path: ["revocations", index, "jti"],
+        });
+      }
+    }
+  });
+
+export type CrlClaims = z.infer<typeof crlClaimsSchema>;
+
+export function parseCrlClaims(input: unknown): CrlClaims {
+  const parsed = crlClaimsSchema.safeParse(input);
+  if (!parsed.success) {
+    const message = parsed.error.issues
+      .map((issue) => issue.message)
+      .join("; ");
+    throw new ProtocolParseError(
+      INVALID_CRL_CLAIMS,
+      message.length > 0 ? message : "Invalid CRL claims payload",
+    );
+  }
+  return parsed.data;
+}

--- a/packages/protocol/src/errors.ts
+++ b/packages/protocol/src/errors.ts
@@ -2,7 +2,8 @@ export type ProtocolParseErrorCode =
   | "INVALID_AIT_CLAIMS"
   | "INVALID_BASE64URL"
   | "INVALID_ULID"
-  | "INVALID_DID";
+  | "INVALID_DID"
+  | "INVALID_CRL_CLAIMS";
 
 export class ProtocolParseError extends Error {
   readonly code: ProtocolParseErrorCode;

--- a/packages/protocol/src/index.test.ts
+++ b/packages/protocol/src/index.test.ts
@@ -4,6 +4,7 @@ import {
   aitClaimsSchema,
   CLAW_PROOF_CANONICAL_VERSION,
   canonicalizeRequest,
+  crlClaimsSchema,
   decodeBase64url,
   encodeBase64url,
   generateUlid,
@@ -14,6 +15,7 @@ import {
   PROTOCOL_VERSION,
   ProtocolParseError,
   parseAitClaims,
+  parseCrlClaims,
   parseDid,
   parseUlid,
   validateAgentName,
@@ -89,5 +91,29 @@ describe("protocol", () => {
     expect(MAX_AGENT_DESCRIPTION_LENGTH).toBe(280);
     expect(AGENT_NAME_REGEX.test("agent_01")).toBe(true);
     expect(aitClaimsSchema).toBeDefined();
+  });
+
+  it("exports CRL helpers from package root", () => {
+    const now = 1700000000;
+    const agentUlid = generateUlid(now);
+    const agentDid = makeAgentDid(agentUlid);
+
+    const parsed = parseCrlClaims({
+      iss: "https://registry.clawdentity.dev",
+      jti: generateUlid(now + 1000),
+      iat: now,
+      exp: now + 3600,
+      revocations: [
+        {
+          jti: generateUlid(now + 2000),
+          agentDid,
+          reason: "manual revoke",
+          revokedAt: now + 100,
+        },
+      ],
+    });
+
+    expect(parsed.revocations[0].agentDid).toBe(agentDid);
+    expect(crlClaimsSchema).toBeDefined();
   });
 });

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -10,6 +10,8 @@ export {
   validateAgentName,
 } from "./ait.js";
 export { decodeBase64url, encodeBase64url } from "./base64url.js";
+export type { CrlClaims } from "./crl.js";
+export { crlClaimsSchema, parseCrlClaims } from "./crl.js";
 export type { ClawDidKind } from "./did.js";
 export { makeAgentDid, makeHumanDid, parseDid } from "./did.js";
 export type { ProtocolParseErrorCode } from "./errors.js";

--- a/packages/protocol/src/text.ts
+++ b/packages/protocol/src/text.ts
@@ -1,0 +1,9 @@
+export function hasControlChars(value: string): boolean {
+  for (const char of value) {
+    const code = char.charCodeAt(0);
+    if (code <= 0x1f || code === 0x7f) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/packages/sdk/AGENTS.md
+++ b/packages/sdk/AGENTS.md
@@ -12,6 +12,8 @@
 - `request-context`: request ID extraction/generation and propagation.
 - `crypto/ed25519`: byte-first keypair/sign/verify helpers for PoP and token workflows.
 - `jwt/ait-jwt`: AIT JWS signing and verification with strict header and issuer checks.
+- `jwt/crl-jwt`: CRL JWT helpers with EdDSA signing, header consistency checks, and tamper-detection test coverage.
+- Tests should prove tamper cases (payload change, header kid swap, signature corruption).
 
 ## Design Rules
 - Keep helpers Cloudflare-compatible and local-runtime-compatible.
@@ -20,6 +22,7 @@
 - Keep all parse/validation errors explicit and deterministic.
 - Keep cryptography APIs byte-first (`Uint8Array`) and runtime-portable.
 - Reuse protocol base64url helpers as the single source of truth; do not duplicate encoding logic in SDK.
+- Keep CRL claim schema authority in `@clawdentity/protocol` (`crl.ts`); SDK JWT helpers should avoid duplicating claim-validation rules.
 - Never log secret keys or raw signature material.
 - Enforce AIT JWT security invariants in verification: `alg=EdDSA`, `typ=AIT`, and `kid` lookup against registry keys.
 

--- a/packages/sdk/src/index.test.ts
+++ b/packages/sdk/src/index.test.ts
@@ -3,6 +3,7 @@ import {
   AitJwtError,
   AppError,
   addSeconds,
+  CrlJwtError,
   decodeEd25519KeypairBase64url,
   decodeEd25519SignatureBase64url,
   encodeEd25519KeypairBase64url,
@@ -13,8 +14,10 @@ import {
   resolveRequestId,
   SDK_VERSION,
   signAIT,
+  signCRL,
   signEd25519,
   verifyAIT,
+  verifyCRL,
   verifyEd25519,
 } from "./index.js";
 
@@ -97,5 +100,46 @@ describe("sdk", () => {
 
     expect(verified.name).toBe("jwt-root-test");
     expect(AitJwtError).toBeTypeOf("function");
+  });
+
+  it("exports CRL JWT helpers from package root", async () => {
+    const keypair = await generateEd25519Keypair();
+    const now = Math.floor(Date.now() / 1000);
+    const token = await signCRL({
+      claims: {
+        iss: "https://registry.clawdentity.dev",
+        jti: "01HF7YAT4TXP6AW5QNXA2Y9K43",
+        iat: now,
+        exp: now + 3600,
+        revocations: [
+          {
+            jti: "01HF7YAT31JZHSMW1CG6Q6MHB7",
+            agentDid: "did:claw:agent:01HF7YAT00W6W7CM7N3W5FDXT4",
+            reason: "manual revoke",
+            revokedAt: now,
+          },
+        ],
+      },
+      signerKid: "reg-crl-root",
+      signerKeypair: keypair,
+    });
+
+    const verified = await verifyCRL({
+      token,
+      registryKeys: [
+        {
+          kid: "reg-crl-root",
+          jwk: {
+            kty: "OKP",
+            crv: "Ed25519",
+            x: encodeEd25519KeypairBase64url(keypair).publicKey,
+          },
+        },
+      ],
+      expectedIssuer: "https://registry.clawdentity.dev",
+    });
+
+    expect(verified.revocations).toHaveLength(1);
+    expect(CrlJwtError).toBeTypeOf("function");
   });
 });

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -27,6 +27,13 @@ export type {
   VerifyAitInput,
 } from "./jwt/ait-jwt.js";
 export { AitJwtError, signAIT, verifyAIT } from "./jwt/ait-jwt.js";
+export type {
+  CrlClaims,
+  RegistryCrlVerificationKey,
+  SignCrlInput,
+  VerifyCrlInput,
+} from "./jwt/crl-jwt.js";
+export { CrlJwtError, signCRL, verifyCRL } from "./jwt/crl-jwt.js";
 export type { Logger } from "./logging.js";
 export { createLogger, createRequestLoggingMiddleware } from "./logging.js";
 export type { RequestContextVariables } from "./request-context.js";

--- a/packages/sdk/src/jwt/crl-jwt.test.ts
+++ b/packages/sdk/src/jwt/crl-jwt.test.ts
@@ -1,0 +1,179 @@
+import {
+  decodeBase64url,
+  encodeBase64url,
+  generateUlid,
+  makeAgentDid,
+} from "@clawdentity/protocol";
+import { describe, expect, it } from "vitest";
+import { generateEd25519Keypair } from "../crypto/ed25519.js";
+import { type CrlClaims, signCRL, verifyCRL } from "./crl-jwt.js";
+
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
+function makeClaims(overrides: Partial<CrlClaims> = {}): CrlClaims {
+  const now = Math.floor(Date.now() / 1000);
+  const agentId = generateUlid(1700105002000);
+
+  return {
+    iss: "https://registry.clawdentity.dev",
+    jti: generateUlid(1700105000000),
+    iat: now,
+    exp: now + 3600,
+    revocations: [
+      {
+        jti: generateUlid(1700105001000),
+        agentDid: makeAgentDid(agentId),
+        reason: "compromised key",
+        revokedAt: now,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function patchTokenSegment(
+  token: string,
+  segmentIndex: 0 | 1,
+  patch: (payload: Record<string, unknown>) => Record<string, unknown>,
+): string {
+  const parts = token.split(".");
+  const bytes = decodeBase64url(parts[segmentIndex]);
+  const parsed = JSON.parse(textDecoder.decode(bytes));
+  const patched = patch(parsed);
+  const encoded = encodeBase64url(textEncoder.encode(JSON.stringify(patched)));
+  parts[segmentIndex] = encoded;
+  return parts.join(".");
+}
+
+function swapSignature(token: string): string {
+  const parts = token.split(".");
+  parts[2] = "A".repeat(parts[2].length);
+  return parts.join(".");
+}
+
+describe("CRL JWT helpers", () => {
+  it("signs and verifies a valid CRL token", async () => {
+    const keypair = await generateEd25519Keypair();
+    const claims = makeClaims();
+    const token = await signCRL({
+      claims,
+      signerKid: "reg-crl-1",
+      signerKeypair: keypair,
+    });
+
+    const verified = await verifyCRL({
+      token,
+      registryKeys: [
+        {
+          kid: "reg-crl-1",
+          jwk: {
+            kty: "OKP",
+            crv: "Ed25519",
+            x: encodeBase64url(keypair.publicKey),
+          },
+        },
+      ],
+      expectedIssuer: "https://registry.clawdentity.dev",
+    });
+
+    expect(verified.jti).toBe(claims.jti);
+    expect(verified.revocations).toHaveLength(1);
+  });
+
+  it("rejects a payload change after signing", async () => {
+    const keypair = await generateEd25519Keypair();
+    const claims = makeClaims();
+    const token = await signCRL({
+      claims,
+      signerKid: "reg-crl-1",
+      signerKeypair: keypair,
+    });
+
+    const tampered = patchTokenSegment(token, 1, (payload) => {
+      const base = payload as Record<string, unknown> & {
+        revocations?: unknown[];
+      };
+      const existing = Array.isArray(base.revocations) ? base.revocations : [];
+      return {
+        ...base,
+        revocations: [...existing, "tampered"],
+      };
+    });
+
+    await expect(
+      verifyCRL({
+        token: tampered,
+        registryKeys: [
+          {
+            kid: "reg-crl-1",
+            jwk: {
+              kty: "OKP",
+              crv: "Ed25519",
+              x: encodeBase64url(keypair.publicKey),
+            },
+          },
+        ],
+      }),
+    ).rejects.toThrow();
+  });
+
+  it("rejects a header kid tampering attempt", async () => {
+    const keypair = await generateEd25519Keypair();
+    const claims = makeClaims();
+    const token = await signCRL({
+      claims,
+      signerKid: "reg-crl-1",
+      signerKeypair: keypair,
+    });
+
+    const tampered = patchTokenSegment(token, 0, (header) => ({
+      ...header,
+      kid: "tamper-kid",
+    }));
+
+    await expect(
+      verifyCRL({
+        token: tampered,
+        registryKeys: [
+          {
+            kid: "reg-crl-1",
+            jwk: {
+              kty: "OKP",
+              crv: "Ed25519",
+              x: encodeBase64url(keypair.publicKey),
+            },
+          },
+        ],
+      }),
+    ).rejects.toThrow(/kid/i);
+  });
+
+  it("rejects tampered signature bytes", async () => {
+    const keypair = await generateEd25519Keypair();
+    const claims = makeClaims();
+    const token = await signCRL({
+      claims,
+      signerKid: "reg-crl-1",
+      signerKeypair: keypair,
+    });
+
+    const tampered = swapSignature(token);
+
+    await expect(
+      verifyCRL({
+        token: tampered,
+        registryKeys: [
+          {
+            kid: "reg-crl-1",
+            jwk: {
+              kty: "OKP",
+              crv: "Ed25519",
+              x: encodeBase64url(keypair.publicKey),
+            },
+          },
+        ],
+      }),
+    ).rejects.toThrow();
+  });
+});

--- a/packages/sdk/src/jwt/crl-jwt.ts
+++ b/packages/sdk/src/jwt/crl-jwt.ts
@@ -1,0 +1,104 @@
+import type { CrlClaims as ProtocolCrlClaims } from "@clawdentity/protocol";
+import type { JWTVerifyOptions } from "jose";
+import { decodeProtectedHeader, importJWK, jwtVerify, SignJWT } from "jose";
+import type { Ed25519KeypairBytes } from "../crypto/ed25519.js";
+import { encodeEd25519KeypairBase64url } from "../crypto/ed25519.js";
+
+export type CrlClaims = ProtocolCrlClaims;
+
+type CrlPublicJwk = {
+  kty: "OKP";
+  crv: "Ed25519";
+  x: string;
+};
+
+type CrlPrivateJwk = CrlPublicJwk & {
+  d: string;
+};
+
+export type RegistryCrlVerificationKey = {
+  kid: string;
+  jwk: CrlPublicJwk;
+};
+
+export type SignCrlInput = {
+  claims: CrlClaims;
+  signerKid: string;
+  signerKeypair: Ed25519KeypairBytes;
+};
+
+export type VerifyCrlInput = {
+  token: string;
+  registryKeys: RegistryCrlVerificationKey[];
+  expectedIssuer?: string;
+};
+
+export class CrlJwtError extends Error {
+  readonly code: "INVALID_CRL_HEADER" | "UNKNOWN_CRL_KID";
+
+  constructor(code: "INVALID_CRL_HEADER" | "UNKNOWN_CRL_KID", message: string) {
+    super(message);
+    this.name = "CrlJwtError";
+    this.code = code;
+  }
+}
+
+function invalidCrlHeader(message: string): CrlJwtError {
+  return new CrlJwtError("INVALID_CRL_HEADER", message);
+}
+
+function unknownCrlKid(kid: string): CrlJwtError {
+  return new CrlJwtError("UNKNOWN_CRL_KID", `Unknown CRL signing kid: ${kid}`);
+}
+
+export async function signCRL(input: SignCrlInput): Promise<string> {
+  const encodedKeypair = encodeEd25519KeypairBase64url(input.signerKeypair);
+  const privateJwk: CrlPrivateJwk = {
+    kty: "OKP",
+    crv: "Ed25519",
+    x: encodedKeypair.publicKey,
+    d: encodedKeypair.secretKey,
+  };
+  const privateKey = await importJWK(privateJwk, "EdDSA");
+
+  return new SignJWT(input.claims)
+    .setProtectedHeader({
+      alg: "EdDSA",
+      typ: "CRL",
+      kid: input.signerKid,
+    })
+    .sign(privateKey);
+}
+
+export async function verifyCRL(input: VerifyCrlInput): Promise<CrlClaims> {
+  const header = decodeProtectedHeader(input.token);
+  if (header.alg !== "EdDSA") {
+    throw invalidCrlHeader("CRL token must use alg=EdDSA");
+  }
+
+  if (header.typ !== "CRL") {
+    throw invalidCrlHeader("CRL token must use typ=CRL");
+  }
+
+  if (typeof header.kid !== "string" || header.kid.length === 0) {
+    throw invalidCrlHeader("CRL token missing protected kid header");
+  }
+
+  const key = input.registryKeys.find((entry) => entry.kid === header.kid);
+  if (!key) {
+    throw unknownCrlKid(header.kid);
+  }
+
+  const publicKey = await importJWK(key.jwk, "EdDSA");
+  const options: JWTVerifyOptions = {
+    algorithms: ["EdDSA"],
+    typ: "CRL",
+  };
+
+  if (input.expectedIssuer !== undefined) {
+    options.issuer = input.expectedIssuer;
+  }
+
+  const { payload } = await jwtVerify(input.token, publicKey, options);
+  return payload as CrlClaims;
+}


### PR DESCRIPTION
## Summary
- add strict CRL claims schema in protocol (`crlClaimsSchema`, `parseCrlClaims`) with `ProtocolParseError` code `INVALID_CRL_CLAIMS`
- add SDK CRL JWT utilities (`signCRL`, `verifyCRL`) using EdDSA with required protected header invariants (`alg=EdDSA`, `typ=CRL`, required `kid`)
- add tamper-detection tests proving signature verification fails when payload, header `kid`, or signature bytes are modified
- export CRL helpers from protocol and SDK package roots with root export test coverage
- refactor duplicated control-character check into shared `packages/protocol/src/text.ts`
- update protocol/sdk `AGENTS.md` best practices for CRL schema and JWT helper behavior

## Files changed
- `packages/protocol/src/crl.ts` (new)
- `packages/protocol/src/crl.test.ts` (new)
- `packages/protocol/src/text.ts` (new)
- `packages/protocol/src/errors.ts`
- `packages/protocol/src/index.ts`
- `packages/protocol/src/index.test.ts`
- `packages/protocol/src/ait.ts`
- `packages/protocol/AGENTS.md`
- `packages/sdk/src/jwt/crl-jwt.ts` (new)
- `packages/sdk/src/jwt/crl-jwt.test.ts` (new)
- `packages/sdk/src/index.ts`
- `packages/sdk/src/index.test.ts`
- `packages/sdk/AGENTS.md`

## Validation
- `pnpm lint`
- `pnpm -r typecheck`
- `pnpm -r test`
- `pnpm -r build`
- pre-push hook: `nx affected -t lint,format,typecheck,test --base=origin/main --head=HEAD`

## Issue
- Refs #8
