### PR TITLE
feat(cli): add offline agent inspect and safe name validation

### DIFF
--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -12,10 +12,13 @@
 - Use `process.exitCode` instead of `process.exit()`.
 - Use `@clawdentity/sdk` `createLogger` for runtime logging; avoid direct `console.*` calls in CLI app code.
 - Keep user-facing command output on `writeStdoutLine` / `writeStderrLine`; reserve structured logger calls for diagnostic events.
+- Prefer `@clawdentity/sdk` helpers (`decodeAIT`) when surfacing agent metadata instead of parsing JWTs manually.
+ - Reject agent names that are only `.` or `..` before resolving directories or files to prevent accidental traversal of home config directories.
 
 ## Config and Secrets
 - Local CLI config lives at `~/.clawdentity/config.json`.
 - Agent identities live at `~/.clawdentity/agents/<name>/` and must include `secret.key`, `public.key`, `identity.json`, and `ait.jwt`.
+- Reject `.` and `..` as agent names before any filesystem operation to prevent directory traversal outside `~/.clawdentity/agents/`.
 - Resolve values with explicit precedence: environment variables > config file > built-in defaults.
 - Keep API tokens masked in human-facing output (`show`, success logs, debug prints).
 - Write config and identity artifacts with restrictive permissions (`0600`) and never commit secrets or generated local config.
@@ -25,6 +28,11 @@
 - Unit-test config I/O and precedence logic with mocked `node:fs/promises` and `node:os`.
 - Command tests should assert both behavior and output by capturing `process.stdout.write` / `process.stderr.write`.
 - Cover invalid input and failure paths, not only happy paths.
+
+## Agent Inspection
+- `agent inspect <name>` reads `~/.clawdentity/agents/<name>/ait.jwt`, decodes it with `decodeAIT`, and prints DID, Owner, Expires, Key ID, Public Key, and Framework so operators can audit metadata offline.
+- Surface user-friendly errors when the JWT is missing or cannot be decoded, mentioning `ait.jwt` explicitly and defaulting to the normalized agent name when validating input.
+- Tests for new inspection behavior must mock `node:fs/promises.readFile` and `@clawdentity/sdk.decodeAIT`, assert the visible output, and confirm missing-file handling covers `ENOENT`.
 
 ## Validation Commands
 - `pnpm -F @clawdentity/cli lint`

--- a/apps/cli/src/commands/agent.test.ts
+++ b/apps/cli/src/commands/agent.test.ts
@@ -1,4 +1,4 @@
-import { access, chmod, mkdir, writeFile } from "node:fs/promises";
+import { access, chmod, mkdir, readFile, writeFile } from "node:fs/promises";
 import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -6,6 +6,7 @@ vi.mock("node:fs/promises", () => ({
   access: vi.fn(),
   chmod: vi.fn(),
   mkdir: vi.fn(),
+  readFile: vi.fn(),
   writeFile: vi.fn(),
 }));
 
@@ -22,11 +23,14 @@ vi.mock("@clawdentity/sdk", () => ({
     warn: vi.fn(),
     error: vi.fn(),
   })),
+  decodeAIT: vi.fn(),
   encodeEd25519KeypairBase64url: vi.fn(),
   generateEd25519Keypair: vi.fn(),
 }));
 
 import {
+  type DecodedAit,
+  decodeAIT,
   encodeEd25519KeypairBase64url,
   generateEd25519Keypair,
 } from "@clawdentity/sdk";
@@ -36,12 +40,14 @@ import { createAgentCommand } from "./agent.js";
 const mockedAccess = vi.mocked(access);
 const mockedChmod = vi.mocked(chmod);
 const mockedMkdir = vi.mocked(mkdir);
+const mockedReadFile = vi.mocked(readFile);
 const mockedWriteFile = vi.mocked(writeFile);
 const mockedResolveConfig = vi.mocked(resolveConfig);
 const mockedGenerateEd25519Keypair = vi.mocked(generateEd25519Keypair);
 const mockedEncodeEd25519KeypairBase64url = vi.mocked(
   encodeEd25519KeypairBase64url,
 );
+const mockedDecodeAIT = vi.mocked(decodeAIT);
 
 const mockFetch = vi.fn<typeof fetch>();
 
@@ -296,5 +302,137 @@ describe("agent create command", () => {
 
     expect(requestBody.framework).toBe("langgraph");
     expect(requestBody.ttlDays).toBe(45);
+  });
+
+  it("rejects dot-segment agent names before hitting the filesystem", async () => {
+    const result = await runAgentCommand(["create", "."]);
+
+    expect(result.stderr).toContain('Agent name must not be "." or "..".');
+    expect(result.exitCode).toBe(1);
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(mockedMkdir).not.toHaveBeenCalled();
+    expect(mockedWriteFile).not.toHaveBeenCalled();
+  });
+});
+
+describe("agent inspect command", () => {
+  const decodedAit: DecodedAit = {
+    header: {
+      alg: "EdDSA",
+      typ: "AIT",
+      kid: "key-01",
+    },
+    claims: {
+      iss: "https://registry.clawdentity.dev",
+      sub: "did:claw:agent:abc",
+      ownerDid: "did:claw:human:def",
+      name: "agent-01",
+      framework: "openclaw",
+      cnf: {
+        jwk: {
+          kty: "OKP",
+          crv: "Ed25519",
+          x: "pub-key",
+        },
+      },
+      iat: 1672531100,
+      nbf: 1672531100,
+      exp: 1672531200,
+      jti: "01HF7YAT00W6W7CM7N3W5FDXT4",
+    },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedReadFile.mockResolvedValue("mock-ait-token");
+    mockedDecodeAIT.mockReturnValue(decodedAit);
+  });
+
+  afterEach(() => {
+    process.exitCode = undefined;
+  });
+
+  it("displays all six decoded AIT fields", async () => {
+    const result = await runAgentCommand(["inspect", "agent-01"]);
+
+    expect(result.stdout).toContain("DID: did:claw:agent:abc");
+    expect(result.stdout).toContain("Owner: did:claw:human:def");
+    expect(result.stdout).toContain("Expires: 2023-01-01T00:00:00.000Z");
+    expect(result.stdout).toContain("Key ID: key-01");
+    expect(result.stdout).toContain("Public Key: pub-key");
+    expect(result.stdout).toContain("Framework: openclaw");
+    expect(result.exitCode).toBeUndefined();
+  });
+
+  it("reads AIT from the expected local file path", async () => {
+    await runAgentCommand(["inspect", "agent-01"]);
+
+    expect(mockedReadFile).toHaveBeenCalledWith(
+      "/mock-home/.clawdentity/agents/agent-01/ait.jwt",
+      "utf-8",
+    );
+    expect(mockedDecodeAIT).toHaveBeenCalledWith("mock-ait-token");
+  });
+
+  it("fails when the AIT file is missing", async () => {
+    mockedReadFile.mockRejectedValueOnce(buildErrnoError("ENOENT"));
+
+    const result = await runAgentCommand(["inspect", "agent-01"]);
+
+    expect(result.stderr).toContain("not found");
+    expect(result.stderr).toContain("ait.jwt");
+    expect(result.exitCode).toBe(1);
+  });
+
+  it("rejects dot-segment agent names before resolving the AIT path", async () => {
+    const result = await runAgentCommand(["inspect", ".."]);
+
+    expect(result.stderr).toContain('Agent name must not be "." or "..".');
+    expect(result.exitCode).toBe(1);
+    expect(mockedReadFile).not.toHaveBeenCalled();
+  });
+
+  it("fails when the AIT file is empty", async () => {
+    mockedReadFile.mockResolvedValueOnce("  \n");
+
+    const result = await runAgentCommand(["inspect", "agent-01"]);
+
+    expect(result.stderr).toContain("empty");
+    expect(result.stderr).toContain("ait.jwt");
+    expect(result.exitCode).toBe(1);
+  });
+
+  it("fails when AIT decoding fails", async () => {
+    mockedDecodeAIT.mockImplementationOnce(() => {
+      throw new Error("Invalid AIT payload");
+    });
+
+    const result = await runAgentCommand(["inspect", "agent-01"]);
+
+    expect(result.stderr).toContain("Invalid AIT payload");
+    expect(result.exitCode).toBe(1);
+  });
+
+  it("fails on invalid agent names", async () => {
+    const result = await runAgentCommand(["inspect", "agent/../../etc"]);
+
+    expect(result.stderr).toContain("invalid characters");
+    expect(mockedReadFile).not.toHaveBeenCalled();
+    expect(result.exitCode).toBe(1);
+  });
+
+  it("formats exp as ISO-8601", async () => {
+    mockedDecodeAIT.mockReturnValueOnce({
+      ...decodedAit,
+      claims: {
+        ...decodedAit.claims,
+        exp: 1893456000,
+      },
+    });
+
+    const result = await runAgentCommand(["inspect", "agent-01"]);
+
+    expect(result.stdout).toContain("Expires: 2030-01-01T00:00:00.000Z");
+    expect(result.exitCode).toBeUndefined();
   });
 });

--- a/apps/cli/src/commands/agent.ts
+++ b/apps/cli/src/commands/agent.ts
@@ -1,8 +1,10 @@
-import { access, chmod, mkdir, writeFile } from "node:fs/promises";
+import { access, chmod, mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { validateAgentName } from "@clawdentity/protocol";
 import {
   createLogger,
+  type DecodedAit,
+  decodeAIT,
   encodeEd25519KeypairBase64url,
   generateEd25519Keypair,
 } from "@clawdentity/sdk";
@@ -14,6 +16,8 @@ import { withErrorHandling } from "./helpers.js";
 const logger = createLogger({ service: "cli", module: "agent" });
 
 const AGENTS_DIR_NAME = "agents";
+const AIT_FILE_NAME = "ait.jwt";
+const RESERVED_AGENT_NAMES = new Set([".", ".."]);
 const FILE_MODE = 0o600;
 
 type AgentCreateOptions = {
@@ -45,12 +49,47 @@ const getAgentDirectory = (name: string): string => {
   return join(getConfigDir(), AGENTS_DIR_NAME, name);
 };
 
+const getAgentAitPath = (name: string): string => {
+  return join(getAgentDirectory(name), AIT_FILE_NAME);
+};
+
+const readAgentAitToken = async (agentName: string): Promise<string> => {
+  const aitPath = getAgentAitPath(agentName);
+
+  let rawToken: string;
+  try {
+    rawToken = await readFile(aitPath, "utf-8");
+  } catch (error) {
+    const nodeError = error as NodeJS.ErrnoException;
+    if (nodeError.code === "ENOENT") {
+      throw new Error(`Agent "${agentName}" not found (${aitPath})`);
+    }
+
+    throw error;
+  }
+
+  const token = rawToken.trim();
+  if (token.length === 0) {
+    throw new Error(`Agent "${agentName}" has an empty ${AIT_FILE_NAME}`);
+  }
+
+  return token;
+};
+
+const formatExpiresAt = (expires: number): string => {
+  return new Date(expires * 1000).toISOString();
+};
+
 const assertValidAgentName = (name: string): string => {
   const normalizedName = name.trim();
 
+  if (RESERVED_AGENT_NAMES.has(normalizedName)) {
+    throw new Error('Agent name must not be "." or "..".');
+  }
+
   if (!validateAgentName(normalizedName)) {
     throw new Error(
-      "Agent name contains invalid characters or length. Use 1-64 chars: a-z, A-Z, 0-9, ., _, -",
+      "Agent name contains invalid characters, reserved path segments, or length. Use 1-64 chars: a-z, A-Z, 0-9, ., _, -",
     );
   }
 
@@ -312,6 +351,23 @@ const registerAgent = async (input: {
   return parseAgentRegistrationResponse(responseBody);
 };
 
+const printAgentInspect = (decoded: DecodedAit): void => {
+  writeStdoutLine(`DID: ${decoded.claims.sub}`);
+  writeStdoutLine(`Owner: ${decoded.claims.ownerDid}`);
+  writeStdoutLine(`Expires: ${formatExpiresAt(decoded.claims.exp)}`);
+  writeStdoutLine(`Key ID: ${decoded.header.kid}`);
+  writeStdoutLine(`Public Key: ${decoded.claims.cnf.jwk.x}`);
+  writeStdoutLine(`Framework: ${decoded.claims.framework}`);
+};
+
+const printAgentInspectCommand = async (name: string): Promise<void> => {
+  const normalizedName = assertValidAgentName(name);
+  const aitToken = await readAgentAitToken(normalizedName);
+  const decoded = decodeAIT(aitToken);
+
+  printAgentInspect(decoded);
+};
+
 export const createAgentCommand = (): Command => {
   const agentCommand = new Command("agent").description(
     "Manage local agent identities",
@@ -381,6 +437,15 @@ export const createAgentCommand = (): Command => {
           writeStdoutLine(`Expires At: ${registration.agent.expiresAt}`);
         },
       ),
+    );
+
+  agentCommand
+    .command("inspect <name>")
+    .description("Decode and show metadata from an agent's stored AIT")
+    .action(
+      withErrorHandling("agent inspect", async (name: string) => {
+        await printAgentInspectCommand(name);
+      }),
     );
 
   return agentCommand;

--- a/apps/cli/src/commands/helpers.test.ts
+++ b/apps/cli/src/commands/helpers.test.ts
@@ -49,7 +49,7 @@ describe("withErrorHandling", () => {
   });
 
   it("passes through successful command execution", async () => {
-    const handler = vi.fn(async (name: string) => {});
+    const handler = vi.fn(async (_name: string) => {});
     const wrapped = withErrorHandling("agent create", handler);
 
     await wrapped("agent-01");

--- a/issues/AGENTS.md
+++ b/issues/AGENTS.md
@@ -36,6 +36,7 @@ Every `T*.md` file must include these sections in this order:
 - Add at least one refactor opportunity, or explicitly state `None`.
 - Add concrete validation commands with expected outcomes.
 - Keep scope narrow: one issue should represent one coherent unit of delivery.
+- For CLI deliverables, argument placeholders must match supported identifier semantics (for example `<name>` for local filesystem lookups) and avoid ambiguous `<ref>` unless resolution rules are explicitly defined.
 
 ## Skill Rules
 - Every issue must declare required skills.

--- a/issues/T22.md
+++ b/issues/T22.md
@@ -32,7 +32,7 @@ Print decoded AIT fields for an existing local identity.
 - `testing-framework`
 
 ## Deliverables
-- Command `claw agent inspect <ref>`
+- Command `claw agent inspect <name>`
 - Displays: did, owner, exp, kid, pubkey, framework
 
 ## Refactor Opportunities

--- a/packages/sdk/AGENTS.md
+++ b/packages/sdk/AGENTS.md
@@ -11,7 +11,7 @@
 - `config`: schema-validated runtime config parsing.
 - `request-context`: request ID extraction/generation and propagation.
 - `crypto/ed25519`: byte-first keypair/sign/verify helpers for PoP and token workflows.
-- `jwt/ait-jwt`: AIT JWS signing and verification with strict header and issuer checks.
+- `jwt/ait-jwt`: AIT JWS signing, verification, and header-only inspection via `decodeAIT`; both helpers reuse the same protected-header guard so alg/typ/kid invariants stay aligned even when skipping signature validation.
 - `jwt/crl-jwt`: CRL JWT helpers with EdDSA signing, header consistency checks, and tamper-detection test coverage.
 - `crl/cache`: in-memory CRL cache with periodic refresh, staleness reporting, and configurable stale behavior.
 - `http/sign` + `http/verify`: PoP request signing and verification that binds method, path+query, timestamp, nonce, and body hash.

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -44,11 +44,13 @@ export type {
 } from "./http/types.js";
 export { verifyHttpRequest } from "./http/verify.js";
 export type {
+  DecodedAit,
+  DecodedAitHeader,
   RegistryAitVerificationKey,
   SignAitInput,
   VerifyAitInput,
 } from "./jwt/ait-jwt.js";
-export { AitJwtError, signAIT, verifyAIT } from "./jwt/ait-jwt.js";
+export { AitJwtError, decodeAIT, signAIT, verifyAIT } from "./jwt/ait-jwt.js";
 export type {
   CrlClaims,
   RegistryCrlVerificationKey,

--- a/packages/sdk/src/jwt/ait-jwt.test.ts
+++ b/packages/sdk/src/jwt/ait-jwt.test.ts
@@ -7,7 +7,7 @@ import {
 } from "@clawdentity/protocol";
 import { describe, expect, it } from "vitest";
 import { generateEd25519Keypair } from "../crypto/ed25519.js";
-import { signAIT, verifyAIT } from "./ait-jwt.js";
+import { decodeAIT, signAIT, verifyAIT } from "./ait-jwt.js";
 
 function makeClaims(overrides: Partial<AitClaims> = {}): AitClaims {
   const agentUlid = generateUlid(1700100000000);
@@ -117,5 +117,83 @@ describe("AIT JWT helpers", () => {
         ],
       }),
     ).rejects.toThrow(/kid/i);
+  });
+
+  function replaceProtectedHeader(
+    token: string,
+    header: Record<string, unknown>,
+  ): string {
+    const [_, payload, signature] = token.split(".");
+    if (!payload || !signature) {
+      throw new Error("malformed token");
+    }
+    const encodedHeader = encodeBase64url(
+      new TextEncoder().encode(JSON.stringify(header)),
+    );
+    return `${encodedHeader}.${payload}.${signature}`;
+  }
+
+  describe("decodeAIT", () => {
+    async function makeSignedToken(): Promise<{
+      token: string;
+      claims: AitClaims;
+    }> {
+      const keypair = await generateEd25519Keypair();
+      const claims = makeClaims();
+      const token = await signAIT({
+        claims,
+        signerKid: "reg-key-1",
+        signerKeypair: keypair,
+      });
+      return { token, claims };
+    }
+
+    it("returns header + claims without verifying signature", async () => {
+      const { token, claims } = await makeSignedToken();
+      const decoded = decodeAIT(token);
+
+      expect(decoded.header).toEqual({
+        alg: "EdDSA",
+        typ: "AIT",
+        kid: "reg-key-1",
+      });
+      expect(decoded.claims).toEqual(claims);
+    });
+
+    it("rejects tokens with the wrong alg header", async () => {
+      const { token } = await makeSignedToken();
+      const badToken = replaceProtectedHeader(token, {
+        alg: "HS256",
+        typ: "AIT",
+        kid: "reg-key-1",
+      });
+
+      expect(() => decodeAIT(badToken)).toThrow(/alg=EdDSA/);
+    });
+
+    it("rejects tokens with the wrong typ header", async () => {
+      const { token } = await makeSignedToken();
+      const badToken = replaceProtectedHeader(token, {
+        alg: "EdDSA",
+        typ: "JWT",
+        kid: "reg-key-1",
+      });
+
+      expect(() => decodeAIT(badToken)).toThrow(/typ=AIT/);
+    });
+
+    it("requires a kid in the protected header", async () => {
+      const { token } = await makeSignedToken();
+      const badToken = replaceProtectedHeader(token, {
+        alg: "EdDSA",
+        typ: "AIT",
+      });
+
+      expect(() => decodeAIT(badToken)).toThrow(/missing protected kid header/);
+    });
+
+    it("throws for malformed JWT strings", () => {
+      expect(() => decodeAIT("not-a-jwt")).toThrow();
+    });
   });
 });

--- a/packages/sdk/src/jwt/ait-jwt.ts
+++ b/packages/sdk/src/jwt/ait-jwt.ts
@@ -1,7 +1,13 @@
 import type { AitClaims, AitCnfJwk } from "@clawdentity/protocol";
 import { parseAitClaims } from "@clawdentity/protocol";
 import type { JWTVerifyOptions } from "jose";
-import { decodeProtectedHeader, importJWK, jwtVerify, SignJWT } from "jose";
+import {
+  decodeJwt,
+  decodeProtectedHeader,
+  importJWK,
+  jwtVerify,
+  SignJWT,
+} from "jose";
 import {
   type Ed25519KeypairBytes,
   encodeEd25519KeypairBase64url,
@@ -28,6 +34,17 @@ export type VerifyAitInput = {
   expectedIssuer?: string;
 };
 
+export type DecodedAitHeader = {
+  alg: "EdDSA";
+  typ: "AIT";
+  kid: string;
+};
+
+export type DecodedAit = {
+  header: DecodedAitHeader;
+  claims: AitClaims;
+};
+
 export class AitJwtError extends Error {
   readonly code: "INVALID_AIT_HEADER" | "UNKNOWN_AIT_KID";
 
@@ -44,6 +61,24 @@ function invalidAitHeader(message: string): AitJwtError {
 
 function unknownAitKid(kid: string): AitJwtError {
   return new AitJwtError("UNKNOWN_AIT_KID", `Unknown AIT signing kid: ${kid}`);
+}
+
+function ensureAitProtectedHeader(
+  header: ReturnType<typeof decodeProtectedHeader>,
+): DecodedAitHeader {
+  if (header.alg !== "EdDSA") {
+    throw invalidAitHeader("AIT token must use alg=EdDSA");
+  }
+
+  if (header.typ !== "AIT") {
+    throw invalidAitHeader("AIT token must use typ=AIT");
+  }
+
+  if (typeof header.kid !== "string" || header.kid.length === 0) {
+    throw invalidAitHeader("AIT token missing protected kid header");
+  }
+
+  return { alg: "EdDSA", typ: "AIT", kid: header.kid };
 }
 
 export async function signAIT(input: SignAitInput): Promise<string> {
@@ -67,18 +102,7 @@ export async function signAIT(input: SignAitInput): Promise<string> {
 }
 
 export async function verifyAIT(input: VerifyAitInput): Promise<AitClaims> {
-  const header = decodeProtectedHeader(input.token);
-  if (header.alg !== "EdDSA") {
-    throw invalidAitHeader("AIT token must use alg=EdDSA");
-  }
-
-  if (header.typ !== "AIT") {
-    throw invalidAitHeader("AIT token must use typ=AIT");
-  }
-
-  if (typeof header.kid !== "string" || header.kid.length === 0) {
-    throw invalidAitHeader("AIT token missing protected kid header");
-  }
+  const header = ensureAitProtectedHeader(decodeProtectedHeader(input.token));
 
   const key = input.registryKeys.find((item) => item.kid === header.kid);
   if (!key) {
@@ -97,4 +121,10 @@ export async function verifyAIT(input: VerifyAitInput): Promise<AitClaims> {
 
   const { payload } = await jwtVerify(input.token, publicKey, options);
   return parseAitClaims(payload);
+}
+
+export function decodeAIT(token: string): DecodedAit {
+  const header = ensureAitProtectedHeader(decodeProtectedHeader(token));
+  const payload = decodeJwt(token);
+  return { header, claims: parseAitClaims(payload) };
 }


### PR DESCRIPTION
## Summary
- add SDK `decodeAIT(token)` for offline AIT decoding without signature verification while enforcing protected header invariants (`alg=EdDSA`, `typ=AIT`, `kid` required)
- expose `decodeAIT`, `DecodedAit`, and `DecodedAitHeader` from `@clawdentity/sdk`
- add CLI command `clawdentity agent inspect <name>` that reads `~/.clawdentity/agents/<name>/ait.jwt`, decodes it, and prints DID/Owner/Expires/Key ID/Public Key/Framework
- harden agent-name validation by rejecting dot-segment names (`.` and `..`) before any filesystem path resolution
- align issue docs from `<ref>` to `<name>` and update AGENTS best-practice guidance for CLI placeholder semantics and traversal-safe names

## Why
Implements T22 behavior for offline AIT inspection and closes the review-reported path traversal gap for dot-segment names.

## Validation
- `pnpm lint`
- `pnpm -r typecheck`
- `pnpm -r test`
- `pnpm -r build`

## Issues
- Closes #24
