### PR TITLE
feat(registry): serve signed CRL snapshot endpoint

### DIFF
--- a/apps/registry/src/AGENTS.md
+++ b/apps/registry/src/AGENTS.md
@@ -16,6 +16,15 @@
 - Return `keys[]` entries with `kid`, `alg`, `crv`, `x`, and `status` so SDK/offline verifiers can consume directly.
 - Keep cache headers explicit and short-lived (`max-age=300` + `stale-while-revalidate`) to balance key rotation with client efficiency.
 
+## CRL Snapshot Contract
+- `GET /v1/crl` is a public endpoint and must remain unauthenticated so SDK/proxy clients can refresh revocation state without PAT bootstrap dependencies.
+- Success response shape must remain `{ crl: <jwt> }` where `crl` is an EdDSA-signed token with `typ=CRL`.
+- Build CRL claims from the full `revocations` table (MVP full snapshot), joining each row to `agents.did` for `revocations[].agentDid`.
+- Keep CRL cache headers explicit and short-lived (`max-age=300` + `stale-while-revalidate`) for predictable revocation propagation.
+- Ensure CRL JWT `exp` exceeds the full cache serve window (`max-age + stale-while-revalidate`) with a small safety buffer so strict verifiers never see cache-valid but token-expired snapshots.
+- If no revocations exist yet, return `404 CRL_NOT_FOUND` instead of emitting an unsigned or schema-invalid empty snapshot.
+- Route tests should verify the returned CRL token using SDK `verifyCRL` and the published active keys from `/.well-known/claw-keys.json`.
+
 ## Validation
 - Run `pnpm -F @clawdentity/registry run test` after changing routes or config loading.
 - Run `pnpm -F @clawdentity/registry run typecheck` before commit.

--- a/apps/registry/src/server.test.ts
+++ b/apps/registry/src/server.test.ts
@@ -10,6 +10,7 @@ import {
   REQUEST_ID_HEADER,
   signAIT,
   verifyAIT,
+  verifyCRL,
 } from "@clawdentity/sdk";
 import { describe, expect, it } from "vitest";
 import { DEFAULT_AGENT_LIST_LIMIT } from "./agent-list.js";
@@ -62,6 +63,13 @@ type FakeD1Row = {
 type FakeAgentInsertRow = Record<string, unknown>;
 type FakeAgentUpdateRow = Record<string, unknown>;
 type FakeRevocationInsertRow = Record<string, unknown>;
+type FakeRevocationRow = {
+  id: string;
+  jti: string;
+  agentId: string;
+  reason: string | null;
+  revokedAt: string;
+};
 type FakeAgentRow = {
   id: string;
   did: string;
@@ -92,6 +100,16 @@ type FakeAgentSelectRow = {
 
 type FakeDbOptions = {
   beforeFirstAgentUpdate?: (agentRows: FakeAgentRow[]) => void;
+  revocationRows?: FakeRevocationRow[];
+};
+
+type FakeCrlSelectRow = {
+  id: string;
+  jti: string;
+  reason: string | null;
+  revoked_at: string;
+  agent_did: string;
+  did: string;
 };
 
 function parseInsertColumns(query: string, tableName: string): string[] {
@@ -337,6 +355,66 @@ function resolveAgentSelectRows(options: {
   return filteredRows;
 }
 
+function getCrlSelectColumnValue(
+  row: FakeCrlSelectRow,
+  column: string,
+): unknown {
+  if (column === "id") {
+    return row.id;
+  }
+  if (column === "jti") {
+    return row.jti;
+  }
+  if (column === "reason") {
+    return row.reason;
+  }
+  if (column === "revoked_at") {
+    return row.revoked_at;
+  }
+  if (column === "revokedat") {
+    return row.revoked_at;
+  }
+  if (column === "agent_did") {
+    return row.agent_did;
+  }
+  if (column === "agentdid" || column === "did") {
+    return row.did;
+  }
+  return undefined;
+}
+
+function resolveCrlSelectRows(options: {
+  agentRows: FakeAgentRow[];
+  revocationRows: FakeRevocationRow[];
+}): FakeCrlSelectRow[] {
+  return options.revocationRows
+    .map((row) => {
+      const agent = options.agentRows.find(
+        (agentRow) => agentRow.id === row.agentId,
+      );
+      if (!agent) {
+        return null;
+      }
+
+      return {
+        id: row.id,
+        jti: row.jti,
+        reason: row.reason,
+        revoked_at: row.revokedAt,
+        agent_did: agent.did,
+        did: agent.did,
+      };
+    })
+    .filter((row): row is FakeCrlSelectRow => row !== null)
+    .sort((left, right) => {
+      const timestampCompare = right.revoked_at.localeCompare(left.revoked_at);
+      if (timestampCompare !== 0) {
+        return timestampCompare;
+      }
+      return right.id.localeCompare(left.id);
+    });
+}
+
 function createFakeDb(
   rows: FakeD1Row[],
   agentRows: FakeAgentRow[] = [],
@@ -346,6 +424,7 @@ function createFakeDb(
   const agentInserts: FakeAgentInsertRow[] = [];
   const agentUpdates: FakeAgentUpdateRow[] = [];
   const revocationInserts: FakeRevocationInsertRow[] = [];
+  const revocationRows = [...(options.revocationRows ?? [])];
   let beforeFirstAgentUpdateApplied = false;
 
   const database: D1Database = {
@@ -397,6 +476,18 @@ function createFakeDb(
               }),
             };
           }
+          if (
+            (normalizedQuery.includes('from "revocations"') ||
+              normalizedQuery.includes("from revocations")) &&
+            normalizedQuery.includes("select")
+          ) {
+            return {
+              results: resolveCrlSelectRows({
+                agentRows,
+                revocationRows,
+              }),
+            };
+          }
           return { results: [] };
         },
         async raw() {
@@ -435,6 +526,21 @@ function createFakeDb(
             return resultRows.map((row) =>
               selectedColumns.map((column) =>
                 getAgentSelectColumnValue(row, column),
+              ),
+            );
+          }
+          if (
+            normalizedQuery.includes('from "revocations"') ||
+            normalizedQuery.includes("from revocations")
+          ) {
+            const resultRows = resolveCrlSelectRows({
+              agentRows,
+              revocationRows,
+            });
+            const selectedColumns = parseSelectedColumns(query);
+            return resultRows.map((row) =>
+              selectedColumns.map((column) =>
+                getCrlSelectColumnValue(row, column),
               ),
             );
           }
@@ -581,6 +687,20 @@ function createFakeDb(
               {},
             );
             revocationInserts.push(row);
+            if (
+              typeof row.id === "string" &&
+              typeof row.jti === "string" &&
+              typeof row.agent_id === "string" &&
+              typeof row.revoked_at === "string"
+            ) {
+              revocationRows.push({
+                id: row.id,
+                jti: row.jti,
+                agentId: row.agent_id,
+                reason: typeof row.reason === "string" ? row.reason : null,
+                revokedAt: row.revoked_at,
+              });
+            }
             changes = 1;
           }
           return { success: true, meta: { changes } } as D1Result;
@@ -819,6 +939,207 @@ describe("GET /.well-known/claw-keys.json", () => {
           })),
       }),
     ).rejects.toThrow(/kid/i);
+  });
+});
+
+describe("GET /v1/crl", () => {
+  it("returns signed CRL snapshot with cache headers", async () => {
+    const signer = await generateEd25519Keypair();
+    const appInstance = createRegistryApp();
+    const signingKeyset = JSON.stringify([
+      {
+        kid: "reg-key-1",
+        alg: "EdDSA",
+        crv: "Ed25519",
+        x: encodeBase64url(signer.publicKey),
+        status: "active",
+      },
+    ]);
+    const agentIdOne = generateUlid(1700400000000);
+    const agentIdTwo = generateUlid(1700400000100);
+    const revocationJtiOne = generateUlid(1700400000200);
+    const revocationJtiTwo = generateUlid(1700400000300);
+    const { database } = createFakeDb(
+      [],
+      [
+        {
+          id: agentIdOne,
+          did: makeAgentDid(agentIdOne),
+          ownerId: "human-1",
+          name: "revoked-one",
+          framework: "openclaw",
+          status: "revoked",
+          expiresAt: "2026-03-01T00:00:00.000Z",
+        },
+        {
+          id: agentIdTwo,
+          did: makeAgentDid(agentIdTwo),
+          ownerId: "human-2",
+          name: "revoked-two",
+          framework: "langchain",
+          status: "revoked",
+          expiresAt: "2026-03-01T00:00:00.000Z",
+        },
+      ],
+      {
+        revocationRows: [
+          {
+            id: generateUlid(1700400000400),
+            jti: revocationJtiOne,
+            agentId: agentIdOne,
+            reason: null,
+            revokedAt: "2026-02-11T10:00:00.000Z",
+          },
+          {
+            id: generateUlid(1700400000500),
+            jti: revocationJtiTwo,
+            agentId: agentIdTwo,
+            reason: "manual revoke",
+            revokedAt: "2026-02-11T11:00:00.000Z",
+          },
+        ],
+      },
+    );
+
+    const response = await appInstance.request(
+      "/v1/crl",
+      {},
+      {
+        DB: database,
+        ENVIRONMENT: "test",
+        REGISTRY_SIGNING_KEY: encodeBase64url(signer.secretKey),
+        REGISTRY_SIGNING_KEYS: signingKeyset,
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe(
+      "public, max-age=300, s-maxage=300, stale-while-revalidate=60",
+    );
+    const body = (await response.json()) as { crl: string };
+    expect(body.crl).toEqual(expect.any(String));
+
+    const keysResponse = await appInstance.request(
+      "/.well-known/claw-keys.json",
+      {},
+      {
+        DB: database,
+        ENVIRONMENT: "test",
+        REGISTRY_SIGNING_KEY: encodeBase64url(signer.secretKey),
+        REGISTRY_SIGNING_KEYS: signingKeyset,
+      },
+    );
+    const keysBody = (await keysResponse.json()) as {
+      keys: Array<{
+        kid: string;
+        alg: "EdDSA";
+        crv: "Ed25519";
+        x: string;
+        status: "active" | "revoked";
+      }>;
+    };
+
+    const claims = await verifyCRL({
+      token: body.crl,
+      expectedIssuer: "https://dev.api.clawdentity.com",
+      registryKeys: keysBody.keys
+        .filter((key) => key.status === "active")
+        .map((key) => ({
+          kid: key.kid,
+          jwk: {
+            kty: "OKP" as const,
+            crv: key.crv,
+            x: key.x,
+          },
+        })),
+    });
+
+    expect(claims.revocations).toHaveLength(2);
+    expect(claims.revocations).toEqual(
+      expect.arrayContaining([
+        {
+          jti: revocationJtiOne,
+          agentDid: makeAgentDid(agentIdOne),
+          revokedAt: Math.floor(Date.parse("2026-02-11T10:00:00.000Z") / 1000),
+        },
+        {
+          jti: revocationJtiTwo,
+          agentDid: makeAgentDid(agentIdTwo),
+          reason: "manual revoke",
+          revokedAt: Math.floor(Date.parse("2026-02-11T11:00:00.000Z") / 1000),
+        },
+      ]),
+    );
+    expect(claims.exp).toBeGreaterThan(claims.iat);
+    expect(claims.exp - claims.iat).toBe(390);
+  });
+
+  it("returns 404 when no revocations are available", async () => {
+    const { database } = createFakeDb([]);
+    const response = await createRegistryApp().request(
+      "/v1/crl",
+      {},
+      { DB: database, ENVIRONMENT: "test" },
+    );
+
+    expect(response.status).toBe(404);
+    const body = (await response.json()) as {
+      error: {
+        code: string;
+        message: string;
+      };
+    };
+    expect(body.error.code).toBe("CRL_NOT_FOUND");
+    expect(body.error.message).toBe("CRL snapshot is not available");
+  });
+
+  it("returns 500 when CRL signing configuration is missing", async () => {
+    const agentId = generateUlid(1700400000600);
+    const { database } = createFakeDb(
+      [],
+      [
+        {
+          id: agentId,
+          did: makeAgentDid(agentId),
+          ownerId: "human-1",
+          name: "revoked-agent",
+          framework: "openclaw",
+          status: "revoked",
+          expiresAt: "2026-03-01T00:00:00.000Z",
+        },
+      ],
+      {
+        revocationRows: [
+          {
+            id: generateUlid(1700400000700),
+            jti: generateUlid(1700400000800),
+            agentId,
+            reason: null,
+            revokedAt: "2026-02-11T12:00:00.000Z",
+          },
+        ],
+      },
+    );
+
+    const response = await createRegistryApp().request(
+      "/v1/crl",
+      {},
+      { DB: database, ENVIRONMENT: "test" },
+    );
+
+    expect(response.status).toBe(500);
+    const body = (await response.json()) as {
+      error: {
+        code: string;
+        message: string;
+        details?: { fieldErrors?: Record<string, unknown> };
+      };
+    };
+    expect(body.error.code).toBe("CONFIG_VALIDATION_FAILED");
+    expect(body.error.message).toBe("Registry configuration is invalid");
+    expect(body.error.details?.fieldErrors).toMatchObject({
+      REGISTRY_SIGNING_KEYS: expect.any(Array),
+    });
   });
 });
 

--- a/apps/registry/src/server.ts
+++ b/apps/registry/src/server.ts
@@ -10,6 +10,7 @@ import {
   type RegistryConfig,
   shouldExposeVerboseErrors,
   signAIT,
+  signCRL,
 } from "@clawdentity/sdk";
 import { and, desc, eq, lt } from "drizzle-orm";
 import { Hono } from "hono";
@@ -41,8 +42,15 @@ type Bindings = {
   REGISTRY_SIGNING_KEYS?: string;
 };
 const logger = createLogger({ service: "registry" });
-const REGISTRY_KEY_CACHE_CONTROL =
-  "public, max-age=300, s-maxage=300, stale-while-revalidate=60";
+const REGISTRY_CACHE_MAX_AGE_SECONDS = 300;
+const REGISTRY_CACHE_STALE_WHILE_REVALIDATE_SECONDS = 60;
+const REGISTRY_KEY_CACHE_CONTROL = `public, max-age=${REGISTRY_CACHE_MAX_AGE_SECONDS}, s-maxage=${REGISTRY_CACHE_MAX_AGE_SECONDS}, stale-while-revalidate=${REGISTRY_CACHE_STALE_WHILE_REVALIDATE_SECONDS}`;
+const REGISTRY_CRL_CACHE_CONTROL = `public, max-age=${REGISTRY_CACHE_MAX_AGE_SECONDS}, s-maxage=${REGISTRY_CACHE_MAX_AGE_SECONDS}, stale-while-revalidate=${REGISTRY_CACHE_STALE_WHILE_REVALIDATE_SECONDS}`;
+const CRL_EXPIRY_SAFETY_BUFFER_SECONDS = 30;
+const CRL_TTL_SECONDS =
+  REGISTRY_CACHE_MAX_AGE_SECONDS +
+  REGISTRY_CACHE_STALE_WHILE_REVALIDATE_SECONDS +
+  CRL_EXPIRY_SAFETY_BUFFER_SECONDS;
 
 type OwnedAgent = {
   id: string;
@@ -54,6 +62,92 @@ type OwnedAgent = {
   expires_at: string | null;
   current_jti: string | null;
 };
+
+type CrlSnapshotRow = {
+  id: string;
+  jti: string;
+  reason: string | null;
+  revoked_at: string;
+  agent_did: string;
+};
+
+function crlBuildError(options: {
+  environment: RegistryConfig["ENVIRONMENT"];
+  message: string;
+  details?: {
+    fieldErrors: Record<string, string[]>;
+    formErrors: string[];
+  };
+}): AppError {
+  const exposeDetails = shouldExposeVerboseErrors(options.environment);
+  return new AppError({
+    code: "CRL_BUILD_FAILED",
+    message: exposeDetails
+      ? options.message
+      : "CRL snapshot could not be generated",
+    status: 500,
+    expose: exposeDetails,
+    details: exposeDetails ? options.details : undefined,
+  });
+}
+
+function parseRevokedAtSeconds(options: {
+  environment: RegistryConfig["ENVIRONMENT"];
+  revocationId: string;
+  revokedAtIso: string;
+}): number {
+  const epochMillis = Date.parse(options.revokedAtIso);
+  if (!Number.isFinite(epochMillis)) {
+    throw crlBuildError({
+      environment: options.environment,
+      message: "CRL revocation timestamp is invalid",
+      details: {
+        fieldErrors: {
+          revokedAt: [
+            `revocation ${options.revocationId} has invalid revoked_at timestamp`,
+          ],
+        },
+        formErrors: [],
+      },
+    });
+  }
+
+  return Math.floor(epochMillis / 1000);
+}
+
+function buildCrlClaims(input: {
+  rows: CrlSnapshotRow[];
+  environment: RegistryConfig["ENVIRONMENT"];
+  issuer: string;
+  nowSeconds: number;
+}) {
+  return {
+    iss: input.issuer,
+    jti: generateUlid(Date.now()),
+    iat: input.nowSeconds,
+    exp: input.nowSeconds + CRL_TTL_SECONDS,
+    revocations: input.rows.map((row) => {
+      const base = {
+        jti: row.jti,
+        agentDid: row.agent_did,
+        revokedAt: parseRevokedAtSeconds({
+          environment: input.environment,
+          revocationId: row.id,
+          revokedAtIso: row.revoked_at,
+        }),
+      };
+
+      if (typeof row.reason === "string" && row.reason.length > 0) {
+        return {
+          ...base,
+          reason: row.reason,
+        };
+      }
+
+      return base;
+    }),
+  };
+}
 
 async function findOwnedAgent(input: {
   db: ReturnType<typeof createDb>;
@@ -162,6 +256,50 @@ function createRegistryApp() {
         "Cache-Control": REGISTRY_KEY_CACHE_CONTROL,
       },
     );
+  });
+
+  app.get("/v1/crl", async (c) => {
+    const config = getConfig(c.env);
+    const db = createDb(c.env.DB);
+
+    const rows = await db
+      .select({
+        id: revocations.id,
+        jti: revocations.jti,
+        reason: revocations.reason,
+        revoked_at: revocations.revoked_at,
+        agent_did: agents.did,
+      })
+      .from(revocations)
+      .innerJoin(agents, eq(revocations.agent_id, agents.id))
+      .orderBy(desc(revocations.revoked_at), desc(revocations.id));
+
+    if (rows.length === 0) {
+      throw new AppError({
+        code: "CRL_NOT_FOUND",
+        message: "CRL snapshot is not available",
+        status: 404,
+        expose: true,
+      });
+    }
+
+    const signer = await resolveRegistrySigner(config);
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const claims = buildCrlClaims({
+      rows,
+      environment: config.ENVIRONMENT,
+      issuer: resolveRegistryIssuer(config.ENVIRONMENT),
+      nowSeconds,
+    });
+    const crl = await signCRL({
+      claims,
+      signerKid: signer.signerKid,
+      signerKeypair: signer.signerKeypair,
+    });
+
+    return c.json({ crl }, 200, {
+      "Cache-Control": REGISTRY_CRL_CACHE_CONTROL,
+    });
   });
 
   app.get("/v1/me", createApiKeyAuth(), (c) => {


### PR DESCRIPTION
## Summary
- implement T18 by adding public `GET /v1/crl` in the registry
- return signed CRL snapshot payload `{ crl: <jwt> }` built from full `revocations` + `agents.did` join
- return `404 CRL_NOT_FOUND` when no revocations exist
- add CRL route tests (success + signature verification, 404 empty, 500 config validation)
- fix cache/expiry reliability gap by making CRL JWT lifetime exceed cache serve window (`max-age + stale-while-revalidate + safety buffer`)
- document CRL route best practices in `apps/registry/src/AGENTS.md`

## Files
- `apps/registry/src/server.ts`
- `apps/registry/src/server.test.ts`
- `apps/registry/src/AGENTS.md`

## Validation
- `pnpm lint`
- `pnpm -r typecheck`
- `pnpm -r test`
- `pnpm -r build`

All passed locally.
