### PR TITLE
[T23] Add CLI agent revoke command by local name

### DIFF
--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -13,7 +13,7 @@
 - Use `@clawdentity/sdk` `createLogger` for runtime logging; avoid direct `console.*` calls in CLI app code.
 - Keep user-facing command output on `writeStdoutLine` / `writeStderrLine`; reserve structured logger calls for diagnostic events.
 - Prefer `@clawdentity/sdk` helpers (`decodeAIT`) when surfacing agent metadata instead of parsing JWTs manually.
- - Reject agent names that are only `.` or `..` before resolving directories or files to prevent accidental traversal of home config directories.
+- Reject agent names that are only `.` or `..` before resolving directories or files to prevent accidental traversal of home config directories.
 
 ## Config and Secrets
 - Local CLI config lives at `~/.clawdentity/config.json`.
@@ -33,6 +33,13 @@
 - `agent inspect <name>` reads `~/.clawdentity/agents/<name>/ait.jwt`, decodes it with `decodeAIT`, and prints DID, Owner, Expires, Key ID, Public Key, and Framework so operators can audit metadata offline.
 - Surface user-friendly errors when the JWT is missing or cannot be decoded, mentioning `ait.jwt` explicitly and defaulting to the normalized agent name when validating input.
 - Tests for new inspection behavior must mock `node:fs/promises.readFile` and `@clawdentity/sdk.decodeAIT`, assert the visible output, and confirm missing-file handling covers `ENOENT`.
+
+## Agent Revocation
+- `agent revoke <name>` accepts local agent name only, then resolves `~/.clawdentity/agents/<name>/identity.json` to load the DID and derive the registry ULID path parameter.
+- Keep revoke flow name-first and filesystem-backed; do not require operators to pass raw ULIDs for locally managed identities.
+- Use registry `DELETE /v1/agents/:id` with PAT auth, and print human-readable confirmation that includes agent name + DID.
+- Keep error messaging explicit for missing/malformed `identity.json`, invalid DID data, missing API key, and registry/network failures.
+- Tests for revoke must cover success/idempotent `204`, auth/config failures, missing/invalid identity metadata, and HTTP error mapping for `401/404/409`.
 
 ## Validation Commands
 - `pnpm -F @clawdentity/cli lint`

--- a/apps/cli/src/commands/agent.test.ts
+++ b/apps/cli/src/commands/agent.test.ts
@@ -315,6 +315,187 @@ describe("agent create command", () => {
   });
 });
 
+describe("agent revoke command", () => {
+  const agentDid = "did:claw:agent:01HF7YAT00W6W7CM7N3W5FDXT4";
+  const agentId = "01HF7YAT00W6W7CM7N3W5FDXT4";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal("fetch", mockFetch);
+
+    mockedResolveConfig.mockResolvedValue({
+      registryUrl: "https://api.clawdentity.com",
+      apiKey: "pat_123",
+    });
+
+    mockedReadFile.mockResolvedValue(
+      JSON.stringify({
+        did: agentDid,
+      }),
+    );
+
+    mockFetch.mockResolvedValue(
+      createJsonResponse(204, {
+        ok: true,
+      }),
+    );
+  });
+
+  afterEach(() => {
+    process.exitCode = undefined;
+    vi.unstubAllGlobals();
+  });
+
+  it("revokes agent by local name and prints confirmation", async () => {
+    const result = await runAgentCommand(["revoke", "agent-01"]);
+
+    expect(mockedReadFile).toHaveBeenCalledWith(
+      "/mock-home/.clawdentity/agents/agent-01/identity.json",
+      "utf-8",
+    );
+    expect(mockFetch).toHaveBeenCalledWith(
+      `https://api.clawdentity.com/v1/agents/${agentId}`,
+      expect.objectContaining({
+        method: "DELETE",
+        headers: expect.objectContaining({
+          authorization: "Bearer pat_123",
+        }),
+      }),
+    );
+
+    expect(result.stdout).toContain(`Agent revoked: agent-01 (${agentDid})`);
+    expect(result.stdout).toContain(
+      "CRL visibility depends on verifier refresh interval.",
+    );
+    expect(result.exitCode).toBeUndefined();
+  });
+
+  it("treats repeat revoke as success (idempotent 204)", async () => {
+    mockFetch.mockResolvedValueOnce(
+      createJsonResponse(204, {
+        ok: true,
+      }),
+    );
+
+    const result = await runAgentCommand(["revoke", "agent-01"]);
+
+    expect(result.stdout).toContain("Agent revoked: agent-01");
+    expect(result.exitCode).toBeUndefined();
+  });
+
+  it("fails when API key is missing", async () => {
+    mockedResolveConfig.mockResolvedValueOnce({
+      registryUrl: "https://api.clawdentity.com",
+    });
+
+    const result = await runAgentCommand(["revoke", "agent-01"]);
+
+    expect(result.stderr).toContain("API key is not configured");
+    expect(result.exitCode).toBe(1);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("fails when local identity.json does not exist", async () => {
+    mockedReadFile.mockRejectedValueOnce(buildErrnoError("ENOENT"));
+
+    const result = await runAgentCommand(["revoke", "agent-01"]);
+
+    expect(result.stderr).toContain("not found");
+    expect(result.stderr).toContain("identity.json");
+    expect(result.exitCode).toBe(1);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("fails when identity.json is invalid JSON", async () => {
+    mockedReadFile.mockResolvedValueOnce("{ did:");
+
+    const result = await runAgentCommand(["revoke", "agent-01"]);
+
+    expect(result.stderr).toContain("identity.json");
+    expect(result.stderr).toContain("valid JSON");
+    expect(result.exitCode).toBe(1);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("fails when identity did is invalid", async () => {
+    mockedReadFile.mockResolvedValueOnce(
+      JSON.stringify({
+        did: "invalid-did",
+      }),
+    );
+
+    const result = await runAgentCommand(["revoke", "agent-01"]);
+
+    expect(result.stderr).toContain("invalid did");
+    expect(result.stderr).toContain("identity.json");
+    expect(result.exitCode).toBe(1);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("handles registry 401 responses", async () => {
+    mockFetch.mockResolvedValueOnce(
+      createJsonResponse(401, {
+        error: {
+          message: "Invalid API key",
+        },
+      }),
+    );
+
+    const result = await runAgentCommand(["revoke", "agent-01"]);
+
+    expect(result.stderr).toContain("authentication failed");
+    expect(result.exitCode).toBe(1);
+  });
+
+  it("handles registry 404 responses", async () => {
+    mockFetch.mockResolvedValueOnce(
+      createJsonResponse(404, {
+        error: {
+          message: "Agent not found",
+        },
+      }),
+    );
+
+    const result = await runAgentCommand(["revoke", "agent-01"]);
+
+    expect(result.stderr).toContain("Agent not found");
+    expect(result.exitCode).toBe(1);
+  });
+
+  it("handles registry 409 responses", async () => {
+    mockFetch.mockResolvedValueOnce(
+      createJsonResponse(409, {
+        error: {
+          message: "Agent cannot be revoked",
+        },
+      }),
+    );
+
+    const result = await runAgentCommand(["revoke", "agent-01"]);
+
+    expect(result.stderr).toContain("cannot be revoked");
+    expect(result.exitCode).toBe(1);
+  });
+
+  it("handles registry connection errors", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("socket hang up"));
+
+    const result = await runAgentCommand(["revoke", "agent-01"]);
+
+    expect(result.stderr).toContain("Unable to connect to the registry");
+    expect(result.exitCode).toBe(1);
+  });
+
+  it("rejects dot-segment agent names before resolving identity path", async () => {
+    const result = await runAgentCommand(["revoke", ".."]);
+
+    expect(result.stderr).toContain('Agent name must not be "." or "..".');
+    expect(result.exitCode).toBe(1);
+    expect(mockedReadFile).not.toHaveBeenCalled();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});
+
 describe("agent inspect command", () => {
   const decodedAit: DecodedAit = {
     header: {

--- a/apps/cli/src/commands/agent.ts
+++ b/apps/cli/src/commands/agent.ts
@@ -1,6 +1,6 @@
 import { access, chmod, mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
-import { validateAgentName } from "@clawdentity/protocol";
+import { parseDid, validateAgentName } from "@clawdentity/protocol";
 import {
   createLogger,
   type DecodedAit,
@@ -17,6 +17,7 @@ const logger = createLogger({ service: "cli", module: "agent" });
 
 const AGENTS_DIR_NAME = "agents";
 const AIT_FILE_NAME = "ait.jwt";
+const IDENTITY_FILE_NAME = "identity.json";
 const RESERVED_AGENT_NAMES = new Set([".", ".."]);
 const FILE_MODE = 0o600;
 
@@ -35,6 +36,10 @@ type AgentRegistrationResponse = {
   ait: string;
 };
 
+type LocalAgentIdentity = {
+  did: string;
+};
+
 type RegistryErrorEnvelope = {
   error?: {
     message?: string;
@@ -51,6 +56,10 @@ const getAgentDirectory = (name: string): string => {
 
 const getAgentAitPath = (name: string): string => {
   return join(getAgentDirectory(name), AIT_FILE_NAME);
+};
+
+const getAgentIdentityPath = (name: string): string => {
+  return join(getAgentDirectory(name), IDENTITY_FILE_NAME);
 };
 
 const readAgentAitToken = async (agentName: string): Promise<string> => {
@@ -74,6 +83,63 @@ const readAgentAitToken = async (agentName: string): Promise<string> => {
   }
 
   return token;
+};
+
+const readAgentIdentity = async (
+  agentName: string,
+): Promise<LocalAgentIdentity> => {
+  const identityPath = getAgentIdentityPath(agentName);
+
+  let rawIdentity: string;
+  try {
+    rawIdentity = await readFile(identityPath, "utf-8");
+  } catch (error) {
+    const nodeError = error as NodeJS.ErrnoException;
+    if (nodeError.code === "ENOENT") {
+      throw new Error(`Agent "${agentName}" not found (${identityPath})`);
+    }
+
+    throw error;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawIdentity);
+  } catch {
+    throw new Error(
+      `Agent "${agentName}" has invalid ${IDENTITY_FILE_NAME} (must be valid JSON)`,
+    );
+  }
+
+  if (!isRecord(parsed) || typeof parsed.did !== "string") {
+    throw new Error(
+      `Agent "${agentName}" has invalid ${IDENTITY_FILE_NAME} (missing did)`,
+    );
+  }
+
+  const did = parsed.did.trim();
+  if (did.length === 0) {
+    throw new Error(
+      `Agent "${agentName}" has invalid ${IDENTITY_FILE_NAME} (missing did)`,
+    );
+  }
+
+  return { did };
+};
+
+const parseAgentIdFromDid = (agentName: string, did: string): string => {
+  try {
+    const parsedDid = parseDid(did);
+    if (parsedDid.kind !== "agent") {
+      throw new Error("DID is not an agent DID");
+    }
+
+    return parsedDid.ulid;
+  } catch {
+    throw new Error(
+      `Agent "${agentName}" has invalid did in ${IDENTITY_FILE_NAME}: ${did}`,
+    );
+  }
 };
 
 const formatExpiresAt = (expires: number): string => {
@@ -146,12 +212,19 @@ const parseJsonResponse = async (response: Response): Promise<unknown> => {
   }
 };
 
-const toRegistryRequestUrl = (registryUrl: string): string => {
+const toRegistryAgentsRequestUrl = (
+  registryUrl: string,
+  agentId?: string,
+): string => {
   const normalizedBaseUrl = registryUrl.endsWith("/")
     ? registryUrl
     : `${registryUrl}/`;
 
-  return new URL("v1/agents", normalizedBaseUrl).toString();
+  const path = agentId
+    ? `v1/agents/${encodeURIComponent(agentId)}`
+    : "v1/agents";
+
+  return new URL(path, normalizedBaseUrl).toString();
 };
 
 const toHttpErrorMessage = (status: number, responseBody: unknown): string => {
@@ -328,7 +401,7 @@ const registerAgent = async (input: {
 
   let response: Response;
   try {
-    response = await fetch(toRegistryRequestUrl(input.registryUrl), {
+    response = await fetch(toRegistryAgentsRequestUrl(input.registryUrl), {
       method: "POST",
       headers: {
         authorization: `Bearer ${input.apiKey}`,
@@ -349,6 +422,70 @@ const registerAgent = async (input: {
   }
 
   return parseAgentRegistrationResponse(responseBody);
+};
+
+const toRevokeHttpErrorMessage = (
+  status: number,
+  responseBody: unknown,
+): string => {
+  const registryMessage = extractRegistryErrorMessage(responseBody);
+
+  if (status === 401) {
+    return registryMessage
+      ? `Registry authentication failed (401): ${registryMessage}`
+      : "Registry authentication failed (401). Check your API key.";
+  }
+
+  if (status === 404) {
+    return registryMessage
+      ? `Agent not found (404): ${registryMessage}`
+      : "Agent not found in the registry (404).";
+  }
+
+  if (status === 409) {
+    return registryMessage
+      ? `Agent cannot be revoked (409): ${registryMessage}`
+      : "Agent cannot be revoked (409).";
+  }
+
+  if (status >= 500) {
+    return `Registry server error (${status}). Try again later.`;
+  }
+
+  if (registryMessage) {
+    return `Registry request failed (${status}): ${registryMessage}`;
+  }
+
+  return `Registry request failed (${status})`;
+};
+
+const revokeAgent = async (input: {
+  apiKey: string;
+  registryUrl: string;
+  agentId: string;
+}): Promise<void> => {
+  let response: Response;
+  try {
+    response = await fetch(
+      toRegistryAgentsRequestUrl(input.registryUrl, input.agentId),
+      {
+        method: "DELETE",
+        headers: {
+          authorization: `Bearer ${input.apiKey}`,
+        },
+      },
+    );
+  } catch {
+    throw new Error(
+      "Unable to connect to the registry. Check network access and registryUrl.",
+    );
+  }
+
+  const responseBody = await parseJsonResponse(response);
+
+  if (!response.ok) {
+    throw new Error(toRevokeHttpErrorMessage(response.status, responseBody));
+  }
 };
 
 const printAgentInspect = (decoded: DecodedAit): void => {
@@ -445,6 +582,40 @@ export const createAgentCommand = (): Command => {
     .action(
       withErrorHandling("agent inspect", async (name: string) => {
         await printAgentInspectCommand(name);
+      }),
+    );
+
+  agentCommand
+    .command("revoke <name>")
+    .description("Revoke a local agent identity via the registry")
+    .action(
+      withErrorHandling("agent revoke", async (name: string) => {
+        const config = await resolveConfig();
+        if (!config.apiKey) {
+          throw new Error(
+            "API key is not configured. Run `clawdentity config set apiKey <token>` or set CLAWDENTITY_API_KEY.",
+          );
+        }
+
+        const agentName = assertValidAgentName(name);
+        const identity = await readAgentIdentity(agentName);
+        const agentId = parseAgentIdFromDid(agentName, identity.did);
+
+        await revokeAgent({
+          apiKey: config.apiKey,
+          registryUrl: config.registryUrl,
+          agentId,
+        });
+
+        logger.info("cli.agent_revoked", {
+          name: agentName,
+          did: identity.did,
+          agentId,
+          registryUrl: config.registryUrl,
+        });
+
+        writeStdoutLine(`Agent revoked: ${agentName} (${identity.did})`);
+        writeStdoutLine("CRL visibility depends on verifier refresh interval.");
       }),
     );
 


### PR DESCRIPTION
## Summary
- add `clawdentity agent revoke <name>` to revoke by local agent name
- resolve `~/.clawdentity/agents/<name>/identity.json`, parse DID, derive ULID, and call `DELETE /v1/agents/:id`
- add revoke-specific CLI error handling for missing identity metadata, invalid DID, and registry/network failures
- add comprehensive revoke command tests (success/idempotent + failure paths)
- update `apps/cli/AGENTS.md` with revoke command best practices and test expectations

## Validation
- `pnpm lint`
- `pnpm -r typecheck`
- `pnpm -r test`
- `pnpm -r build`
- pre-push gate: `nx affected -t lint,format,typecheck,test --base=origin/main --head=HEAD`

Closes #25
