### PR TITLE
feat(registry): implement T19 public agent resolve endpoint

### DIFF
--- a/apps/registry/src/AGENTS.md
+++ b/apps/registry/src/AGENTS.md
@@ -25,10 +25,20 @@
 - If no revocations exist yet, return `404 CRL_NOT_FOUND` instead of emitting an unsigned or schema-invalid empty snapshot.
 - Route tests should verify the returned CRL token using SDK `verifyCRL` and the published active keys from `/.well-known/claw-keys.json`.
 
+## GET /v1/resolve/:id Contract
+- Public endpoint: no PAT/auth required.
+- Validate `:id` as ULID via dedicated parser and return `400 AGENT_RESOLVE_INVALID_PATH` on invalid path input.
+- Rate-limit by client IP with a basic in-memory limiter and return `429 RATE_LIMIT_EXCEEDED` when over threshold.
+- Return only public fields: `{ did, name, framework, status, ownerDid }`.
+- Do not expose PII or internal fields (email, API key metadata, or private key material).
+- For unknown IDs, return `404 AGENT_NOT_FOUND` with no ownership-leak variants.
+- Keep framework output stable as a non-empty string for legacy rows missing `framework`.
+
 ## Validation
 - Run `pnpm -F @clawdentity/registry run test` after changing routes or config loading.
 - Run `pnpm -F @clawdentity/registry run typecheck` before commit.
-- When using fake D1 adapters in route tests, make select responses honor bound parameters so query-shape regressions are caught.
+- When using fake D1 adapters in route tests, make select responses honor bound parameters, selected-column projection, and join semantics so query-shape regressions are caught.
+- Fake D1 join emulation should drop rows when `innerJoin` targets are missing so tests catch missing/incorrect joins instead of masking them with stubbed values.
 
 ## GET /v1/agents Contract
 - Require PAT auth via `createApiKeyAuth`; only caller-owned agents may be returned.

--- a/apps/registry/src/agent-resolve.ts
+++ b/apps/registry/src/agent-resolve.ts
@@ -1,0 +1,99 @@
+import { parseUlid } from "@clawdentity/protocol";
+import {
+  AppError,
+  type RegistryConfig,
+  shouldExposeVerboseErrors,
+} from "@clawdentity/sdk";
+
+const DEFAULT_RESOLVED_FRAMEWORK = "openclaw";
+
+type AgentStatus = "active" | "revoked";
+
+type ResolvePathErrorDetails = {
+  fieldErrors: Record<string, string[]>;
+  formErrors: string[];
+};
+
+export type ResolvedAgentRow = {
+  did: string;
+  name: string;
+  framework: string | null;
+  status: AgentStatus;
+  owner_did: string;
+};
+
+export type ResolvedAgent = {
+  did: string;
+  name: string;
+  framework: string;
+  status: AgentStatus;
+  ownerDid: string;
+};
+
+function invalidResolvePathError(options: {
+  environment: RegistryConfig["ENVIRONMENT"];
+  details?: ResolvePathErrorDetails;
+}): AppError {
+  const exposeDetails = shouldExposeVerboseErrors(options.environment);
+  return new AppError({
+    code: "AGENT_RESOLVE_INVALID_PATH",
+    message: exposeDetails
+      ? "Agent resolve path is invalid"
+      : "Request could not be processed",
+    status: 400,
+    expose: exposeDetails,
+    details: exposeDetails ? options.details : undefined,
+  });
+}
+
+export function parseAgentResolvePath(input: {
+  id: string;
+  environment: RegistryConfig["ENVIRONMENT"];
+}): string {
+  const id = input.id.trim();
+  if (id.length === 0) {
+    throw invalidResolvePathError({
+      environment: input.environment,
+      details: {
+        fieldErrors: { id: ["id is required"] },
+        formErrors: [],
+      },
+    });
+  }
+
+  try {
+    return parseUlid(id).value;
+  } catch {
+    throw invalidResolvePathError({
+      environment: input.environment,
+      details: {
+        fieldErrors: { id: ["id must be a valid ULID"] },
+        formErrors: [],
+      },
+    });
+  }
+}
+
+export function agentResolveNotFoundError(): AppError {
+  return new AppError({
+    code: "AGENT_NOT_FOUND",
+    message: "Agent not found",
+    status: 404,
+    expose: true,
+  });
+}
+
+export function mapResolvedAgentRow(row: ResolvedAgentRow): ResolvedAgent {
+  const framework =
+    typeof row.framework === "string" && row.framework.length > 0
+      ? row.framework
+      : DEFAULT_RESOLVED_FRAMEWORK;
+
+  return {
+    did: row.did,
+    name: row.name,
+    framework,
+    status: row.status,
+    ownerDid: row.owner_did,
+  };
+}

--- a/apps/registry/src/rate-limit.ts
+++ b/apps/registry/src/rate-limit.ts
@@ -1,0 +1,87 @@
+import { AppError } from "@clawdentity/sdk";
+import type { MiddlewareHandler } from "hono";
+
+export const RESOLVE_RATE_LIMIT_WINDOW_MS = 60_000;
+export const RESOLVE_RATE_LIMIT_MAX_REQUESTS = 10;
+export const RESOLVE_RATE_LIMIT_MAX_BUCKETS = 10_000;
+
+type InMemoryBucket = {
+  windowStartedAtMs: number;
+  count: number;
+};
+
+type RateLimitOptions = {
+  bucketKey: string;
+  maxRequests: number;
+  maxBuckets?: number;
+  windowMs: number;
+  nowMs?: () => number;
+};
+
+function resolveClientIp(request: Request): string {
+  const cfIp = request.headers.get("cf-connecting-ip");
+  if (typeof cfIp === "string" && cfIp.trim().length > 0) {
+    return cfIp.trim();
+  }
+
+  return "unknown";
+}
+
+export function createInMemoryRateLimit(
+  options: RateLimitOptions,
+): MiddlewareHandler {
+  const nowMs = options.nowMs ?? Date.now;
+  const maxBuckets = options.maxBuckets ?? RESOLVE_RATE_LIMIT_MAX_BUCKETS;
+  const buckets = new Map<string, InMemoryBucket>();
+
+  return async (c, next) => {
+    const now = nowMs();
+    for (const [key, bucket] of buckets.entries()) {
+      if (now - bucket.windowStartedAtMs >= options.windowMs) {
+        buckets.delete(key);
+      }
+    }
+
+    const clientIp = resolveClientIp(c.req.raw);
+    const key = `${options.bucketKey}:${clientIp}`;
+    const existing = buckets.get(key);
+
+    if (!existing || now - existing.windowStartedAtMs >= options.windowMs) {
+      if (!existing && buckets.size >= maxBuckets) {
+        let oldestKey: string | undefined;
+        let oldestWindowStart = Number.POSITIVE_INFINITY;
+
+        for (const [bucketKey, bucket] of buckets.entries()) {
+          if (bucket.windowStartedAtMs < oldestWindowStart) {
+            oldestWindowStart = bucket.windowStartedAtMs;
+            oldestKey = bucketKey;
+          }
+        }
+
+        if (oldestKey) {
+          buckets.delete(oldestKey);
+        }
+      }
+
+      buckets.set(key, {
+        windowStartedAtMs: now,
+        count: 1,
+      });
+      await next();
+      return;
+    }
+
+    if (existing.count >= options.maxRequests) {
+      throw new AppError({
+        code: "RATE_LIMIT_EXCEEDED",
+        message: "Too many requests",
+        status: 429,
+        expose: true,
+      });
+    }
+
+    existing.count += 1;
+    buckets.set(key, existing);
+    await next();
+  };
+}

--- a/apps/registry/src/server.test.ts
+++ b/apps/registry/src/server.test.ts
@@ -22,6 +22,7 @@ import {
   deriveApiKeyLookupPrefix,
   hashApiKeyToken,
 } from "./auth/api-key-auth.js";
+import { RESOLVE_RATE_LIMIT_MAX_REQUESTS } from "./rate-limit.js";
 import app, { createRegistryApp } from "./server.js";
 
 function makeAitClaims(publicKey: Uint8Array): AitClaims {
@@ -88,6 +89,7 @@ type FakeAgentSelectRow = {
   id: string;
   did: string;
   owner_id: string;
+  owner_did: string;
   name: string;
   framework: string | null;
   public_key: string;
@@ -213,6 +215,21 @@ function parseSelectedColumns(query: string): string[] {
     .split(",")
     .map((column) => column.trim())
     .map((column) => {
+      const normalizedColumn = column.toLowerCase();
+      if (
+        normalizedColumn.includes(`"humans"."did"`) ||
+        normalizedColumn.includes("humans.did")
+      ) {
+        return "owner_did";
+      }
+
+      if (
+        normalizedColumn.includes(`"agents"."did"`) ||
+        normalizedColumn.includes("agents.did")
+      ) {
+        return "did";
+      }
+
       const aliasMatch = column.match(/\s+as\s+"?([a-zA-Z0-9_]+)"?\s*$/i);
       if (aliasMatch?.[1]) {
         return aliasMatch[1].toLowerCase();
@@ -233,6 +250,17 @@ function parseSelectedColumns(query: string): string[] {
     .filter((column) => column.length > 0);
 }
 
+function createFakePublicKey(agentId: string): string {
+  const seed = agentId.length > 0 ? agentId : "agent";
+  const bytes = new Uint8Array(32);
+
+  for (let index = 0; index < bytes.length; index += 1) {
+    bytes[index] = seed.charCodeAt(index % seed.length) & 0xff;
+  }
+
+  return encodeBase64url(bytes);
+}
+
 function getAgentSelectColumnValue(
   row: FakeAgentSelectRow,
   column: string,
@@ -245,6 +273,9 @@ function getAgentSelectColumnValue(
   }
   if (column === "owner_id") {
     return row.owner_id;
+  }
+  if (column === "owner_did") {
+    return row.owner_did;
   }
   if (column === "name") {
     return row.name;
@@ -276,8 +307,10 @@ function getAgentSelectColumnValue(
 function resolveAgentSelectRows(options: {
   query: string;
   params: unknown[];
+  authRows: FakeD1Row[];
   agentRows: FakeAgentRow[];
 }): FakeAgentSelectRow[] {
+  const normalizedQuery = options.query.toLowerCase();
   const whereClause = extractWhereClause(options.query);
   const equalityParams = parseWhereEqualityParams({
     whereClause,
@@ -290,6 +323,9 @@ function resolveAgentSelectRows(options: {
   const hasCurrentJtiFilter = hasFilter(whereClause, "current_jti");
   const hasCursorFilter = hasFilter(whereClause, "id", "<");
   const hasLimitClause = options.query.toLowerCase().includes(" limit ");
+  const requiresHumanJoin =
+    normalizedQuery.includes('join "humans"') ||
+    normalizedQuery.includes("join humans");
 
   const ownerId =
     hasOwnerFilter && typeof equalityParams.values.owner_id?.[0] === "string"
@@ -336,21 +372,28 @@ function resolveAgentSelectRows(options: {
     )
     .filter((row) => (cursorFilter ? row.id < cursorFilter : true))
     .sort((left, right) => right.id.localeCompare(left.id))
-    .slice(0, limit)
-    .map((row) => ({
-      id: row.id,
-      did: row.did,
-      owner_id: row.ownerId,
-      name: row.name,
-      framework: row.framework,
-      public_key:
-        row.publicKey ?? "AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA",
-      status: row.status,
-      expires_at: row.expiresAt,
-      current_jti: row.currentJti ?? null,
-      created_at: row.createdAt ?? "2026-01-01T00:00:00.000Z",
-      updated_at: row.updatedAt ?? "2026-01-01T00:00:00.000Z",
-    }));
+    .map((row) => {
+      const ownerDid = options.authRows.find(
+        (authRow) => authRow.humanId === row.ownerId,
+      )?.humanDid;
+
+      return {
+        id: row.id,
+        did: row.did,
+        owner_id: row.ownerId,
+        owner_did: ownerDid ?? "",
+        name: row.name,
+        framework: row.framework,
+        public_key: row.publicKey ?? createFakePublicKey(row.id),
+        status: row.status,
+        expires_at: row.expiresAt,
+        current_jti: row.currentJti ?? null,
+        created_at: row.createdAt ?? "2026-01-01T00:00:00.000Z",
+        updated_at: row.updatedAt ?? "2026-01-01T00:00:00.000Z",
+      };
+    })
+    .filter((row) => (requiresHumanJoin ? row.owner_did.length > 0 : true))
+    .slice(0, limit);
 
   return filteredRows;
 }
@@ -468,11 +511,27 @@ function createFakeDb(
             (normalizedQuery.includes("select") ||
               normalizedQuery.includes("returning"))
           ) {
+            const resultRows = resolveAgentSelectRows({
+              query,
+              params,
+              authRows: rows,
+              agentRows,
+            });
+            const selectedColumns = parseSelectedColumns(query);
+
             return {
-              results: resolveAgentSelectRows({
-                query,
-                params,
-                agentRows,
+              results: resultRows.map((row) => {
+                if (selectedColumns.length === 0) {
+                  return row;
+                }
+
+                return selectedColumns.reduce<Record<string, unknown>>(
+                  (acc, column) => {
+                    acc[column] = getAgentSelectColumnValue(row, column);
+                    return acc;
+                  },
+                  {},
+                );
               }),
             };
           }
@@ -520,6 +579,7 @@ function createFakeDb(
             const resultRows = resolveAgentSelectRows({
               query,
               params,
+              authRows: rows,
               agentRows,
             });
             const selectedColumns = parseSelectedColumns(query);
@@ -1140,6 +1200,166 @@ describe("GET /v1/crl", () => {
     expect(body.error.details?.fieldErrors).toMatchObject({
       REGISTRY_SIGNING_KEYS: expect.any(Array),
     });
+  });
+});
+
+describe("GET /v1/resolve/:id", () => {
+  it("returns public profile fields without requiring auth", async () => {
+    const { authRow } = await makeValidPatContext();
+    const agentId = generateUlid(1700500000000);
+    const { database } = createFakeDb(
+      [authRow],
+      [
+        {
+          id: agentId,
+          did: makeAgentDid(agentId),
+          ownerId: "human-1",
+          name: "resolve-me",
+          framework: "openclaw",
+          status: "active",
+          expiresAt: "2026-04-01T00:00:00.000Z",
+        },
+      ],
+    );
+
+    const res = await createRegistryApp().request(
+      `/v1/resolve/${agentId}`,
+      {},
+      { DB: database, ENVIRONMENT: "test" },
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      did: string;
+      name: string;
+      framework: string;
+      status: "active" | "revoked";
+      ownerDid: string;
+      email?: string;
+      displayName?: string;
+    };
+    expect(body).toEqual({
+      did: makeAgentDid(agentId),
+      name: "resolve-me",
+      framework: "openclaw",
+      status: "active",
+      ownerDid: authRow.humanDid,
+    });
+    expect(body).not.toHaveProperty("email");
+    expect(body).not.toHaveProperty("displayName");
+  });
+
+  it("falls back framework to openclaw when stored framework is null", async () => {
+    const { authRow } = await makeValidPatContext();
+    const agentId = generateUlid(1700500000100);
+    const { database } = createFakeDb(
+      [authRow],
+      [
+        {
+          id: agentId,
+          did: makeAgentDid(agentId),
+          ownerId: "human-1",
+          name: "legacy-framework-null",
+          framework: null,
+          status: "active",
+          expiresAt: "2026-04-01T00:00:00.000Z",
+        },
+      ],
+    );
+
+    const res = await createRegistryApp().request(
+      `/v1/resolve/${agentId}`,
+      {},
+      { DB: database, ENVIRONMENT: "test" },
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { framework: string };
+    expect(body.framework).toBe("openclaw");
+  });
+
+  it("returns 400 for invalid id path", async () => {
+    const res = await createRegistryApp().request(
+      "/v1/resolve/not-a-ulid",
+      {},
+      { DB: {} as D1Database, ENVIRONMENT: "test" },
+    );
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as {
+      error: {
+        code: string;
+        details?: { fieldErrors?: Record<string, string[]> };
+      };
+    };
+    expect(body.error.code).toBe("AGENT_RESOLVE_INVALID_PATH");
+    expect(body.error.details?.fieldErrors?.id).toEqual([
+      "id must be a valid ULID",
+    ]);
+  });
+
+  it("returns 404 when agent does not exist", async () => {
+    const { authRow } = await makeValidPatContext();
+    const missingAgentId = generateUlid(1700500000200);
+    const { database } = createFakeDb([authRow], []);
+
+    const res = await createRegistryApp().request(
+      `/v1/resolve/${missingAgentId}`,
+      {},
+      { DB: database, ENVIRONMENT: "test" },
+    );
+
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("AGENT_NOT_FOUND");
+  });
+
+  it("returns 429 when rate limit is exceeded for the same client", async () => {
+    const { authRow } = await makeValidPatContext();
+    const agentId = generateUlid(1700500000300);
+    const { database } = createFakeDb(
+      [authRow],
+      [
+        {
+          id: agentId,
+          did: makeAgentDid(agentId),
+          ownerId: "human-1",
+          name: "rate-limited-agent",
+          framework: "openclaw",
+          status: "active",
+          expiresAt: "2026-04-01T00:00:00.000Z",
+        },
+      ],
+    );
+    const appInstance = createRegistryApp();
+
+    for (let index = 0; index < RESOLVE_RATE_LIMIT_MAX_REQUESTS; index += 1) {
+      const response = await appInstance.request(
+        `/v1/resolve/${agentId}`,
+        {
+          headers: {
+            "CF-Connecting-IP": "203.0.113.10",
+          },
+        },
+        { DB: database, ENVIRONMENT: "test" },
+      );
+
+      expect(response.status).toBe(200);
+    }
+
+    const rateLimited = await appInstance.request(
+      `/v1/resolve/${agentId}`,
+      {
+        headers: {
+          "CF-Connecting-IP": "203.0.113.10",
+        },
+      },
+      { DB: database, ENVIRONMENT: "test" },
+    );
+
+    expect(rateLimited.status).toBe(429);
+    const body = (await rateLimited.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("RATE_LIMIT_EXCEEDED");
   });
 });
 

--- a/apps/registry/src/server.ts
+++ b/apps/registry/src/server.ts
@@ -21,6 +21,11 @@ import {
   resolveRegistryIssuer,
 } from "./agent-registration.js";
 import {
+  agentResolveNotFoundError,
+  mapResolvedAgentRow,
+  parseAgentResolvePath,
+} from "./agent-resolve.js";
+import {
   agentNotFoundError,
   invalidAgentReissueStateError,
   invalidAgentRevokeStateError,
@@ -31,7 +36,12 @@ import {
   createApiKeyAuth,
 } from "./auth/api-key-auth.js";
 import { createDb } from "./db/client.js";
-import { agents, revocations } from "./db/schema.js";
+import { agents, humans, revocations } from "./db/schema.js";
+import {
+  createInMemoryRateLimit,
+  RESOLVE_RATE_LIMIT_MAX_REQUESTS,
+  RESOLVE_RATE_LIMIT_WINDOW_MS,
+} from "./rate-limit.js";
 import { resolveRegistrySigner } from "./registry-signer.js";
 
 type Bindings = {
@@ -231,6 +241,11 @@ function createRegistryApp() {
     Bindings: Bindings;
     Variables: { requestId: string; human: AuthenticatedHuman };
   }>();
+  const resolveRateLimit = createInMemoryRateLimit({
+    bucketKey: "resolve",
+    maxRequests: RESOLVE_RATE_LIMIT_MAX_REQUESTS,
+    windowMs: RESOLVE_RATE_LIMIT_WINDOW_MS,
+  });
 
   app.use("*", createRequestContextMiddleware());
   app.use("*", createRequestLoggingMiddleware(logger));
@@ -300,6 +315,35 @@ function createRegistryApp() {
     return c.json({ crl }, 200, {
       "Cache-Control": REGISTRY_CRL_CACHE_CONTROL,
     });
+  });
+
+  app.get("/v1/resolve/:id", resolveRateLimit, async (c) => {
+    const config = getConfig(c.env);
+    const id = parseAgentResolvePath({
+      id: c.req.param("id"),
+      environment: config.ENVIRONMENT,
+    });
+    const db = createDb(c.env.DB);
+
+    const rows = await db
+      .select({
+        did: agents.did,
+        name: agents.name,
+        framework: agents.framework,
+        status: agents.status,
+        owner_did: humans.did,
+      })
+      .from(agents)
+      .innerJoin(humans, eq(agents.owner_id, humans.id))
+      .where(eq(agents.id, id))
+      .limit(1);
+
+    const row = rows[0];
+    if (!row) {
+      throw agentResolveNotFoundError();
+    }
+
+    return c.json(mapResolvedAgentRow(row));
   });
 
   app.get("/v1/me", createApiKeyAuth(), (c) => {


### PR DESCRIPTION
## Summary
- add public `GET /v1/resolve/:id` endpoint returning `{ did, name, framework, status, ownerDid }`
- add dedicated resolve-path validation and mapping helpers
- add in-memory IP-based rate limiting for resolve endpoint (`429 RATE_LIMIT_EXCEEDED`)
- add comprehensive route tests for success, invalid id, missing agent, rate limiting, and non-PII contract
- harden fake D1 test emulation to preserve join semantics and selected-column projection
- update `apps/registry/src/AGENTS.md` with resolve-route and fake-DB best practices

## Validation
- `pnpm lint`
- `pnpm -r typecheck`
- `pnpm -r test`
- `pnpm -r build`
- pre-push hook: `nx affected -t lint,format,typecheck,test --base=origin/main --head=HEAD`

Closes #21
