### PR TITLE
feat(cli): implement T20 CLI framework and local config

### DIFF
--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -1,0 +1,35 @@
+# AGENTS.md (apps/cli)
+
+## Purpose
+- Define conventions for the `clawdentity` CLI package.
+- Keep command behavior predictable, testable, and safe for local credential storage.
+
+## Command Architecture
+- Keep `src/index.ts` as a pure program builder (`createProgram()`); no side effects on import.
+- Keep `src/bin.ts` as a thin runtime entry only (`parseAsync` + top-level error handling).
+- Implement command groups under `src/commands/*` and register them from `createProgram()`.
+- Prefer shared helpers (for validation, output, and error handling) over repeating per-command logic.
+- Use `process.exitCode` instead of `process.exit()`.
+- Use `@clawdentity/sdk` `createLogger` for runtime logging; avoid direct `console.*` calls in CLI app code.
+
+## Config and Secrets
+- Local CLI config lives at `~/.clawdentity/config.json`.
+- Resolve values with explicit precedence: environment variables > config file > built-in defaults.
+- Keep API tokens masked in human-facing output (`show`, success logs, debug prints).
+- Write config with restrictive permissions (`0600`) and never commit secrets or generated local config.
+
+## Testing Rules
+- Use Vitest for all tests.
+- Unit-test config I/O and precedence logic with mocked `node:fs/promises` and `node:os`.
+- Command tests should assert both behavior and output, using `vi.spyOn(console, ...)` where needed.
+- Cover invalid input and failure paths, not only happy paths.
+
+## Validation Commands
+- `pnpm -F @clawdentity/cli lint`
+- `pnpm -F @clawdentity/cli typecheck`
+- `pnpm -F @clawdentity/cli test`
+- `pnpm -F @clawdentity/cli build`
+- For cross-package changes, run root checks: `pnpm lint`, `pnpm -r typecheck`, `pnpm -r test`, `pnpm -r build`.
+
+## Refactor Trigger
+- If command count grows, move to a typed command registry/builder so command wiring stays declarative and avoids duplicate validation/output code.

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -5,6 +5,9 @@
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "bin": {
+    "clawdentity": "./dist/bin.js"
+  },
   "exports": {
     ".": {
       "import": "./dist/index.js",
@@ -20,6 +23,10 @@
   },
   "dependencies": {
     "@clawdentity/protocol": "workspace:*",
-    "@clawdentity/sdk": "workspace:*"
+    "@clawdentity/sdk": "workspace:*",
+    "commander": "^13.1.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.18.11"
   }
 }

--- a/apps/cli/sample-config.json
+++ b/apps/cli/sample-config.json
@@ -1,0 +1,3 @@
+{
+  "registryUrl": "https://api.clawdentity.com"
+}

--- a/apps/cli/src/bin.ts
+++ b/apps/cli/src/bin.ts
@@ -1,0 +1,15 @@
+import { createLogger } from "@clawdentity/sdk";
+import { createProgram } from "./index.js";
+import { writeStderrLine } from "./io.js";
+
+const logger = createLogger({ service: "cli", module: "bin" });
+
+createProgram()
+  .parseAsync(process.argv)
+  .catch((error: unknown) => {
+    process.exitCode = 1;
+    const message = error instanceof Error ? error.message : String(error);
+
+    logger.error("cli.execution_failed", { errorMessage: message });
+    writeStderrLine(message);
+  });

--- a/apps/cli/src/commands/config.test.ts
+++ b/apps/cli/src/commands/config.test.ts
@@ -1,0 +1,190 @@
+import { access } from "node:fs/promises";
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:fs/promises", () => ({
+  access: vi.fn(),
+}));
+
+vi.mock("../config/manager.js", () => ({
+  getConfigFilePath: vi.fn(() => "/mock-home/.clawdentity/config.json"),
+  getConfigValue: vi.fn(),
+  readConfig: vi.fn(),
+  resolveConfig: vi.fn(),
+  setConfigValue: vi.fn(),
+  writeConfig: vi.fn(),
+}));
+
+vi.mock("@clawdentity/sdk", () => ({
+  createLogger: vi.fn(() => ({
+    child: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  })),
+}));
+
+import {
+  getConfigValue,
+  readConfig,
+  resolveConfig,
+  setConfigValue,
+  writeConfig,
+} from "../config/manager.js";
+import { createConfigCommand } from "./config.js";
+
+const mockedAccess = vi.mocked(access);
+const mockedReadConfig = vi.mocked(readConfig);
+const mockedWriteConfig = vi.mocked(writeConfig);
+const mockedSetConfigValue = vi.mocked(setConfigValue);
+const mockedGetConfigValue = vi.mocked(getConfigValue);
+const mockedResolveConfig = vi.mocked(resolveConfig);
+
+const buildErrnoError = (code: string): NodeJS.ErrnoException => {
+  const error = new Error(code) as NodeJS.ErrnoException;
+  error.code = code;
+  return error;
+};
+
+const runConfigCommand = async (args: string[]) => {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const previousExitCode = process.exitCode;
+  const stdoutSpy = vi
+    .spyOn(process.stdout, "write")
+    .mockImplementation((chunk: unknown) => {
+      stdout.push(String(chunk));
+      return true;
+    });
+  const stderrSpy = vi
+    .spyOn(process.stderr, "write")
+    .mockImplementation((chunk: unknown) => {
+      stderr.push(String(chunk));
+      return true;
+    });
+
+  process.exitCode = undefined;
+
+  const command = createConfigCommand();
+
+  command.configureOutput({
+    writeOut: (message) => stdout.push(message),
+    writeErr: (message) => stderr.push(message),
+    outputError: (message) => stderr.push(message),
+  });
+
+  const root = new Command("clawdentity");
+  root.addCommand(command);
+
+  try {
+    await root.parseAsync(["node", "clawdentity", "config", ...args]);
+  } finally {
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+  }
+
+  const exitCode = process.exitCode;
+  process.exitCode = previousExitCode;
+
+  return {
+    exitCode,
+    stderr: stderr.join(""),
+    stdout: stdout.join(""),
+  };
+};
+
+describe("config command", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockedReadConfig.mockResolvedValue({
+      registryUrl: "https://api.clawdentity.com",
+    });
+    mockedResolveConfig.mockResolvedValue({
+      registryUrl: "https://api.clawdentity.com",
+    });
+  });
+
+  afterEach(() => {
+    process.exitCode = undefined;
+  });
+
+  it("initializes config when missing", async () => {
+    mockedAccess.mockRejectedValueOnce(buildErrnoError("ENOENT"));
+
+    const result = await runConfigCommand(["init"]);
+
+    expect(mockedReadConfig).toHaveBeenCalled();
+    expect(mockedWriteConfig).toHaveBeenCalledWith({
+      registryUrl: "https://api.clawdentity.com",
+    });
+    expect(result.stdout).toContain(
+      "Initialized config at /mock-home/.clawdentity/config.json",
+    );
+    expect(result.exitCode).toBeUndefined();
+  });
+
+  it("skips init when config already exists", async () => {
+    mockedAccess.mockResolvedValueOnce(undefined);
+
+    const result = await runConfigCommand(["init"]);
+
+    expect(mockedWriteConfig).not.toHaveBeenCalled();
+    expect(result.stdout).toContain(
+      "Config already exists at /mock-home/.clawdentity/config.json",
+    );
+  });
+
+  it("sets registry url", async () => {
+    await runConfigCommand(["set", "registryUrl", "http://localhost:8787"]);
+
+    expect(mockedSetConfigValue).toHaveBeenCalledWith(
+      "registryUrl",
+      "http://localhost:8787",
+    );
+  });
+
+  it("masks apiKey output when setting", async () => {
+    const result = await runConfigCommand(["set", "apiKey", "super-secret"]);
+
+    expect(mockedSetConfigValue).toHaveBeenCalledWith("apiKey", "super-secret");
+    expect(result.stdout).toContain("Set apiKey=********");
+  });
+
+  it("rejects invalid keys for set", async () => {
+    const result = await runConfigCommand(["set", "invalid", "value"]);
+
+    expect(mockedSetConfigValue).not.toHaveBeenCalled();
+    expect(result.stderr).toContain("Invalid config key");
+    expect(result.exitCode).toBe(1);
+  });
+
+  it("returns config values", async () => {
+    mockedGetConfigValue.mockResolvedValueOnce("http://localhost:8787");
+
+    const result = await runConfigCommand(["get", "registryUrl"]);
+
+    expect(result.stdout).toContain("http://localhost:8787");
+  });
+
+  it("prints not set for missing value", async () => {
+    mockedGetConfigValue.mockResolvedValueOnce(undefined);
+
+    const result = await runConfigCommand(["get", "apiKey"]);
+
+    expect(result.stdout).toContain("(not set)");
+  });
+
+  it("shows resolved config", async () => {
+    mockedResolveConfig.mockResolvedValueOnce({
+      registryUrl: "http://localhost:8787",
+      apiKey: "super-secret",
+    });
+
+    const result = await runConfigCommand(["show"]);
+
+    expect(result.stdout).toContain("http://localhost:8787");
+    expect(result.stdout).toContain('"apiKey": "********"');
+  });
+});

--- a/apps/cli/src/commands/config.ts
+++ b/apps/cli/src/commands/config.ts
@@ -1,0 +1,158 @@
+import { access } from "node:fs/promises";
+import { createLogger } from "@clawdentity/sdk";
+import { Command } from "commander";
+import {
+  type CliConfig,
+  type CliConfigKey,
+  getConfigFilePath,
+  getConfigValue,
+  readConfig,
+  resolveConfig,
+  setConfigValue,
+  writeConfig,
+} from "../config/manager.js";
+import { writeStderrLine, writeStdoutLine } from "../io.js";
+
+const logger = createLogger({ service: "cli", module: "config" });
+
+const VALID_KEYS = [
+  "registryUrl",
+  "apiKey",
+] as const satisfies readonly CliConfigKey[];
+
+const withErrorHandling = <T extends unknown[]>(
+  command: string,
+  handler: (...args: T) => Promise<void>,
+) => {
+  return async (...args: T) => {
+    try {
+      await handler(...args);
+    } catch (error) {
+      process.exitCode = 1;
+      const message = error instanceof Error ? error.message : String(error);
+
+      logger.error("cli.command_failed", {
+        command,
+        errorMessage: message,
+      });
+      writeStderrLine(message);
+    }
+  };
+};
+
+const isValidConfigKey = (value: string): value is CliConfigKey => {
+  return VALID_KEYS.includes(value as CliConfigKey);
+};
+
+const maskApiKey = (config: CliConfig): CliConfig => {
+  if (!config.apiKey) {
+    return config;
+  }
+
+  return {
+    ...config,
+    apiKey: "********",
+  };
+};
+
+const isNotFoundError = (error: unknown): boolean => {
+  const nodeError = error as NodeJS.ErrnoException;
+  return nodeError.code === "ENOENT";
+};
+
+const getValidatedKey = (key: string): CliConfigKey | undefined => {
+  if (isValidConfigKey(key)) {
+    return key;
+  }
+
+  process.exitCode = 1;
+  writeStderrLine(
+    `Invalid config key "${key}". Valid keys: ${VALID_KEYS.join(", ")}`,
+  );
+  logger.warn("cli.invalid_config_key", { key });
+
+  return undefined;
+};
+
+export const createConfigCommand = (): Command => {
+  const configCommand = new Command("config").description(
+    "Manage local CLI configuration",
+  );
+
+  configCommand
+    .command("init")
+    .description("Initialize local config file")
+    .action(
+      withErrorHandling("config init", async () => {
+        const configFilePath = getConfigFilePath();
+
+        try {
+          await access(configFilePath);
+          writeStdoutLine(`Config already exists at ${configFilePath}`);
+          return;
+        } catch (error) {
+          if (!isNotFoundError(error)) {
+            throw error;
+          }
+        }
+
+        const config = await readConfig();
+        await writeConfig(config);
+
+        writeStdoutLine(`Initialized config at ${configFilePath}`);
+        writeStdoutLine(JSON.stringify(maskApiKey(config), null, 2));
+      }),
+    );
+
+  configCommand
+    .command("set <key> <value>")
+    .description("Set a config value")
+    .action(
+      withErrorHandling("config set", async (key: string, value: string) => {
+        const validatedKey = getValidatedKey(key);
+
+        if (!validatedKey) {
+          return;
+        }
+
+        await setConfigValue(validatedKey, value);
+
+        const printedValue = validatedKey === "apiKey" ? "********" : value;
+        writeStdoutLine(`Set ${validatedKey}=${printedValue}`);
+      }),
+    );
+
+  configCommand
+    .command("get <key>")
+    .description("Get a resolved config value")
+    .action(
+      withErrorHandling("config get", async (key: string) => {
+        const validatedKey = getValidatedKey(key);
+
+        if (!validatedKey) {
+          return;
+        }
+
+        const value = await getConfigValue(validatedKey);
+
+        if (value === undefined) {
+          writeStdoutLine("(not set)");
+          return;
+        }
+
+        writeStdoutLine(value);
+      }),
+    );
+
+  configCommand
+    .command("show")
+    .description("Show resolved config values")
+    .action(
+      withErrorHandling("config show", async () => {
+        const resolvedConfig = await resolveConfig();
+        writeStdoutLine(JSON.stringify(maskApiKey(resolvedConfig), null, 2));
+      }),
+    );
+
+  return configCommand;
+};

--- a/apps/cli/src/config/manager.test.ts
+++ b/apps/cli/src/config/manager.test.ts
@@ -1,0 +1,141 @@
+import { chmod, mkdir, readFile, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:os", () => ({
+  homedir: vi.fn(() => "/mock-home"),
+}));
+
+vi.mock("node:fs/promises", () => ({
+  chmod: vi.fn(),
+  mkdir: vi.fn(),
+  readFile: vi.fn(),
+  writeFile: vi.fn(),
+}));
+
+import {
+  DEFAULT_REGISTRY_URL,
+  getConfigDir,
+  getConfigFilePath,
+  getConfigValue,
+  readConfig,
+  resolveConfig,
+  setConfigValue,
+  writeConfig,
+} from "./manager.js";
+
+const mockedReadFile = vi.mocked(readFile);
+const mockedWriteFile = vi.mocked(writeFile);
+const mockedMkdir = vi.mocked(mkdir);
+const mockedChmod = vi.mocked(chmod);
+const mockedHomedir = vi.mocked(homedir);
+
+const buildErrnoError = (code: string): NodeJS.ErrnoException => {
+  const error = new Error(code) as NodeJS.ErrnoException;
+  error.code = code;
+  return error;
+};
+
+describe("config manager", () => {
+  const previousEnv = process.env;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedHomedir.mockReturnValue("/mock-home");
+    process.env = { ...previousEnv };
+  });
+
+  afterEach(() => {
+    process.env = previousEnv;
+  });
+
+  it("returns defaults when config does not exist", async () => {
+    mockedReadFile.mockRejectedValueOnce(buildErrnoError("ENOENT"));
+
+    await expect(readConfig()).resolves.toEqual({
+      registryUrl: DEFAULT_REGISTRY_URL,
+    });
+  });
+
+  it("merges file contents with defaults", async () => {
+    mockedReadFile.mockResolvedValueOnce('{"apiKey":"secret"}');
+
+    await expect(readConfig()).resolves.toEqual({
+      registryUrl: DEFAULT_REGISTRY_URL,
+      apiKey: "secret",
+    });
+  });
+
+  it("rethrows non-ENOENT read failures", async () => {
+    mockedReadFile.mockRejectedValueOnce(buildErrnoError("EACCES"));
+
+    await expect(readConfig()).rejects.toMatchObject({
+      code: "EACCES",
+    });
+  });
+
+  it("writes config and secures file permissions", async () => {
+    await writeConfig({
+      registryUrl: "http://localhost:8787",
+      apiKey: "token",
+    });
+
+    expect(mockedMkdir).toHaveBeenCalledWith("/mock-home/.clawdentity", {
+      recursive: true,
+    });
+    expect(mockedWriteFile).toHaveBeenCalledWith(
+      "/mock-home/.clawdentity/config.json",
+      '{\n  "registryUrl": "http://localhost:8787",\n  "apiKey": "token"\n}\n',
+      "utf-8",
+    );
+    expect(mockedChmod).toHaveBeenCalledWith(
+      "/mock-home/.clawdentity/config.json",
+      0o600,
+    );
+  });
+
+  it("applies env override over file config", async () => {
+    mockedReadFile.mockResolvedValueOnce('{"registryUrl":"http://file:8787"}');
+    process.env.CLAWDENTITY_REGISTRY_URL = "http://env:8787";
+
+    await expect(resolveConfig()).resolves.toEqual({
+      registryUrl: "http://env:8787",
+    });
+  });
+
+  it("prefers env apiKey over config file", async () => {
+    mockedReadFile.mockResolvedValueOnce('{"apiKey":"from-file"}');
+    process.env.CLAWDENTITY_API_KEY = "from-env";
+
+    await expect(resolveConfig()).resolves.toEqual({
+      registryUrl: DEFAULT_REGISTRY_URL,
+      apiKey: "from-env",
+    });
+  });
+
+  it("returns a single resolved value", async () => {
+    mockedReadFile.mockResolvedValueOnce('{"registryUrl":"http://file:8787"}');
+    process.env.CLAWDENTITY_REGISTRY_URL = "http://env:8787";
+
+    await expect(getConfigValue("registryUrl")).resolves.toBe(
+      "http://env:8787",
+    );
+  });
+
+  it("reads, merges, and writes when setting values", async () => {
+    mockedReadFile.mockResolvedValueOnce('{"registryUrl":"http://file:8787"}');
+
+    await setConfigValue("apiKey", "new-token");
+
+    expect(mockedWriteFile).toHaveBeenCalledWith(
+      "/mock-home/.clawdentity/config.json",
+      '{\n  "registryUrl": "http://file:8787",\n  "apiKey": "new-token"\n}\n',
+      "utf-8",
+    );
+  });
+
+  it("exposes config location helpers", () => {
+    expect(getConfigDir()).toBe("/mock-home/.clawdentity");
+    expect(getConfigFilePath()).toBe("/mock-home/.clawdentity/config.json");
+  });
+});

--- a/apps/cli/src/config/manager.ts
+++ b/apps/cli/src/config/manager.ts
@@ -1,0 +1,114 @@
+import { chmod, mkdir, readFile, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+export const DEFAULT_REGISTRY_URL = "https://api.clawdentity.com";
+
+export interface CliConfig {
+  registryUrl: string;
+  apiKey?: string;
+}
+
+export type CliConfigKey = keyof CliConfig;
+
+const CONFIG_DIR = ".clawdentity";
+const CONFIG_FILE = "config.json";
+
+const ENV_KEY_MAP: Record<CliConfigKey, string> = {
+  registryUrl: "CLAWDENTITY_REGISTRY_URL",
+  apiKey: "CLAWDENTITY_API_KEY",
+};
+
+const DEFAULT_CONFIG: CliConfig = {
+  registryUrl: DEFAULT_REGISTRY_URL,
+};
+
+const isConfigObject = (value: unknown): value is Record<string, unknown> => {
+  return typeof value === "object" && value !== null;
+};
+
+const normalizeConfig = (raw: unknown): CliConfig => {
+  if (!isConfigObject(raw)) {
+    return { ...DEFAULT_CONFIG };
+  }
+
+  const config: CliConfig = {
+    ...DEFAULT_CONFIG,
+  };
+
+  if (typeof raw.registryUrl === "string" && raw.registryUrl.length > 0) {
+    config.registryUrl = raw.registryUrl;
+  }
+
+  if (typeof raw.apiKey === "string" && raw.apiKey.length > 0) {
+    config.apiKey = raw.apiKey;
+  }
+
+  return config;
+};
+
+export const getConfigDir = (): string => join(homedir(), CONFIG_DIR);
+
+export const getConfigFilePath = (): string =>
+  join(getConfigDir(), CONFIG_FILE);
+
+export const readConfig = async (): Promise<CliConfig> => {
+  try {
+    const configContents = await readFile(getConfigFilePath(), "utf-8");
+    return normalizeConfig(JSON.parse(configContents));
+  } catch (error) {
+    const nodeError = error as NodeJS.ErrnoException;
+
+    if (nodeError.code === "ENOENT") {
+      return { ...DEFAULT_CONFIG };
+    }
+
+    throw error;
+  }
+};
+
+export const resolveConfig = async (): Promise<CliConfig> => {
+  const config = await readConfig();
+
+  for (const key of Object.keys(ENV_KEY_MAP) as CliConfigKey[]) {
+    const envVar = process.env[ENV_KEY_MAP[key]];
+
+    if (typeof envVar === "string" && envVar.length > 0) {
+      config[key] = envVar;
+    }
+  }
+
+  return config;
+};
+
+export const writeConfig = async (config: CliConfig): Promise<void> => {
+  const configFilePath = getConfigFilePath();
+  const configDirectory = dirname(configFilePath);
+
+  await mkdir(configDirectory, { recursive: true });
+  await writeFile(
+    configFilePath,
+    `${JSON.stringify(config, null, 2)}\n`,
+    "utf-8",
+  );
+  await chmod(configFilePath, 0o600);
+};
+
+export const getConfigValue = async <K extends CliConfigKey>(
+  key: K,
+): Promise<CliConfig[K]> => {
+  const config = await resolveConfig();
+  return config[key];
+};
+
+export const setConfigValue = async <K extends CliConfigKey>(
+  key: K,
+  value: CliConfig[K],
+): Promise<void> => {
+  const currentConfig = await readConfig();
+
+  await writeConfig({
+    ...currentConfig,
+    [key]: value,
+  });
+};

--- a/apps/cli/src/index.test.ts
+++ b/apps/cli/src/index.test.ts
@@ -1,8 +1,40 @@
 import { describe, expect, it } from "vitest";
-import { CLI_VERSION } from "./index.js";
+import { CLI_VERSION, createProgram } from "./index.js";
 
 describe("cli", () => {
   it("exports CLI_VERSION", () => {
     expect(CLI_VERSION).toBe("0.0.0");
+  });
+
+  it("creates a program named clawdentity", () => {
+    expect(createProgram().name()).toBe("clawdentity");
+  });
+
+  it("registers the config command", () => {
+    const hasConfigCommand = createProgram()
+      .commands.map((command) => command.name())
+      .includes("config");
+
+    expect(hasConfigCommand).toBe(true);
+  });
+
+  it("prints version output", async () => {
+    const output: string[] = [];
+    const program = createProgram();
+
+    program.exitOverride();
+    program.configureOutput({
+      writeOut: (value) => output.push(value),
+      writeErr: (value) => output.push(value),
+    });
+
+    await expect(
+      program.parseAsync(["node", "clawdentity", "--version"]),
+    ).rejects.toMatchObject({
+      code: "commander.version",
+      exitCode: 0,
+    });
+
+    expect(output.join("")).toContain("0.0.0");
   });
 });

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1,1 +1,11 @@
+import { Command } from "commander";
+import { createConfigCommand } from "./commands/config.js";
+
 export const CLI_VERSION = "0.0.0";
+
+export const createProgram = (): Command => {
+  return new Command("clawdentity")
+    .description("Clawdentity CLI - Agent identity management")
+    .version(CLI_VERSION)
+    .addCommand(createConfigCommand());
+};

--- a/apps/cli/src/io.ts
+++ b/apps/cli/src/io.ts
@@ -1,0 +1,10 @@
+const withTrailingNewline = (value: string): string =>
+  value.endsWith("\n") ? value : `${value}\n`;
+
+export const writeStdoutLine = (value: string): void => {
+  process.stdout.write(withTrailingNewline(value));
+};
+
+export const writeStderrLine = (value: string): void => {
+  process.stderr.write(withTrailingNewline(value));
+};

--- a/apps/cli/tsconfig.json
+++ b/apps/cli/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "./dist",
-    "rootDir": "./src"
+    "types": ["node"],
+    "outDir": "./dist"
   },
   "include": ["src"]
 }

--- a/apps/cli/tsup.config.ts
+++ b/apps/cli/tsup.config.ts
@@ -1,8 +1,11 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: ["src/index.ts"],
+  entry: ["src/index.ts", "src/bin.ts"],
   format: ["esm"],
   dts: true,
   clean: true,
+  banner: {
+    js: "#!/usr/bin/env node",
+  },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(yaml@2.8.2)
+        version: 4.0.18(@types/node@22.19.11)(yaml@2.8.2)
       wrangler:
         specifier: ^4.64.0
         version: 4.64.0(@cloudflare/workers-types@4.20260210.0)
@@ -41,6 +41,13 @@ importers:
       '@clawdentity/sdk':
         specifier: workspace:*
         version: link:../../packages/sdk
+      commander:
+        specifier: ^13.1.0
+        version: 13.1.0
+    devDependencies:
+      '@types/node':
+        specifier: ^22.18.11
+        version: 22.19.11
 
   apps/proxy:
     dependencies:
@@ -1062,6 +1069,9 @@ packages:
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/node@22.19.11':
+    resolution: {integrity: sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==}
 
   '@vitest/expect@4.0.18':
     resolution: {integrity: sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==}
@@ -2134,6 +2144,9 @@ packages:
     resolution: {integrity: sha512-yu26mwteFYzBAot7KVMqFGCVpsF6g8wXfJzQUHvu1no3+rRRSFcSV2nKeYvNPLD2J4b08jYBDhHUjeH0ygIl9w==}
     hasBin: true
 
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
   undici@7.18.2:
     resolution: {integrity: sha512-y+8YjDFzWdQlSE9N5nzKMT3g4a5UBX1HKowfdXh0uvAnTaqqwqB92Jt4UXBAeKekDs5IaDKyJFR4X1gYVCgXcw==}
     engines: {node: '>=20.18.1'}
@@ -2885,6 +2898,10 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/node@22.19.11':
+    dependencies:
+      undici-types: 6.21.0
+
   '@vitest/expect@4.0.18':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -2894,13 +2911,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.18(vite@7.3.1(yaml@2.8.2))':
+  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@22.19.11)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(yaml@2.8.2)
+      vite: 7.3.1(@types/node@22.19.11)(yaml@2.8.2)
 
   '@vitest/pretty-format@4.0.18':
     dependencies:
@@ -3938,6 +3955,8 @@ snapshots:
 
   ulid@3.0.2: {}
 
+  undici-types@6.21.0: {}
+
   undici@7.18.2: {}
 
   unenv@2.0.0-rc.24:
@@ -3946,7 +3965,7 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  vite@7.3.1(yaml@2.8.2):
+  vite@7.3.1(@types/node@22.19.11)(yaml@2.8.2):
     dependencies:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.3)
@@ -3955,13 +3974,14 @@ snapshots:
       rollup: 4.57.1
       tinyglobby: 0.2.15
     optionalDependencies:
+      '@types/node': 22.19.11
       fsevents: 2.3.3
       yaml: 2.8.2
 
-  vitest@4.0.18(yaml@2.8.2):
+  vitest@4.0.18(@types/node@22.19.11)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.1(yaml@2.8.2))
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@22.19.11)(yaml@2.8.2))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -3978,8 +3998,10 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.1(yaml@2.8.2)
+      vite: 7.3.1(@types/node@22.19.11)(yaml@2.8.2)
       why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.11
     transitivePeerDependencies:
       - jiti
       - less


### PR DESCRIPTION
## Summary
- add a Commander-based  program with a dedicated  entry and command router
- implement local CLI config management at  with env override precedence (), secure  writes, and 
- add stream-based CLI output helpers and structured runtime logging via  
- expand CLI tests for router/version behavior, config manager I/O+precedence, and config command flows
- add  and  best-practice guidance

## Testing
- pnpm -F @clawdentity/cli lint
- pnpm -F @clawdentity/cli typecheck
- pnpm -F @clawdentity/cli test
- pnpm -F @clawdentity/cli build
- pnpm lint
- pnpm -r typecheck
- pnpm -r test
- pnpm -r build

Closes #22