### PR TITLE
feat(cli): add agent create command and shared error helper

### DIFF
--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -8,20 +8,22 @@
 - Keep `src/index.ts` as a pure program builder (`createProgram()`); no side effects on import.
 - Keep `src/bin.ts` as a thin runtime entry only (`parseAsync` + top-level error handling).
 - Implement command groups under `src/commands/*` and register them from `createProgram()`.
-- Prefer shared helpers (for validation, output, and error handling) over repeating per-command logic.
+- Reuse shared command helpers from `src/commands/helpers.ts` (especially `withErrorHandling`) instead of duplicating command-level try/catch blocks.
 - Use `process.exitCode` instead of `process.exit()`.
 - Use `@clawdentity/sdk` `createLogger` for runtime logging; avoid direct `console.*` calls in CLI app code.
+- Keep user-facing command output on `writeStdoutLine` / `writeStderrLine`; reserve structured logger calls for diagnostic events.
 
 ## Config and Secrets
 - Local CLI config lives at `~/.clawdentity/config.json`.
+- Agent identities live at `~/.clawdentity/agents/<name>/` and must include `secret.key`, `public.key`, `identity.json`, and `ait.jwt`.
 - Resolve values with explicit precedence: environment variables > config file > built-in defaults.
 - Keep API tokens masked in human-facing output (`show`, success logs, debug prints).
-- Write config with restrictive permissions (`0600`) and never commit secrets or generated local config.
+- Write config and identity artifacts with restrictive permissions (`0600`) and never commit secrets or generated local config.
 
 ## Testing Rules
 - Use Vitest for all tests.
 - Unit-test config I/O and precedence logic with mocked `node:fs/promises` and `node:os`.
-- Command tests should assert both behavior and output, using `vi.spyOn(console, ...)` where needed.
+- Command tests should assert both behavior and output by capturing `process.stdout.write` / `process.stderr.write`.
 - Cover invalid input and failure paths, not only happy paths.
 
 ## Validation Commands

--- a/apps/cli/src/commands/agent.test.ts
+++ b/apps/cli/src/commands/agent.test.ts
@@ -1,0 +1,300 @@
+import { access, chmod, mkdir, writeFile } from "node:fs/promises";
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:fs/promises", () => ({
+  access: vi.fn(),
+  chmod: vi.fn(),
+  mkdir: vi.fn(),
+  writeFile: vi.fn(),
+}));
+
+vi.mock("../config/manager.js", () => ({
+  getConfigDir: vi.fn(() => "/mock-home/.clawdentity"),
+  resolveConfig: vi.fn(),
+}));
+
+vi.mock("@clawdentity/sdk", () => ({
+  createLogger: vi.fn(() => ({
+    child: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  })),
+  encodeEd25519KeypairBase64url: vi.fn(),
+  generateEd25519Keypair: vi.fn(),
+}));
+
+import {
+  encodeEd25519KeypairBase64url,
+  generateEd25519Keypair,
+} from "@clawdentity/sdk";
+import { resolveConfig } from "../config/manager.js";
+import { createAgentCommand } from "./agent.js";
+
+const mockedAccess = vi.mocked(access);
+const mockedChmod = vi.mocked(chmod);
+const mockedMkdir = vi.mocked(mkdir);
+const mockedWriteFile = vi.mocked(writeFile);
+const mockedResolveConfig = vi.mocked(resolveConfig);
+const mockedGenerateEd25519Keypair = vi.mocked(generateEd25519Keypair);
+const mockedEncodeEd25519KeypairBase64url = vi.mocked(
+  encodeEd25519KeypairBase64url,
+);
+
+const mockFetch = vi.fn<typeof fetch>();
+
+const buildErrnoError = (code: string): NodeJS.ErrnoException => {
+  const error = new Error(code) as NodeJS.ErrnoException;
+  error.code = code;
+  return error;
+};
+
+const createJsonResponse = (status: number, body: unknown): Response => {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: vi.fn(async () => body),
+  } as unknown as Response;
+};
+
+const runAgentCommand = async (args: string[]) => {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const previousExitCode = process.exitCode;
+
+  const stdoutSpy = vi
+    .spyOn(process.stdout, "write")
+    .mockImplementation((chunk: unknown) => {
+      stdout.push(String(chunk));
+      return true;
+    });
+  const stderrSpy = vi
+    .spyOn(process.stderr, "write")
+    .mockImplementation((chunk: unknown) => {
+      stderr.push(String(chunk));
+      return true;
+    });
+
+  process.exitCode = undefined;
+
+  const command = createAgentCommand();
+  command.configureOutput({
+    writeOut: (message) => stdout.push(message),
+    writeErr: (message) => stderr.push(message),
+    outputError: (message) => stderr.push(message),
+  });
+
+  const root = new Command("clawdentity");
+  root.addCommand(command);
+
+  try {
+    await root.parseAsync(["node", "clawdentity", "agent", ...args]);
+  } finally {
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+  }
+
+  const exitCode = process.exitCode;
+  process.exitCode = previousExitCode;
+
+  return {
+    exitCode,
+    stderr: stderr.join(""),
+    stdout: stdout.join(""),
+  };
+};
+
+describe("agent create command", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal("fetch", mockFetch);
+
+    mockedResolveConfig.mockResolvedValue({
+      registryUrl: "https://api.clawdentity.com",
+      apiKey: "pat_123",
+    });
+
+    mockedAccess.mockRejectedValue(buildErrnoError("ENOENT"));
+    mockedMkdir.mockResolvedValue(undefined);
+    mockedWriteFile.mockResolvedValue(undefined);
+    mockedChmod.mockResolvedValue(undefined);
+
+    mockedGenerateEd25519Keypair.mockResolvedValue({
+      publicKey: Uint8Array.from({ length: 32 }, (_, index) => index + 1),
+      secretKey: Uint8Array.from({ length: 32 }, (_, index) => 64 - index),
+    });
+
+    mockedEncodeEd25519KeypairBase64url.mockReturnValue({
+      publicKey: "public-key-b64url",
+      secretKey: "secret-key-b64url",
+    });
+
+    mockFetch.mockResolvedValue(
+      createJsonResponse(201, {
+        agent: {
+          did: "did:claw:agent:01HF7YAT00W6W7CM7N3W5FDXT4",
+          name: "agent-01",
+          framework: "openclaw",
+          expiresAt: "2030-01-01T00:00:00.000Z",
+        },
+        ait: "ait.jwt.value",
+      }),
+    );
+  });
+
+  afterEach(() => {
+    process.exitCode = undefined;
+    vi.unstubAllGlobals();
+  });
+
+  it("creates an agent identity and writes all files", async () => {
+    const result = await runAgentCommand(["create", "agent-01"]);
+
+    expect(mockedGenerateEd25519Keypair).toHaveBeenCalled();
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://api.clawdentity.com/v1/agents",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          authorization: "Bearer pat_123",
+          "content-type": "application/json",
+        }),
+      }),
+    );
+
+    expect(mockedWriteFile).toHaveBeenCalledTimes(4);
+    expect(mockedWriteFile).toHaveBeenCalledWith(
+      "/mock-home/.clawdentity/agents/agent-01/secret.key",
+      "secret-key-b64url",
+      "utf-8",
+    );
+    expect(mockedWriteFile).toHaveBeenCalledWith(
+      "/mock-home/.clawdentity/agents/agent-01/public.key",
+      "public-key-b64url",
+      "utf-8",
+    );
+    expect(mockedWriteFile).toHaveBeenCalledWith(
+      "/mock-home/.clawdentity/agents/agent-01/identity.json",
+      expect.stringContaining(
+        '"did": "did:claw:agent:01HF7YAT00W6W7CM7N3W5FDXT4"',
+      ),
+      "utf-8",
+    );
+    expect(mockedWriteFile).toHaveBeenCalledWith(
+      "/mock-home/.clawdentity/agents/agent-01/ait.jwt",
+      "ait.jwt.value",
+      "utf-8",
+    );
+
+    expect(result.stdout).toContain(
+      "Agent DID: did:claw:agent:01HF7YAT00W6W7CM7N3W5FDXT4",
+    );
+    expect(result.stdout).toContain("Expires At: 2030-01-01T00:00:00.000Z");
+    expect(result.exitCode).toBeUndefined();
+  });
+
+  it("fails when API key is missing", async () => {
+    mockedResolveConfig.mockResolvedValueOnce({
+      registryUrl: "https://api.clawdentity.com",
+    });
+
+    const result = await runAgentCommand(["create", "agent-01"]);
+
+    expect(result.stderr).toContain("API key is not configured");
+    expect(result.exitCode).toBe(1);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("handles registry 401 responses", async () => {
+    mockFetch.mockResolvedValueOnce(
+      createJsonResponse(401, {
+        error: {
+          message: "Invalid API key",
+        },
+      }),
+    );
+
+    const result = await runAgentCommand(["create", "agent-01"]);
+
+    expect(result.stderr).toContain("authentication failed");
+    expect(result.exitCode).toBe(1);
+  });
+
+  it("handles registry 400 responses", async () => {
+    mockFetch.mockResolvedValueOnce(
+      createJsonResponse(400, {
+        error: {
+          message: "name contains invalid characters",
+        },
+      }),
+    );
+
+    const result = await runAgentCommand(["create", "agent-01"]);
+
+    expect(result.stderr).toContain("rejected the request");
+    expect(result.exitCode).toBe(1);
+  });
+
+  it("handles registry connection errors", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("socket hang up"));
+
+    const result = await runAgentCommand(["create", "agent-01"]);
+
+    expect(result.stderr).toContain("Unable to connect to the registry");
+    expect(result.exitCode).toBe(1);
+  });
+
+  it("fails when agent directory already exists", async () => {
+    mockedAccess.mockResolvedValueOnce(undefined);
+
+    const result = await runAgentCommand(["create", "agent-01"]);
+
+    expect(result.stderr).toContain("already exists");
+    expect(result.exitCode).toBe(1);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("sets 0600 permissions on every identity file", async () => {
+    await runAgentCommand(["create", "agent-01"]);
+
+    expect(mockedChmod).toHaveBeenCalledTimes(4);
+    expect(mockedChmod).toHaveBeenCalledWith(
+      "/mock-home/.clawdentity/agents/agent-01/secret.key",
+      0o600,
+    );
+    expect(mockedChmod).toHaveBeenCalledWith(
+      "/mock-home/.clawdentity/agents/agent-01/public.key",
+      0o600,
+    );
+    expect(mockedChmod).toHaveBeenCalledWith(
+      "/mock-home/.clawdentity/agents/agent-01/identity.json",
+      0o600,
+    );
+    expect(mockedChmod).toHaveBeenCalledWith(
+      "/mock-home/.clawdentity/agents/agent-01/ait.jwt",
+      0o600,
+    );
+  });
+
+  it("sends optional framework and ttl-days values", async () => {
+    await runAgentCommand([
+      "create",
+      "agent-01",
+      "--framework",
+      "langgraph",
+      "--ttl-days",
+      "45",
+    ]);
+
+    const request = mockFetch.mock.calls[0] as [string, RequestInit];
+    const requestBody = JSON.parse(String(request[1]?.body)) as {
+      framework?: string;
+      ttlDays?: number;
+    };
+
+    expect(requestBody.framework).toBe("langgraph");
+    expect(requestBody.ttlDays).toBe(45);
+  });
+});

--- a/apps/cli/src/commands/agent.ts
+++ b/apps/cli/src/commands/agent.ts
@@ -1,0 +1,387 @@
+import { access, chmod, mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { validateAgentName } from "@clawdentity/protocol";
+import {
+  createLogger,
+  encodeEd25519KeypairBase64url,
+  generateEd25519Keypair,
+} from "@clawdentity/sdk";
+import { Command } from "commander";
+import { getConfigDir, resolveConfig } from "../config/manager.js";
+import { writeStdoutLine } from "../io.js";
+import { withErrorHandling } from "./helpers.js";
+
+const logger = createLogger({ service: "cli", module: "agent" });
+
+const AGENTS_DIR_NAME = "agents";
+const FILE_MODE = 0o600;
+
+type AgentCreateOptions = {
+  framework?: string;
+  ttlDays?: string;
+};
+
+type AgentRegistrationResponse = {
+  agent: {
+    did: string;
+    name: string;
+    framework: string;
+    expiresAt: string;
+  };
+  ait: string;
+};
+
+type RegistryErrorEnvelope = {
+  error?: {
+    message?: string;
+  };
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+  return typeof value === "object" && value !== null;
+};
+
+const getAgentDirectory = (name: string): string => {
+  return join(getConfigDir(), AGENTS_DIR_NAME, name);
+};
+
+const assertValidAgentName = (name: string): string => {
+  const normalizedName = name.trim();
+
+  if (!validateAgentName(normalizedName)) {
+    throw new Error(
+      "Agent name contains invalid characters or length. Use 1-64 chars: a-z, A-Z, 0-9, ., _, -",
+    );
+  }
+
+  return normalizedName;
+};
+
+const resolveFramework = (
+  framework: string | undefined,
+): string | undefined => {
+  if (framework === undefined) {
+    return undefined;
+  }
+
+  const normalizedFramework = framework.trim();
+  if (normalizedFramework.length === 0) {
+    throw new Error("--framework must not be empty when provided");
+  }
+
+  return normalizedFramework;
+};
+
+const resolveTtlDays = (ttlDays: string | undefined): number | undefined => {
+  if (ttlDays === undefined) {
+    return undefined;
+  }
+
+  const parsed = Number.parseInt(ttlDays, 10);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error("--ttl-days must be a positive integer");
+  }
+
+  return parsed;
+};
+
+const extractRegistryErrorMessage = (payload: unknown): string | undefined => {
+  if (!isRecord(payload)) {
+    return undefined;
+  }
+
+  const envelope = payload as RegistryErrorEnvelope;
+  if (!envelope.error || typeof envelope.error.message !== "string") {
+    return undefined;
+  }
+
+  const trimmed = envelope.error.message.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+};
+
+const parseJsonResponse = async (response: Response): Promise<unknown> => {
+  try {
+    return await response.json();
+  } catch {
+    return undefined;
+  }
+};
+
+const toRegistryRequestUrl = (registryUrl: string): string => {
+  const normalizedBaseUrl = registryUrl.endsWith("/")
+    ? registryUrl
+    : `${registryUrl}/`;
+
+  return new URL("v1/agents", normalizedBaseUrl).toString();
+};
+
+const toHttpErrorMessage = (status: number, responseBody: unknown): string => {
+  const registryMessage = extractRegistryErrorMessage(responseBody);
+
+  if (status === 401) {
+    return registryMessage
+      ? `Registry authentication failed (401): ${registryMessage}`
+      : "Registry authentication failed (401). Check your API key.";
+  }
+
+  if (status === 400) {
+    return registryMessage
+      ? `Registry rejected the request (400): ${registryMessage}`
+      : "Registry rejected the request (400). Check name/framework/ttl-days.";
+  }
+
+  if (status >= 500) {
+    return `Registry server error (${status}). Try again later.`;
+  }
+
+  if (registryMessage) {
+    return `Registry request failed (${status}): ${registryMessage}`;
+  }
+
+  return `Registry request failed (${status})`;
+};
+
+const parseAgentRegistrationResponse = (
+  payload: unknown,
+): AgentRegistrationResponse => {
+  if (!isRecord(payload)) {
+    throw new Error("Registry returned an invalid response payload");
+  }
+
+  const agentValue = payload.agent;
+  const aitValue = payload.ait;
+
+  if (!isRecord(agentValue) || typeof aitValue !== "string") {
+    throw new Error("Registry returned an invalid response payload");
+  }
+
+  const did = agentValue.did;
+  const name = agentValue.name;
+  const framework = agentValue.framework;
+  const expiresAt = agentValue.expiresAt;
+
+  if (
+    typeof did !== "string" ||
+    typeof name !== "string" ||
+    typeof framework !== "string" ||
+    typeof expiresAt !== "string"
+  ) {
+    throw new Error("Registry returned an invalid response payload");
+  }
+
+  return {
+    agent: {
+      did,
+      name,
+      framework,
+      expiresAt,
+    },
+    ait: aitValue,
+  };
+};
+
+const ensureAgentDirectoryAvailable = async (
+  agentName: string,
+  agentDirectory: string,
+): Promise<void> => {
+  try {
+    await access(agentDirectory);
+    throw new Error(`Agent "${agentName}" already exists at ${agentDirectory}`);
+  } catch (error) {
+    const nodeError = error as NodeJS.ErrnoException;
+    if (nodeError.code === "ENOENT") {
+      return;
+    }
+
+    throw error;
+  }
+};
+
+const writeSecureFile = async (
+  path: string,
+  content: string,
+): Promise<void> => {
+  await writeFile(path, content, "utf-8");
+  await chmod(path, FILE_MODE);
+};
+
+const ensureAgentDirectory = async (
+  agentName: string,
+  agentDirectory: string,
+): Promise<void> => {
+  await mkdir(join(getConfigDir(), AGENTS_DIR_NAME), { recursive: true });
+
+  try {
+    await mkdir(agentDirectory);
+  } catch (error) {
+    const nodeError = error as NodeJS.ErrnoException;
+    if (nodeError.code === "EEXIST") {
+      throw new Error(
+        `Agent "${agentName}" already exists at ${agentDirectory}`,
+      );
+    }
+
+    throw error;
+  }
+};
+
+const writeAgentIdentity = async (input: {
+  agentDirectory: string;
+  did: string;
+  name: string;
+  framework: string;
+  expiresAt: string;
+  registryUrl: string;
+  publicKey: string;
+  secretKey: string;
+  ait: string;
+}): Promise<void> => {
+  await ensureAgentDirectory(input.name, input.agentDirectory);
+
+  const identityJson = {
+    did: input.did,
+    name: input.name,
+    framework: input.framework,
+    expiresAt: input.expiresAt,
+    registryUrl: input.registryUrl,
+  };
+
+  await writeSecureFile(
+    join(input.agentDirectory, "secret.key"),
+    input.secretKey,
+  );
+  await writeSecureFile(
+    join(input.agentDirectory, "public.key"),
+    input.publicKey,
+  );
+  await writeSecureFile(
+    join(input.agentDirectory, "identity.json"),
+    `${JSON.stringify(identityJson, null, 2)}\n`,
+  );
+  await writeSecureFile(join(input.agentDirectory, "ait.jwt"), input.ait);
+};
+
+const registerAgent = async (input: {
+  apiKey: string;
+  registryUrl: string;
+  name: string;
+  publicKey: string;
+  framework?: string;
+  ttlDays?: number;
+}): Promise<AgentRegistrationResponse> => {
+  const requestBody: {
+    name: string;
+    publicKey: string;
+    framework?: string;
+    ttlDays?: number;
+  } = {
+    name: input.name,
+    publicKey: input.publicKey,
+  };
+
+  if (input.framework) {
+    requestBody.framework = input.framework;
+  }
+
+  if (input.ttlDays !== undefined) {
+    requestBody.ttlDays = input.ttlDays;
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(toRegistryRequestUrl(input.registryUrl), {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${input.apiKey}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(requestBody),
+    });
+  } catch {
+    throw new Error(
+      "Unable to connect to the registry. Check network access and registryUrl.",
+    );
+  }
+
+  const responseBody = await parseJsonResponse(response);
+
+  if (!response.ok) {
+    throw new Error(toHttpErrorMessage(response.status, responseBody));
+  }
+
+  return parseAgentRegistrationResponse(responseBody);
+};
+
+export const createAgentCommand = (): Command => {
+  const agentCommand = new Command("agent").description(
+    "Manage local agent identities",
+  );
+
+  agentCommand
+    .command("create <name>")
+    .description("Generate and register a new agent identity")
+    .option(
+      "--framework <framework>",
+      "Agent framework label (registry defaults to openclaw)",
+    )
+    .option(
+      "--ttl-days <days>",
+      "Agent token TTL in days (registry default when omitted)",
+    )
+    .action(
+      withErrorHandling(
+        "agent create",
+        async (name: string, options: AgentCreateOptions) => {
+          const config = await resolveConfig();
+          if (!config.apiKey) {
+            throw new Error(
+              "API key is not configured. Run `clawdentity config set apiKey <token>` or set CLAWDENTITY_API_KEY.",
+            );
+          }
+
+          const agentName = assertValidAgentName(name);
+          const framework = resolveFramework(options.framework);
+          const ttlDays = resolveTtlDays(options.ttlDays);
+          const agentDirectory = getAgentDirectory(agentName);
+
+          await ensureAgentDirectoryAvailable(agentName, agentDirectory);
+
+          const keypair = await generateEd25519Keypair();
+          const encoded = encodeEd25519KeypairBase64url(keypair);
+          const registration = await registerAgent({
+            apiKey: config.apiKey,
+            registryUrl: config.registryUrl,
+            name: agentName,
+            publicKey: encoded.publicKey,
+            framework,
+            ttlDays,
+          });
+
+          await writeAgentIdentity({
+            agentDirectory,
+            did: registration.agent.did,
+            name: registration.agent.name,
+            framework: registration.agent.framework,
+            expiresAt: registration.agent.expiresAt,
+            registryUrl: config.registryUrl,
+            publicKey: encoded.publicKey,
+            secretKey: encoded.secretKey,
+            ait: registration.ait,
+          });
+
+          logger.info("cli.agent_created", {
+            name: registration.agent.name,
+            did: registration.agent.did,
+            agentDirectory,
+            registryUrl: config.registryUrl,
+            expiresAt: registration.agent.expiresAt,
+          });
+
+          writeStdoutLine(`Agent DID: ${registration.agent.did}`);
+          writeStdoutLine(`Expires At: ${registration.agent.expiresAt}`);
+        },
+      ),
+    );
+
+  return agentCommand;
+};

--- a/apps/cli/src/commands/config.ts
+++ b/apps/cli/src/commands/config.ts
@@ -12,6 +12,7 @@ import {
   writeConfig,
 } from "../config/manager.js";
 import { writeStderrLine, writeStdoutLine } from "../io.js";
+import { withErrorHandling } from "./helpers.js";
 
 const logger = createLogger({ service: "cli", module: "config" });
 
@@ -19,26 +20,6 @@ const VALID_KEYS = [
   "registryUrl",
   "apiKey",
 ] as const satisfies readonly CliConfigKey[];
-
-const withErrorHandling = <T extends unknown[]>(
-  command: string,
-  handler: (...args: T) => Promise<void>,
-) => {
-  return async (...args: T) => {
-    try {
-      await handler(...args);
-    } catch (error) {
-      process.exitCode = 1;
-      const message = error instanceof Error ? error.message : String(error);
-
-      logger.error("cli.command_failed", {
-        command,
-        errorMessage: message,
-      });
-      writeStderrLine(message);
-    }
-  };
-};
 
 const isValidConfigKey = (value: string): value is CliConfigKey => {
   return VALID_KEYS.includes(value as CliConfigKey);

--- a/apps/cli/src/commands/helpers.test.ts
+++ b/apps/cli/src/commands/helpers.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { mockLoggerError } = vi.hoisted(() => ({
+  mockLoggerError: vi.fn(),
+}));
+
+vi.mock("@clawdentity/sdk", () => ({
+  createLogger: vi.fn(() => ({
+    child: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: mockLoggerError,
+  })),
+}));
+
+import { withErrorHandling } from "./helpers.js";
+
+describe("withErrorHandling", () => {
+  afterEach(() => {
+    process.exitCode = undefined;
+    mockLoggerError.mockReset();
+    vi.restoreAllMocks();
+  });
+
+  it("catches command errors, sets exit code, and writes to stderr", async () => {
+    const stderr: string[] = [];
+    const stderrSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation((chunk: unknown) => {
+        stderr.push(String(chunk));
+        return true;
+      });
+
+    const wrapped = withErrorHandling("agent create", async () => {
+      throw new Error("command failed");
+    });
+
+    await wrapped();
+
+    stderrSpy.mockRestore();
+
+    expect(process.exitCode).toBe(1);
+    expect(stderr.join("")).toContain("command failed");
+    expect(mockLoggerError).toHaveBeenCalledWith("cli.command_failed", {
+      command: "agent create",
+      errorMessage: "command failed",
+    });
+  });
+
+  it("passes through successful command execution", async () => {
+    const handler = vi.fn(async (name: string) => {});
+    const wrapped = withErrorHandling("agent create", handler);
+
+    await wrapped("agent-01");
+
+    expect(process.exitCode).toBeUndefined();
+    expect(handler).toHaveBeenCalledWith("agent-01");
+    expect(mockLoggerError).not.toHaveBeenCalled();
+  });
+});

--- a/apps/cli/src/commands/helpers.ts
+++ b/apps/cli/src/commands/helpers.ts
@@ -1,0 +1,24 @@
+import { createLogger } from "@clawdentity/sdk";
+import { writeStderrLine } from "../io.js";
+
+const logger = createLogger({ service: "cli", module: "commands" });
+
+export const withErrorHandling = <T extends unknown[]>(
+  command: string,
+  handler: (...args: T) => Promise<void>,
+) => {
+  return async (...args: T) => {
+    try {
+      await handler(...args);
+    } catch (error) {
+      process.exitCode = 1;
+      const message = error instanceof Error ? error.message : String(error);
+
+      logger.error("cli.command_failed", {
+        command,
+        errorMessage: message,
+      });
+      writeStderrLine(message);
+    }
+  };
+};

--- a/apps/cli/src/index.test.ts
+++ b/apps/cli/src/index.test.ts
@@ -18,6 +18,14 @@ describe("cli", () => {
     expect(hasConfigCommand).toBe(true);
   });
 
+  it("registers the agent command", () => {
+    const hasAgentCommand = createProgram()
+      .commands.map((command) => command.name())
+      .includes("agent");
+
+    expect(hasAgentCommand).toBe(true);
+  });
+
   it("prints version output", async () => {
     const output: string[] = [];
     const program = createProgram();

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1,4 +1,5 @@
 import { Command } from "commander";
+import { createAgentCommand } from "./commands/agent.js";
 import { createConfigCommand } from "./commands/config.js";
 
 export const CLI_VERSION = "0.0.0";
@@ -7,5 +8,6 @@ export const createProgram = (): Command => {
   return new Command("clawdentity")
     .description("Clawdentity CLI - Agent identity management")
     .version(CLI_VERSION)
+    .addCommand(createAgentCommand())
     .addCommand(createConfigCommand());
 };


### PR DESCRIPTION
## Summary
- add `clawdentity agent create <name>` to generate local Ed25519 keys, register `publicKey` with `POST /v1/agents`, and persist identity artifacts under `~/.clawdentity/agents/<name>/`
- extract shared `withErrorHandling` into `apps/cli/src/commands/helpers.ts` and reuse it in `config` + `agent` commands
- add unit coverage for `agent create` happy/error paths and helper behavior, and register/assert the new command in CLI program tests
- update CLI package guidance in `apps/cli/AGENTS.md` for shared command helpers, secure identity file handling, and command test output capture

## Validation
- `pnpm -F @clawdentity/cli lint`
- `pnpm -F @clawdentity/cli test`
- `pnpm -F @clawdentity/cli build`
- `pnpm lint`
- `pnpm -r typecheck`
- `pnpm -r test`
- `pnpm -r build`
- pre-commit hook: `lint-staged` (biome check + affected typecheck)
- pre-push hook: `nx affected -t lint,format,typecheck,test --base=origin/main --head=HEAD`
