### PR TITLE
[T24] Verify an AIT locally (signature + expiry + CRL).

### DIFF
--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -8,6 +8,7 @@
 - Keep `src/index.ts` as a pure program builder (`createProgram()`); no side effects on import.
 - Keep `src/bin.ts` as a thin runtime entry only (`parseAsync` + top-level error handling).
 - Implement command groups under `src/commands/*` and register them from `createProgram()`.
+- Keep top-level command contracts stable (`config`, `agent`, `verify`) so automation and docs do not drift.
 - Reuse shared command helpers from `src/commands/helpers.ts` (especially `withErrorHandling`) instead of duplicating command-level try/catch blocks.
 - Use `process.exitCode` instead of `process.exit()`.
 - Use `@clawdentity/sdk` `createLogger` for runtime logging; avoid direct `console.*` calls in CLI app code.
@@ -17,6 +18,7 @@
 
 ## Config and Secrets
 - Local CLI config lives at `~/.clawdentity/config.json`.
+- CLI verification caches live under `~/.clawdentity/cache/` and must never include private keys or PATs.
 - Agent identities live at `~/.clawdentity/agents/<name>/` and must include `secret.key`, `public.key`, `identity.json`, and `ait.jwt`.
 - Reject `.` and `..` as agent names before any filesystem operation to prevent directory traversal outside `~/.clawdentity/agents/`.
 - Resolve values with explicit precedence: environment variables > config file > built-in defaults.
@@ -40,6 +42,13 @@
 - Use registry `DELETE /v1/agents/:id` with PAT auth, and print human-readable confirmation that includes agent name + DID.
 - Keep error messaging explicit for missing/malformed `identity.json`, invalid DID data, missing API key, and registry/network failures.
 - Tests for revoke must cover success/idempotent `204`, auth/config failures, missing/invalid identity metadata, and HTTP error mapping for `401/404/409`.
+
+## Token Verification
+- `verify <tokenOrFile>` accepts either a raw AIT token or a filesystem path to a file containing one token.
+- Verification is fail-closed for revocation checks: if CRL cannot be fetched/validated and no fresh cache is available, command must fail.
+- Verify flow must use SDK primitives (`verifyAIT`, `verifyCRL`) and registry endpoints (`/.well-known/claw-keys.json`, `/v1/crl`) instead of local JWT parsing.
+- Keep user output explicit and command-like: successful checks print `✅ ...`; failed checks print `❌ <reason>` and set non-zero exit code.
+- Cache files (`registry-keys.json`, `crl-claims.json`) should include source registry URL + fetch timestamp so stale or cross-environment cache reuse is avoided.
 
 ## Validation Commands
 - `pnpm -F @clawdentity/cli lint`

--- a/apps/cli/src/AGENTS.md
+++ b/apps/cli/src/AGENTS.md
@@ -1,0 +1,25 @@
+# AGENTS.md (apps/cli/src)
+
+## Purpose
+- Keep CLI source modules small, composable, and safe for local operator workflows.
+
+## Command Modules
+- Keep each command implementation in `commands/<name>.ts` with one exported factory (`create<Name>Command`).
+- Reuse shared command wrappers (`withErrorHandling`) and IO helpers (`writeStdoutLine`, `writeStderrLine`) instead of inline process writes.
+- Prefer explicit error-to-reason mapping for operator-facing failures rather than generic stack traces.
+
+## Verification Flow Contract
+- `verify` must support both raw token input and file-path input without requiring extra flags.
+- Resolve registry material from configured `registryUrl` only (`/.well-known/claw-keys.json`, `/v1/crl`).
+- Use cached key/CRL artifacts only when fresh and scoped to the same registry URL.
+- Treat CRL refresh/validation failures as hard verification failures (fail-closed behavior).
+
+## Caching Rules
+- Cache reads must be tolerant of malformed JSON by ignoring bad cache and fetching fresh data.
+- Cache writes must use restrictive permissions through config-manager helpers.
+- Cache payloads must be JSON and include `fetchedAtMs` timestamps for TTL checks.
+
+## Testing Rules
+- Command tests must capture `stdout`/`stderr` and assert exit-code behavior.
+- Include success, revoked, invalid token, keyset failure, CRL failure, and cache-hit scenarios for `verify`.
+- Keep tests deterministic by mocking network and filesystem dependencies.

--- a/apps/cli/src/commands/AGENTS.md
+++ b/apps/cli/src/commands/AGENTS.md
@@ -1,0 +1,21 @@
+# AGENTS.md (apps/cli/src/commands)
+
+## Purpose
+- Define implementation guardrails for individual CLI command modules.
+
+## Command Patterns
+- Export one command factory per file (`create<Name>Command`).
+- Keep command handlers focused on orchestration; move reusable logic into local helpers.
+- Use `withErrorHandling` for command actions unless a command has a documented reason not to.
+- Route all user-facing messages through `writeStdoutLine`/`writeStderrLine`.
+
+## Verification Command Rules
+- `verify` must preserve the `✅`/`❌` output contract with explicit reasons.
+- Token argument can be either a raw token or file path; missing file paths should fall back to raw token mode.
+- Signature and CRL validation must use SDK helpers (`verifyAIT`, `verifyCRL`), not local JWT cryptography code.
+- Cache usage must enforce TTL and registry URL matching before reuse.
+
+## Testing Rules
+- Mock network and filesystem dependencies in command tests.
+- Include success and failure scenarios for external calls, parsing, and cache behavior.
+- Assert exit code behavior in addition to stdout/stderr text.

--- a/apps/cli/src/commands/verify.test.ts
+++ b/apps/cli/src/commands/verify.test.ts
@@ -1,0 +1,350 @@
+import { readFile } from "node:fs/promises";
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:fs/promises", () => ({
+  readFile: vi.fn(),
+}));
+
+vi.mock("../config/manager.js", () => ({
+  readCacheFile: vi.fn(),
+  resolveConfig: vi.fn(),
+  writeCacheFile: vi.fn(),
+}));
+
+vi.mock("@clawdentity/sdk", () => ({
+  createLogger: vi.fn(() => ({
+    child: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  })),
+  parseRegistryConfig: vi.fn(),
+  verifyAIT: vi.fn(),
+  verifyCRL: vi.fn(),
+}));
+
+import { parseRegistryConfig, verifyAIT, verifyCRL } from "@clawdentity/sdk";
+import {
+  readCacheFile,
+  resolveConfig,
+  writeCacheFile,
+} from "../config/manager.js";
+import { createVerifyCommand } from "./verify.js";
+
+const mockedTokenReadFile = vi.mocked(readFile);
+const mockedResolveConfig = vi.mocked(resolveConfig);
+const mockedReadCacheFile = vi.mocked(readCacheFile);
+const mockedWriteCacheFile = vi.mocked(writeCacheFile);
+const mockedParseRegistryConfig = vi.mocked(parseRegistryConfig);
+const mockedVerifyAit = vi.mocked(verifyAIT);
+const mockedVerifyCrl = vi.mocked(verifyCRL);
+
+const mockFetch = vi.fn<typeof fetch>();
+
+const buildErrnoError = (code: string): NodeJS.ErrnoException => {
+  const error = new Error(code) as NodeJS.ErrnoException;
+  error.code = code;
+  return error;
+};
+
+const createJsonResponse = (status: number, body: unknown): Response => {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: vi.fn(async () => body),
+  } as unknown as Response;
+};
+
+const runVerifyCommand = async (args: string[]) => {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const previousExitCode = process.exitCode;
+
+  const stdoutSpy = vi
+    .spyOn(process.stdout, "write")
+    .mockImplementation((chunk: unknown) => {
+      stdout.push(String(chunk));
+      return true;
+    });
+
+  const stderrSpy = vi
+    .spyOn(process.stderr, "write")
+    .mockImplementation((chunk: unknown) => {
+      stderr.push(String(chunk));
+      return true;
+    });
+
+  process.exitCode = undefined;
+
+  const command = createVerifyCommand();
+  command.configureOutput({
+    writeOut: (message) => stdout.push(message),
+    writeErr: (message) => stderr.push(message),
+    outputError: (message) => stderr.push(message),
+  });
+
+  const root = new Command("clawdentity");
+  root.addCommand(command);
+
+  try {
+    await root.parseAsync(["node", "clawdentity", "verify", ...args]);
+  } finally {
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+  }
+
+  const exitCode = process.exitCode;
+  process.exitCode = previousExitCode;
+
+  return {
+    exitCode,
+    stderr: stderr.join(""),
+    stdout: stdout.join(""),
+  };
+};
+
+const activeSigningKey = {
+  kid: "reg-key-1",
+  alg: "EdDSA",
+  crv: "Ed25519",
+  x: "AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA",
+  status: "active",
+} as const;
+
+const tokenClaims = {
+  iss: "https://api.clawdentity.com",
+  sub: "did:claw:agent:01HF7YAT00W6W7CM7N3W5FDXT4",
+  ownerDid: "did:claw:human:01HF7YAT00W6W7CM7N3W5FDXT5",
+  name: "agent-01",
+  framework: "openclaw",
+  cnf: {
+    jwk: {
+      kty: "OKP",
+      crv: "Ed25519",
+      x: "AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA",
+    },
+  },
+  iat: 1_700_000_000,
+  nbf: 1_700_000_000,
+  exp: 1_900_000_000,
+  jti: "01HF7YAT5QJ4K3YVQJ6Q2F9M1N",
+} as const;
+
+const crlClaims = {
+  iss: "https://api.clawdentity.com",
+  jti: "01HF7YAT4TXP6AW5QNXA2Y9K43",
+  iat: 1_700_000_000,
+  exp: 1_900_000_000,
+  revocations: [
+    {
+      jti: "01HF7YAT31JZHSMW1CG6Q6MHB7",
+      agentDid: "did:claw:agent:01HF7YAT00W6W7CM7N3W5FDXT4",
+      revokedAt: 1_700_000_100,
+    },
+  ],
+};
+
+describe("verify command", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal("fetch", mockFetch);
+
+    mockedTokenReadFile.mockRejectedValue(buildErrnoError("ENOENT"));
+    mockedResolveConfig.mockResolvedValue({
+      registryUrl: "https://api.clawdentity.com",
+    });
+    mockedReadCacheFile.mockResolvedValue(undefined);
+    mockedWriteCacheFile.mockResolvedValue(undefined);
+
+    mockedParseRegistryConfig.mockReturnValue({
+      ENVIRONMENT: "test",
+      REGISTRY_SIGNING_KEYS: [activeSigningKey],
+    });
+
+    mockedVerifyAit.mockResolvedValue(tokenClaims);
+    mockedVerifyCrl.mockResolvedValue(crlClaims);
+
+    mockFetch.mockResolvedValueOnce(
+      createJsonResponse(200, {
+        keys: [activeSigningKey],
+      }),
+    );
+    mockFetch.mockResolvedValueOnce(
+      createJsonResponse(200, {
+        crl: "crl.jwt.value",
+      }),
+    );
+  });
+
+  afterEach(() => {
+    process.exitCode = undefined;
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it("verifies a valid token", async () => {
+    const result = await runVerifyCommand(["token.jwt"]);
+
+    expect(result.stdout).toContain("✅ token verified");
+    expect(result.exitCode).toBeUndefined();
+    expect(mockedVerifyAit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        token: "token.jwt",
+      }),
+    );
+  });
+
+  it("fails when token is revoked", async () => {
+    mockedVerifyCrl.mockResolvedValueOnce({
+      ...crlClaims,
+      revocations: [
+        {
+          ...crlClaims.revocations[0],
+          jti: tokenClaims.jti,
+        },
+      ],
+    });
+
+    const result = await runVerifyCommand(["token.jwt"]);
+
+    expect(result.stdout).toContain("❌ revoked");
+    expect(result.exitCode).toBe(1);
+  });
+
+  it("fails with reason when token signature is invalid", async () => {
+    mockedVerifyAit.mockRejectedValueOnce(
+      new Error("signature verification failed"),
+    );
+
+    const result = await runVerifyCommand(["token.jwt"]);
+
+    expect(result.stdout).toContain("❌ invalid token");
+    expect(result.exitCode).toBe(1);
+  });
+
+  it("fails when keyset cannot be fetched", async () => {
+    mockFetch.mockReset();
+    mockFetch.mockRejectedValueOnce(new Error("network down"));
+
+    const result = await runVerifyCommand(["token.jwt"]);
+
+    expect(result.stdout).toContain("❌ verification keys unavailable");
+    expect(result.exitCode).toBe(1);
+  });
+
+  it("fails when CRL cannot be fetched", async () => {
+    mockFetch.mockReset();
+    mockFetch.mockResolvedValueOnce(
+      createJsonResponse(200, {
+        keys: [activeSigningKey],
+      }),
+    );
+    mockFetch.mockRejectedValueOnce(new Error("network down"));
+
+    const result = await runVerifyCommand(["token.jwt"]);
+
+    expect(result.stdout).toContain("❌ revocation check unavailable");
+    expect(result.exitCode).toBe(1);
+  });
+
+  it("fails when fetched CRL cannot be verified", async () => {
+    mockedVerifyCrl.mockRejectedValueOnce(new Error("invalid CRL token"));
+
+    const result = await runVerifyCommand(["token.jwt"]);
+
+    expect(result.stdout).toContain(
+      "❌ revocation check unavailable (invalid CRL)",
+    );
+    expect(result.exitCode).toBe(1);
+  });
+
+  it("supports reading token from file path", async () => {
+    mockedTokenReadFile.mockResolvedValueOnce("file-token.jwt\n");
+
+    const result = await runVerifyCommand(["./ait.jwt"]);
+
+    expect(result.stdout).toContain("✅ token verified");
+    expect(mockedVerifyAit).toHaveBeenCalledWith(
+      expect.objectContaining({ token: "file-token.jwt" }),
+    );
+  });
+
+  it("uses fresh disk caches and skips network fetch", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-02-15T16:00:00.000Z"));
+
+    mockedReadCacheFile.mockImplementation(async (fileName: string) => {
+      if (fileName === "registry-keys.json") {
+        return JSON.stringify({
+          registryUrl: "https://api.clawdentity.com/",
+          fetchedAtMs: Date.now() - 1_000,
+          keys: [activeSigningKey],
+        });
+      }
+
+      if (fileName === "crl-claims.json") {
+        return JSON.stringify({
+          registryUrl: "https://api.clawdentity.com/",
+          fetchedAtMs: Date.now() - 1_000,
+          claims: crlClaims,
+        });
+      }
+
+      return undefined;
+    });
+
+    mockFetch.mockReset();
+
+    const result = await runVerifyCommand(["token.jwt"]);
+
+    expect(result.stdout).toContain("✅ token verified");
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(mockedVerifyCrl).not.toHaveBeenCalled();
+    expect(mockedWriteCacheFile).not.toHaveBeenCalled();
+  });
+
+  it("refreshes stale caches from the network", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-02-15T16:00:00.000Z"));
+
+    mockedReadCacheFile.mockImplementation(async (fileName: string) => {
+      if (fileName === "registry-keys.json") {
+        return JSON.stringify({
+          registryUrl: "https://api.clawdentity.com/",
+          fetchedAtMs: Date.now() - 60 * 60 * 1000 - 1,
+          keys: [activeSigningKey],
+        });
+      }
+
+      if (fileName === "crl-claims.json") {
+        return JSON.stringify({
+          registryUrl: "https://api.clawdentity.com/",
+          fetchedAtMs: Date.now() - 15 * 60 * 1000 - 1,
+          claims: crlClaims,
+        });
+      }
+
+      return undefined;
+    });
+
+    mockFetch.mockReset();
+    mockFetch.mockResolvedValueOnce(
+      createJsonResponse(200, {
+        keys: [activeSigningKey],
+      }),
+    );
+    mockFetch.mockResolvedValueOnce(
+      createJsonResponse(200, {
+        crl: "crl.jwt.value",
+      }),
+    );
+
+    const result = await runVerifyCommand(["token.jwt"]);
+
+    expect(result.stdout).toContain("✅ token verified");
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockedWriteCacheFile).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/cli/src/commands/verify.ts
+++ b/apps/cli/src/commands/verify.ts
@@ -1,0 +1,496 @@
+import { readFile } from "node:fs/promises";
+import { parseCrlClaims } from "@clawdentity/protocol";
+import {
+  createLogger,
+  parseRegistryConfig,
+  type RegistryConfig,
+  verifyAIT,
+  verifyCRL,
+} from "@clawdentity/sdk";
+import { Command } from "commander";
+import {
+  readCacheFile,
+  resolveConfig,
+  writeCacheFile,
+} from "../config/manager.js";
+import { writeStdoutLine } from "../io.js";
+import { withErrorHandling } from "./helpers.js";
+
+const logger = createLogger({ service: "cli", module: "verify" });
+
+const REGISTRY_KEYS_CACHE_FILE = "registry-keys.json";
+const CRL_CLAIMS_CACHE_FILE = "crl-claims.json";
+const REGISTRY_KEYS_CACHE_TTL_MS = 60 * 60 * 1000;
+const CRL_CACHE_MAX_AGE_MS = 15 * 60 * 1000;
+
+type RegistrySigningKey = NonNullable<
+  RegistryConfig["REGISTRY_SIGNING_KEYS"]
+>[number];
+
+type VerificationKey = {
+  kid: string;
+  jwk: {
+    kty: "OKP";
+    crv: "Ed25519";
+    x: string;
+  };
+};
+
+type CrlVerificationClaims = Awaited<ReturnType<typeof verifyCRL>>;
+
+type RegistryKeysCacheEntry = {
+  registryUrl: string;
+  fetchedAtMs: number;
+  keys: RegistrySigningKey[];
+};
+
+type CrlClaimsCacheEntry = {
+  registryUrl: string;
+  fetchedAtMs: number;
+  claims: CrlVerificationClaims;
+};
+
+class VerifyCommandError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "VerifyCommandError";
+  }
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+  return typeof value === "object" && value !== null;
+};
+
+const normalizeRegistryUrl = (registryUrl: string): string => {
+  try {
+    return new URL(registryUrl).toString();
+  } catch {
+    throw new VerifyCommandError(
+      "verification keys unavailable (registryUrl is invalid)",
+    );
+  }
+};
+
+const toRegistryUrl = (registryUrl: string, path: string): string => {
+  const normalizedBaseUrl = registryUrl.endsWith("/")
+    ? registryUrl
+    : `${registryUrl}/`;
+
+  return new URL(path, normalizedBaseUrl).toString();
+};
+
+const toExpectedIssuer = (registryUrl: string): string | undefined => {
+  try {
+    const hostname = new URL(registryUrl).hostname;
+    if (hostname === "api.clawdentity.com") {
+      return "https://api.clawdentity.com";
+    }
+
+    if (hostname === "dev.api.clawdentity.com") {
+      return "https://dev.api.clawdentity.com";
+    }
+
+    return undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+const resolveToken = async (tokenOrFile: string): Promise<string> => {
+  const input = tokenOrFile.trim();
+  if (input.length === 0) {
+    throw new VerifyCommandError("invalid token (value is empty)");
+  }
+
+  try {
+    const fileContents = await readFile(input, "utf-8");
+    const token = fileContents.trim();
+    if (token.length === 0) {
+      throw new VerifyCommandError(`invalid token (${input} is empty)`);
+    }
+
+    return token;
+  } catch (error) {
+    const nodeError = error as NodeJS.ErrnoException;
+    if (nodeError.code === "ENOENT") {
+      return input;
+    }
+
+    if (error instanceof VerifyCommandError) {
+      throw error;
+    }
+
+    throw new VerifyCommandError(`invalid token (unable to read ${input})`);
+  }
+};
+
+const parseJson = (raw: string): unknown => {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+};
+
+const parseResponseJson = async (response: Response): Promise<unknown> => {
+  try {
+    return await response.json();
+  } catch {
+    return undefined;
+  }
+};
+
+const parseSigningKeys = (payload: unknown): RegistrySigningKey[] => {
+  if (!isRecord(payload) || !Array.isArray(payload.keys)) {
+    throw new VerifyCommandError(
+      "verification keys unavailable (response payload is invalid)",
+    );
+  }
+
+  const parsedConfig = parseRegistryConfig({
+    ENVIRONMENT: "test",
+    REGISTRY_SIGNING_KEYS: JSON.stringify(payload.keys),
+  });
+
+  const keys = parsedConfig.REGISTRY_SIGNING_KEYS ?? [];
+  if (keys.length === 0) {
+    throw new VerifyCommandError(
+      "verification keys unavailable (no signing keys were published)",
+    );
+  }
+
+  return keys;
+};
+
+const parseRegistryKeysCache = (
+  rawCache: string,
+): RegistryKeysCacheEntry | undefined => {
+  const parsed = parseJson(rawCache);
+  if (!isRecord(parsed)) {
+    return undefined;
+  }
+
+  const { registryUrl, fetchedAtMs, keys } = parsed;
+  if (typeof registryUrl !== "string") {
+    return undefined;
+  }
+
+  if (typeof fetchedAtMs !== "number") {
+    return undefined;
+  }
+
+  if (!Number.isFinite(fetchedAtMs) || fetchedAtMs < 0) {
+    return undefined;
+  }
+
+  try {
+    const parsedKeys = parseSigningKeys({ keys });
+    return {
+      registryUrl,
+      fetchedAtMs,
+      keys: parsedKeys,
+    };
+  } catch {
+    return undefined;
+  }
+};
+
+const parseCrlCache = (rawCache: string): CrlClaimsCacheEntry | undefined => {
+  const parsed = parseJson(rawCache);
+  if (!isRecord(parsed)) {
+    return undefined;
+  }
+
+  const { registryUrl, fetchedAtMs, claims } = parsed;
+  if (typeof registryUrl !== "string") {
+    return undefined;
+  }
+
+  if (typeof fetchedAtMs !== "number") {
+    return undefined;
+  }
+
+  if (!Number.isFinite(fetchedAtMs) || fetchedAtMs < 0) {
+    return undefined;
+  }
+
+  try {
+    return {
+      registryUrl,
+      fetchedAtMs,
+      claims: parseCrlClaims(claims),
+    };
+  } catch {
+    return undefined;
+  }
+};
+
+const toVerificationKeys = (keys: RegistrySigningKey[]): VerificationKey[] => {
+  return keys
+    .filter((key) => key.status === "active")
+    .map((key) => ({
+      kid: key.kid,
+      jwk: {
+        kty: "OKP",
+        crv: "Ed25519",
+        x: key.x,
+      },
+    }));
+};
+
+const isFreshCache = (input: {
+  cache: { fetchedAtMs: number; registryUrl: string } | undefined;
+  nowMs: number;
+  registryUrl: string;
+  ttlMs: number;
+}) => {
+  return (
+    input.cache !== undefined &&
+    input.cache.registryUrl === input.registryUrl &&
+    input.nowMs - input.cache.fetchedAtMs <= input.ttlMs
+  );
+};
+
+const fetchRegistryKeys = async (
+  registryUrl: string,
+): Promise<RegistrySigningKey[]> => {
+  let response: Response;
+
+  try {
+    response = await fetch(
+      toRegistryUrl(registryUrl, "/.well-known/claw-keys.json"),
+    );
+  } catch {
+    throw new VerifyCommandError(
+      "verification keys unavailable (network error)",
+    );
+  }
+
+  if (!response.ok) {
+    throw new VerifyCommandError(
+      `verification keys unavailable (status ${response.status})`,
+    );
+  }
+
+  return parseSigningKeys(await parseResponseJson(response));
+};
+
+const loadRegistryKeys = async (
+  registryUrl: string,
+): Promise<RegistrySigningKey[]> => {
+  const now = Date.now();
+  const rawCache = await readCacheFile(REGISTRY_KEYS_CACHE_FILE);
+  const cache =
+    typeof rawCache === "string" ? parseRegistryKeysCache(rawCache) : undefined;
+
+  const isFresh = isFreshCache({
+    cache,
+    nowMs: now,
+    registryUrl,
+    ttlMs: REGISTRY_KEYS_CACHE_TTL_MS,
+  });
+
+  if (isFresh && cache) {
+    return cache.keys;
+  }
+
+  const keys = await fetchRegistryKeys(registryUrl);
+
+  await writeCacheFile(
+    REGISTRY_KEYS_CACHE_FILE,
+    `${JSON.stringify(
+      {
+        registryUrl,
+        fetchedAtMs: now,
+        keys,
+      } satisfies RegistryKeysCacheEntry,
+      null,
+      2,
+    )}\n`,
+  );
+
+  return keys;
+};
+
+const fetchCrlClaims = async (input: {
+  expectedIssuer?: string;
+  registryUrl: string;
+  verificationKeys: VerificationKey[];
+}): Promise<CrlVerificationClaims> => {
+  let response: Response;
+
+  try {
+    response = await fetch(toRegistryUrl(input.registryUrl, "/v1/crl"));
+  } catch {
+    throw new VerifyCommandError(
+      "revocation check unavailable (network error)",
+    );
+  }
+
+  if (!response.ok) {
+    throw new VerifyCommandError(
+      `revocation check unavailable (status ${response.status})`,
+    );
+  }
+
+  const payload = await parseResponseJson(response);
+  if (!isRecord(payload) || typeof payload.crl !== "string") {
+    throw new VerifyCommandError(
+      "revocation check unavailable (response payload is invalid)",
+    );
+  }
+
+  try {
+    return await verifyCRL({
+      token: payload.crl,
+      registryKeys: input.verificationKeys,
+      expectedIssuer: input.expectedIssuer,
+    });
+  } catch {
+    throw new VerifyCommandError("revocation check unavailable (invalid CRL)");
+  }
+};
+
+const loadCrlClaims = async (input: {
+  expectedIssuer?: string;
+  registryUrl: string;
+  verificationKeys: VerificationKey[];
+}): Promise<CrlVerificationClaims> => {
+  const now = Date.now();
+  const rawCache = await readCacheFile(CRL_CLAIMS_CACHE_FILE);
+  const cache =
+    typeof rawCache === "string" ? parseCrlCache(rawCache) : undefined;
+
+  const isFresh = isFreshCache({
+    cache,
+    nowMs: now,
+    registryUrl: input.registryUrl,
+    ttlMs: CRL_CACHE_MAX_AGE_MS,
+  });
+
+  if (isFresh && cache) {
+    return cache.claims;
+  }
+
+  const claims = await fetchCrlClaims(input);
+
+  await writeCacheFile(
+    CRL_CLAIMS_CACHE_FILE,
+    `${JSON.stringify(
+      {
+        registryUrl: input.registryUrl,
+        fetchedAtMs: now,
+        claims,
+      } satisfies CrlClaimsCacheEntry,
+      null,
+      2,
+    )}\n`,
+  );
+
+  return claims;
+};
+
+const toInvalidTokenReason = (error: unknown): string => {
+  if (isRecord(error) && typeof error.message === "string") {
+    return `invalid token (${error.message})`;
+  }
+
+  if (error instanceof Error && error.message.length > 0) {
+    return `invalid token (${error.message})`;
+  }
+
+  return "invalid token";
+};
+
+const printResult = (passed: boolean, reason: string): void => {
+  if (passed) {
+    writeStdoutLine(`✅ ${reason}`);
+    return;
+  }
+
+  process.exitCode = 1;
+  writeStdoutLine(`❌ ${reason}`);
+};
+
+const runVerify = async (tokenOrFile: string): Promise<void> => {
+  const config = await resolveConfig();
+  const registryUrl = normalizeRegistryUrl(config.registryUrl);
+  const expectedIssuer = toExpectedIssuer(registryUrl);
+  const token = await resolveToken(tokenOrFile);
+
+  let keys: RegistrySigningKey[];
+  try {
+    keys = await loadRegistryKeys(registryUrl);
+  } catch (error) {
+    if (error instanceof VerifyCommandError) {
+      printResult(false, error.message);
+      return;
+    }
+
+    throw error;
+  }
+
+  const verificationKeys = toVerificationKeys(keys);
+  if (verificationKeys.length === 0) {
+    printResult(false, "verification keys unavailable (no active keys)");
+    return;
+  }
+
+  let claims: Awaited<ReturnType<typeof verifyAIT>>;
+  try {
+    claims = await verifyAIT({
+      token,
+      registryKeys: verificationKeys,
+      expectedIssuer,
+    });
+  } catch (error) {
+    printResult(false, toInvalidTokenReason(error));
+    return;
+  }
+
+  let crlClaims: CrlVerificationClaims;
+  try {
+    crlClaims = await loadCrlClaims({
+      expectedIssuer,
+      registryUrl,
+      verificationKeys,
+    });
+  } catch (error) {
+    if (error instanceof VerifyCommandError) {
+      printResult(false, error.message);
+      return;
+    }
+
+    throw error;
+  }
+
+  const isRevoked = crlClaims.revocations.some(
+    (revocation) => revocation.jti === claims.jti,
+  );
+
+  if (isRevoked) {
+    printResult(false, "revoked");
+    return;
+  }
+
+  logger.info("cli.verify.success", {
+    did: claims.sub,
+    jti: claims.jti,
+    issuer: claims.iss,
+  });
+  printResult(true, `token verified (${claims.sub})`);
+};
+
+export const createVerifyCommand = (): Command => {
+  return new Command("verify")
+    .description("Verify an AIT using registry keys and CRL state")
+    .argument(
+      "<tokenOrFile>",
+      "Raw AIT token or file path containing the token",
+    )
+    .action(
+      withErrorHandling("verify", async (tokenOrFile: string) => {
+        await runVerify(tokenOrFile);
+      }),
+    );
+};

--- a/apps/cli/src/config/manager.test.ts
+++ b/apps/cli/src/config/manager.test.ts
@@ -15,12 +15,16 @@ vi.mock("node:fs/promises", () => ({
 
 import {
   DEFAULT_REGISTRY_URL,
+  getCacheDir,
+  getCacheFilePath,
   getConfigDir,
   getConfigFilePath,
   getConfigValue,
+  readCacheFile,
   readConfig,
   resolveConfig,
   setConfigValue,
+  writeCacheFile,
   writeConfig,
 } from "./manager.js";
 
@@ -137,5 +141,40 @@ describe("config manager", () => {
   it("exposes config location helpers", () => {
     expect(getConfigDir()).toBe("/mock-home/.clawdentity");
     expect(getConfigFilePath()).toBe("/mock-home/.clawdentity/config.json");
+    expect(getCacheDir()).toBe("/mock-home/.clawdentity/cache");
+    expect(getCacheFilePath("registry-keys.json")).toBe(
+      "/mock-home/.clawdentity/cache/registry-keys.json",
+    );
+  });
+
+  it("returns undefined when cache file does not exist", async () => {
+    mockedReadFile.mockRejectedValueOnce(buildErrnoError("ENOENT"));
+
+    await expect(readCacheFile("registry-keys.json")).resolves.toBeUndefined();
+  });
+
+  it("reads cache file contents", async () => {
+    mockedReadFile.mockResolvedValueOnce("cached-value");
+
+    await expect(readCacheFile("crl-claims.json")).resolves.toBe(
+      "cached-value",
+    );
+  });
+
+  it("writes cache file and secures file permissions", async () => {
+    await writeCacheFile("registry-keys.json", '{\n  "ok": true\n}\n');
+
+    expect(mockedMkdir).toHaveBeenCalledWith("/mock-home/.clawdentity/cache", {
+      recursive: true,
+    });
+    expect(mockedWriteFile).toHaveBeenCalledWith(
+      "/mock-home/.clawdentity/cache/registry-keys.json",
+      '{\n  "ok": true\n}\n',
+      "utf-8",
+    );
+    expect(mockedChmod).toHaveBeenCalledWith(
+      "/mock-home/.clawdentity/cache/registry-keys.json",
+      0o600,
+    );
   });
 });

--- a/apps/cli/src/config/manager.ts
+++ b/apps/cli/src/config/manager.ts
@@ -13,6 +13,8 @@ export type CliConfigKey = keyof CliConfig;
 
 const CONFIG_DIR = ".clawdentity";
 const CONFIG_FILE = "config.json";
+const CACHE_DIR = "cache";
+const FILE_MODE = 0o600;
 
 const ENV_KEY_MAP: Record<CliConfigKey, string> = {
   registryUrl: "CLAWDENTITY_REGISTRY_URL",
@@ -52,6 +54,18 @@ export const getConfigDir = (): string => join(homedir(), CONFIG_DIR);
 export const getConfigFilePath = (): string =>
   join(getConfigDir(), CONFIG_FILE);
 
+export const getCacheDir = (): string => join(getConfigDir(), CACHE_DIR);
+
+export const getCacheFilePath = (fileName: string): string =>
+  join(getCacheDir(), fileName);
+
+const writeSecureFile = async (filePath: string, value: string) => {
+  const targetDirectory = dirname(filePath);
+  await mkdir(targetDirectory, { recursive: true });
+  await writeFile(filePath, value, "utf-8");
+  await chmod(filePath, FILE_MODE);
+};
+
 export const readConfig = async (): Promise<CliConfig> => {
   try {
     const configContents = await readFile(getConfigFilePath(), "utf-8");
@@ -82,16 +96,10 @@ export const resolveConfig = async (): Promise<CliConfig> => {
 };
 
 export const writeConfig = async (config: CliConfig): Promise<void> => {
-  const configFilePath = getConfigFilePath();
-  const configDirectory = dirname(configFilePath);
-
-  await mkdir(configDirectory, { recursive: true });
-  await writeFile(
-    configFilePath,
+  await writeSecureFile(
+    getConfigFilePath(),
     `${JSON.stringify(config, null, 2)}\n`,
-    "utf-8",
   );
-  await chmod(configFilePath, 0o600);
 };
 
 export const getConfigValue = async <K extends CliConfigKey>(
@@ -111,4 +119,26 @@ export const setConfigValue = async <K extends CliConfigKey>(
     ...currentConfig,
     [key]: value,
   });
+};
+
+export const readCacheFile = async (
+  fileName: string,
+): Promise<string | undefined> => {
+  try {
+    return await readFile(getCacheFilePath(fileName), "utf-8");
+  } catch (error) {
+    const nodeError = error as NodeJS.ErrnoException;
+    if (nodeError.code === "ENOENT") {
+      return undefined;
+    }
+
+    throw error;
+  }
+};
+
+export const writeCacheFile = async (
+  fileName: string,
+  value: string,
+): Promise<void> => {
+  await writeSecureFile(getCacheFilePath(fileName), value);
 };

--- a/apps/cli/src/index.test.ts
+++ b/apps/cli/src/index.test.ts
@@ -26,6 +26,14 @@ describe("cli", () => {
     expect(hasAgentCommand).toBe(true);
   });
 
+  it("registers the verify command", () => {
+    const hasVerifyCommand = createProgram()
+      .commands.map((command) => command.name())
+      .includes("verify");
+
+    expect(hasVerifyCommand).toBe(true);
+  });
+
   it("prints version output", async () => {
     const output: string[] = [];
     const program = createProgram();

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander";
 import { createAgentCommand } from "./commands/agent.js";
 import { createConfigCommand } from "./commands/config.js";
+import { createVerifyCommand } from "./commands/verify.js";
 
 export const CLI_VERSION = "0.0.0";
 
@@ -9,5 +10,6 @@ export const createProgram = (): Command => {
     .description("Clawdentity CLI - Agent identity management")
     .version(CLI_VERSION)
     .addCommand(createAgentCommand())
-    .addCommand(createConfigCommand());
+    .addCommand(createConfigCommand())
+    .addCommand(createVerifyCommand());
 };


### PR DESCRIPTION
## Summary
- add `clawdentity verify <tokenOrFile>` command for local AIT verification
- verify AIT signature/issuer/expiry via SDK and enforce CRL revocation checks
- add disk-backed cache helpers for registry keys and CRL claims under `~/.clawdentity/cache`
- add CLI tests for success, revoked token, invalid token, key/CRL fetch failures, file input, and cache paths
- update CLI AGENTS guidance for verify/caching behavior and command-folder conventions

## Validation
- `pnpm -F @clawdentity/cli lint`
- `pnpm -F @clawdentity/cli typecheck`
- `pnpm -F @clawdentity/cli test`
- `pnpm -F @clawdentity/cli build`
- `pnpm lint`
- `pnpm -r typecheck`
- `pnpm -r test`
- `pnpm -r build`

## Links
- Implements #26
