### PR TITLE
T26 | start proxy server with health endpoint and basic logging

### DIFF
--- a/apps/proxy/AGENTS.md
+++ b/apps/proxy/AGENTS.md
@@ -8,6 +8,7 @@
 - Keep runtime config centralized in `src/config.ts`.
 - Parse config with a schema and fail fast with `CONFIG_VALIDATION_FAILED` before startup proceeds.
 - Keep defaults explicit for non-secret settings (`listenPort`, `openclawBaseUrl`, `registryUrl`, CRL timings, stale behavior).
+- Keep runtime `ENVIRONMENT` explicit and validated to supported values: `local`, `development`, `production`, `test` (default `development`).
 - Require hook token input via env (`OPENCLAW_HOOK_TOKEN` or OpenClaw-compatible alias `OPENCLAW_HOOKS_TOKEN`) and never log the token value.
 - Load env files with OpenClaw precedence and no overrides:
   - first `./.env` from the proxy working directory
@@ -35,4 +36,11 @@
 ## Testing Rules
 - Cover both config happy paths and failure paths in `src/config.test.ts`.
 - Keep startup tests in `src/index.test.ts` to verify runtime initialization fails when config is invalid.
+- Keep server route/middleware behavior in `src/server.test.ts` (`GET /health`, request id propagation, and structured request logging).
 - Keep tests offline and deterministic (no network, no filesystem dependency).
+
+## Server Runtime
+- Keep `src/server.ts` as the HTTP app/runtime entry.
+- Keep middleware order stable: request context -> request logging -> error handler.
+- Keep `/health` response contract stable: `{ status, version, environment }` with HTTP 200.
+- Log startup and request completion with structured JSON logs; never log secrets or tokens.

--- a/apps/proxy/package.json
+++ b/apps/proxy/package.json
@@ -9,19 +9,26 @@
     ".": {
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
+    },
+    "./server": {
+      "import": "./dist/server.js",
+      "types": "./dist/server.d.ts"
     }
   },
   "scripts": {
     "build": "tsup",
     "format": "biome format .",
     "lint": "biome lint .",
+    "start": "node ./dist/bin.js",
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@hono/node-server": "^1.19.6",
     "@clawdentity/protocol": "workspace:*",
     "@clawdentity/sdk": "workspace:*",
     "dotenv": "^17.2.3",
+    "hono": "^4.11.9",
     "json5": "^2.2.3",
     "zod": "^4.1.12"
   }

--- a/apps/proxy/src/AGENTS.md
+++ b/apps/proxy/src/AGENTS.md
@@ -3,8 +3,10 @@
 ## Source Layout
 - Keep `index.ts` as runtime bootstrap surface and version export.
 - Keep runtime env parsing and defaults in `config.ts`; do not scatter `process.env` reads across handlers.
+- Keep HTTP app/startup concerns in `server.ts`; use `bin.ts` as process entrypoint for Node runtime startup.
 - Keep `.env` fallback loading and OpenClaw config (`hooks.token`) fallback logic inside `config.ts` so runtime behavior is deterministic.
 - Keep fallback semantics consistent across merge + parse stages: empty/whitespace env values are treated as missing, so non-empty `.env`/file values can be used.
+- Do not derive runtime environment from `NODE_ENV`; use validated `ENVIRONMENT` from proxy config.
 
 ## Config Error Handling
 - Convert parse failures to `ProxyConfigError` with code `CONFIG_VALIDATION_FAILED`.
@@ -13,3 +15,4 @@
 ## Maintainability
 - Prefer schema-driven parsing with small pure helpers for coercion/overrides.
 - Keep CRL defaults centralized as exported constants in `config.ts`; do not duplicate timing literals across modules.
+- Keep server middleware composable and single-responsibility to reduce churn in later T27-T31 auth/forwarding work.

--- a/apps/proxy/src/bin.ts
+++ b/apps/proxy/src/bin.ts
@@ -1,0 +1,3 @@
+import { startProxyServer } from "./server.js";
+
+startProxyServer();

--- a/apps/proxy/src/config.test.ts
+++ b/apps/proxy/src/config.test.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_CRL_MAX_AGE_MS,
   DEFAULT_CRL_REFRESH_INTERVAL_MS,
   DEFAULT_OPENCLAW_BASE_URL,
+  DEFAULT_PROXY_ENVIRONMENT,
   DEFAULT_PROXY_LISTEN_PORT,
   DEFAULT_REGISTRY_URL,
   loadProxyConfig,
@@ -26,6 +27,7 @@ describe("proxy config", () => {
       openclawBaseUrl: DEFAULT_OPENCLAW_BASE_URL,
       openclawHookToken: "super-secret-hook-token",
       registryUrl: DEFAULT_REGISTRY_URL,
+      environment: DEFAULT_PROXY_ENVIRONMENT,
       allowList: {
         owners: [],
         agents: [],
@@ -42,12 +44,14 @@ describe("proxy config", () => {
       PORT: "4100",
       OPENCLAW_HOOKS_TOKEN: "hooks-token",
       CLAWDENTITY_REGISTRY_URL: "https://registry.example.com",
+      ENVIRONMENT: "local",
       CRL_STALE_BEHAVIOR: "fail-closed",
     });
 
     expect(config.listenPort).toBe(4100);
     expect(config.openclawHookToken).toBe("hooks-token");
     expect(config.registryUrl).toBe("https://registry.example.com");
+    expect(config.environment).toBe("local");
     expect(config.crlStaleBehavior).toBe("fail-closed");
   });
 
@@ -88,6 +92,15 @@ describe("proxy config", () => {
       parseProxyConfig({
         OPENCLAW_HOOK_TOKEN: "token",
         ALLOW_ALL_VERIFIED: "maybe",
+      }),
+    ).toThrow(ProxyConfigError);
+  });
+
+  it("throws on unsupported environment value", () => {
+    expect(() =>
+      parseProxyConfig({
+        OPENCLAW_HOOK_TOKEN: "token",
+        ENVIRONMENT: "staging",
       }),
     ).toThrow(ProxyConfigError);
   });

--- a/apps/proxy/src/config.ts
+++ b/apps/proxy/src/config.ts
@@ -6,6 +6,13 @@ import JSON5 from "json5";
 import { z } from "zod";
 
 export type ProxyCrlStaleBehavior = "fail-open" | "fail-closed";
+export const proxyEnvironmentValues = [
+  "local",
+  "development",
+  "production",
+  "test",
+] as const;
+export type ProxyEnvironment = (typeof proxyEnvironmentValues)[number];
 
 export type ProxyConfigLoadOptions = {
   cwd?: string;
@@ -15,6 +22,7 @@ export type ProxyConfigLoadOptions = {
 export const DEFAULT_PROXY_LISTEN_PORT = 4000;
 export const DEFAULT_OPENCLAW_BASE_URL = "http://127.0.0.1:18789";
 export const DEFAULT_REGISTRY_URL = "https://api.clawdentity.com";
+export const DEFAULT_PROXY_ENVIRONMENT: ProxyEnvironment = "development";
 export const DEFAULT_CRL_REFRESH_INTERVAL_MS = 5 * 60 * 1000;
 export const DEFAULT_CRL_MAX_AGE_MS = 15 * 60 * 1000;
 export const DEFAULT_CRL_STALE_BEHAVIOR: ProxyCrlStaleBehavior = "fail-open";
@@ -47,6 +55,9 @@ const proxyRuntimeEnvSchema = z.object({
   OPENCLAW_BASE_URL: z.string().trim().url().default(DEFAULT_OPENCLAW_BASE_URL),
   OPENCLAW_HOOK_TOKEN: z.string().trim().min(1),
   REGISTRY_URL: z.string().trim().url().default(DEFAULT_REGISTRY_URL),
+  ENVIRONMENT: z
+    .enum(proxyEnvironmentValues)
+    .default(DEFAULT_PROXY_ENVIRONMENT),
   ALLOW_LIST: z.string().optional(),
   ALLOWLIST_OWNERS: z.string().optional(),
   ALLOWLIST_AGENTS: z.string().optional(),
@@ -77,6 +88,7 @@ export const proxyConfigSchema = z.object({
   openclawBaseUrl: z.string().url(),
   openclawHookToken: z.string().min(1),
   registryUrl: z.string().url(),
+  environment: z.enum(proxyEnvironmentValues),
   allowList: proxyAllowListSchema,
   crlRefreshIntervalMs: z.number().int().positive(),
   crlMaxAgeMs: z.number().int().positive(),
@@ -94,6 +106,7 @@ type RuntimeEnvInput = {
   OPENCLAW_HOOKS_TOKEN?: unknown;
   REGISTRY_URL?: unknown;
   CLAWDENTITY_REGISTRY_URL?: unknown;
+  ENVIRONMENT?: unknown;
   ALLOW_LIST?: unknown;
   ALLOWLIST_OWNERS?: unknown;
   ALLOWLIST_AGENTS?: unknown;
@@ -379,6 +392,7 @@ function normalizeRuntimeEnv(input: unknown): Record<string, unknown> {
       "REGISTRY_URL",
       "CLAWDENTITY_REGISTRY_URL",
     ]),
+    ENVIRONMENT: firstNonEmpty(env, ["ENVIRONMENT"]),
     ALLOW_LIST: firstNonEmpty(env, ["ALLOW_LIST"]),
     ALLOWLIST_OWNERS: firstNonEmpty(env, ["ALLOWLIST_OWNERS"]),
     ALLOWLIST_AGENTS: firstNonEmpty(env, ["ALLOWLIST_AGENTS"]),
@@ -517,6 +531,7 @@ export function parseProxyConfig(env: unknown): ProxyConfig {
     openclawBaseUrl: parsedRuntimeEnv.data.OPENCLAW_BASE_URL,
     openclawHookToken: parsedRuntimeEnv.data.OPENCLAW_HOOK_TOKEN,
     registryUrl: parsedRuntimeEnv.data.REGISTRY_URL,
+    environment: parsedRuntimeEnv.data.ENVIRONMENT,
     allowList: parseAllowList(parsedRuntimeEnv.data),
     crlRefreshIntervalMs: parsedRuntimeEnv.data.CRL_REFRESH_INTERVAL_MS,
     crlMaxAgeMs: parsedRuntimeEnv.data.CRL_MAX_AGE_MS,

--- a/apps/proxy/src/server.test.ts
+++ b/apps/proxy/src/server.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_PROXY_ENVIRONMENT,
+  ProxyConfigError,
+  parseProxyConfig,
+} from "./config.js";
+import { PROXY_VERSION } from "./index.js";
+import { createProxyApp, startProxyServer } from "./server.js";
+
+describe("proxy server", () => {
+  it("returns health response with status, version, and environment", async () => {
+    const app = createProxyApp({
+      config: parseProxyConfig({
+        OPENCLAW_HOOK_TOKEN: "token",
+      }),
+    });
+
+    const res = await app.request("/health");
+    const body = (await res.json()) as {
+      status: string;
+      version: string;
+      environment: string;
+    };
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({
+      status: "ok",
+      version: PROXY_VERSION,
+      environment: DEFAULT_PROXY_ENVIRONMENT,
+    });
+    expect(res.headers.get("x-request-id")).toBeTruthy();
+  });
+
+  it("uses ENVIRONMENT from config for health payload", async () => {
+    const app = createProxyApp({
+      config: parseProxyConfig({
+        OPENCLAW_HOOK_TOKEN: "token",
+        ENVIRONMENT: "local",
+      }),
+    });
+
+    const res = await app.request("/health");
+    const body = (await res.json()) as { environment: string };
+
+    expect(res.status).toBe(200);
+    expect(body.environment).toBe("local");
+  });
+
+  it("emits structured request completion log for /health", async () => {
+    const logSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    try {
+      const app = createProxyApp({
+        config: parseProxyConfig({
+          OPENCLAW_HOOK_TOKEN: "token",
+        }),
+      });
+
+      const res = await app.request("/health");
+      expect(res.status).toBe(200);
+
+      const line = String(logSpy.mock.calls.at(-1)?.[0] ?? "");
+      const parsed = JSON.parse(line) as Record<string, unknown>;
+
+      expect(parsed.message).toBe("request.completed");
+      expect(parsed.service).toBe("proxy");
+      expect(parsed.path).toBe("/health");
+      expect(parsed.status).toBe(200);
+      expect(typeof parsed.requestId).toBe("string");
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  it("fails startup when required config is missing", () => {
+    expect(() =>
+      startProxyServer({
+        env: {},
+      }),
+    ).toThrow(ProxyConfigError);
+  });
+});

--- a/apps/proxy/src/server.ts
+++ b/apps/proxy/src/server.ts
@@ -1,0 +1,90 @@
+import {
+  createHonoErrorHandler,
+  createLogger,
+  createRequestContextMiddleware,
+  createRequestLoggingMiddleware,
+  type Logger,
+  type RequestContextVariables,
+} from "@clawdentity/sdk";
+import { serve } from "@hono/node-server";
+import { Hono } from "hono";
+import type { ProxyConfig } from "./config.js";
+import { loadProxyConfig } from "./config.js";
+import { PROXY_VERSION } from "./index.js";
+
+type CreateProxyAppOptions = {
+  config: ProxyConfig;
+  logger?: Logger;
+};
+
+type StartProxyServerOptions = {
+  env?: unknown;
+  config?: ProxyConfig;
+  logger?: Logger;
+  port?: number;
+};
+
+export type ProxyApp = Hono<{
+  Variables: RequestContextVariables;
+}>;
+
+export type StartedProxyServer = {
+  app: ProxyApp;
+  config: ProxyConfig;
+  port: number;
+  server: ReturnType<typeof serve>;
+};
+
+function resolveLogger(logger?: Logger): Logger {
+  return logger ?? createLogger({ service: "proxy" });
+}
+
+export function createProxyApp(options: CreateProxyAppOptions): ProxyApp {
+  const logger = resolveLogger(options.logger);
+  const app = new Hono<{
+    Variables: RequestContextVariables;
+  }>();
+
+  app.use("*", createRequestContextMiddleware());
+  app.use("*", createRequestLoggingMiddleware(logger));
+  app.onError(createHonoErrorHandler(logger));
+
+  app.get("/health", (c) =>
+    c.json({
+      status: "ok",
+      version: PROXY_VERSION,
+      environment: options.config.environment,
+    }),
+  );
+
+  return app;
+}
+
+export function startProxyServer(
+  options: StartProxyServerOptions = {},
+): StartedProxyServer {
+  const config = options.config ?? loadProxyConfig(options.env);
+  const logger = resolveLogger(options.logger);
+  const app = createProxyApp({
+    config,
+    logger,
+  });
+  const port = options.port ?? config.listenPort;
+  const server = serve({
+    fetch: app.fetch,
+    port,
+  });
+
+  logger.info("proxy.server_started", {
+    port,
+    version: PROXY_VERSION,
+    environment: config.environment,
+  });
+
+  return {
+    app,
+    config,
+    port,
+    server,
+  };
+}

--- a/apps/proxy/tsconfig.json
+++ b/apps/proxy/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "./dist",
-    "rootDir": "./src"
+    "outDir": "./dist"
   },
   "include": ["src"]
 }

--- a/apps/proxy/tsup.config.ts
+++ b/apps/proxy/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: ["src/index.ts"],
+  entry: ["src/index.ts", "src/server.ts", "src/bin.ts"],
   format: ["esm"],
   dts: true,
   clean: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,9 +57,15 @@ importers:
       '@clawdentity/sdk':
         specifier: workspace:*
         version: link:../../packages/sdk
+      '@hono/node-server':
+        specifier: ^1.19.6
+        version: 1.19.9(hono@4.11.9)
       dotenv:
         specifier: ^17.2.3
         version: 17.3.1
+      hono:
+        specifier: ^4.11.9
+        version: 4.11.9
       json5:
         specifier: ^2.2.3
         version: 2.2.3
@@ -687,6 +693,12 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@hono/node-server@1.19.9':
+    resolution: {integrity: sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
 
   '@img/colour@1.0.0':
     resolution: {integrity: sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==}
@@ -2633,6 +2645,10 @@ snapshots:
 
   '@esbuild/win32-x64@0.27.3':
     optional: true
+
+  '@hono/node-server@1.19.9(hono@4.11.9)':
+    dependencies:
+      hono: 4.11.9
 
   '@img/colour@1.0.0': {}
 


### PR DESCRIPTION
## Summary
- add proxy HTTP server bootstrap in `apps/proxy/src/server.ts` with middleware stack and startup helper
- add `GET /health` returning `{ status, version, environment }`
- add structured request logging via shared SDK middleware and startup log event
- add `ENVIRONMENT` to proxy config with supported values `local|development|production|test` (default `development`) and avoid `NODE_ENV` coupling
- add Node runtime entrypoint (`src/bin.ts`) and wire build/start scripts
- update proxy AGENTS docs with server and environment best practices

## Validation
- `pnpm -F @clawdentity/proxy lint`
- `pnpm -F @clawdentity/proxy test`
- `pnpm -F @clawdentity/proxy typecheck`
- `pnpm -F @clawdentity/proxy build`
- `pnpm -r lint`
- `pnpm -r test`
- `pnpm -r build`

Closes #28
