### PR TITLE
feat(proxy): enforce agent DID allowlist and remove allow-all bypass (T28)

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -75,7 +75,7 @@ Because OpenClaw requires `hooks.token` and expects Bearer/token auth for `/hook
 
 - **Proxy**
   - Verify inbound Clawdentity headers
-  - Enforce allowlist rules (by owner DID and/or agent DID)
+  - Enforce allowlist rules (agent DID only in current phase; owner DID support deferred)
   - Rate-limit per verified agent DID
   - Forward to OpenClaw `/hooks/agent` with `x-openclaw-token`
 

--- a/apps/proxy/AGENTS.md
+++ b/apps/proxy/AGENTS.md
@@ -25,9 +25,10 @@
   - state/config path aliases: `OPENCLAW_STATE_DIR`/`CLAWDBOT_STATE_DIR`, `OPENCLAW_CONFIG_PATH`/`CLAWDBOT_CONFIG_PATH`
 
 ## Allowlist and Access
-- Keep allowlist shape as `{ owners: string[], agents: string[], allowAllVerified: boolean }`.
-- Allow bootstrap from `ALLOW_LIST` JSON with optional explicit overrides (`ALLOWLIST_OWNERS`, `ALLOWLIST_AGENTS`, `ALLOW_ALL_VERIFIED`).
+- Keep allowlist shape as `{ owners: string[], agents: string[] }`.
+- Allow bootstrap from `ALLOW_LIST` JSON with optional explicit overrides (`ALLOWLIST_OWNERS`, `ALLOWLIST_AGENTS`).
 - Keep allowlist parsing deterministic and reject malformed input with structured config errors.
+- Reject deprecated `ALLOW_ALL_VERIFIED` at startup; never provide a global allow-all bypass for verified callers.
 
 ## Auth Verification
 - Protect all non-health routes with Clawdentity auth verification middleware.
@@ -36,9 +37,11 @@
 - Reject malformed authorization values that contain extra segments beyond `Claw <AIT>`.
 - Reject malformed `X-Claw-Timestamp` values; accept only plain unix-seconds integer strings.
 - Verify request pipeline order as: AIT -> timestamp skew -> PoP signature -> nonce replay -> CRL revocation.
+- Enforce proxy access by explicit agent DID allowlist after auth verification; owner DID-only entries do not grant access.
 - When AIT verification fails with unknown `kid`, refresh registry keyset once and retry verification before returning `401`.
 - When CRL verification fails with unknown `kid`, refresh registry keyset once and retry verification before returning dependency failure.
 - Return `401` for invalid/expired/replayed/revoked/invalid-proof requests.
+- Return `403` when requests are verified but agent DID is not allowlisted.
 - Return `503` when registry keyset dependency is unavailable, and when CRL dependency is unavailable under `fail-closed` stale policy.
 
 ## CRL Policy

--- a/apps/proxy/src/AGENTS.md
+++ b/apps/proxy/src/AGENTS.md
@@ -16,8 +16,10 @@
 ## Maintainability
 - Prefer schema-driven parsing with small pure helpers for coercion/overrides.
 - Keep CRL defaults centralized as exported constants in `config.ts`; do not duplicate timing literals across modules.
+- Keep allowlist schema strict and agent-first: reject unknown allowlist keys and require explicit `allowList.agents` membership after verification.
+- Keep `ALLOW_ALL_VERIFIED` removed; fail fast when deprecated bypass flags are provided.
 - Keep server middleware composable and single-responsibility to reduce churn in later T27-T31 auth/forwarding work.
-- Keep auth failure semantics stable: auth-invalid requests map to `401`; registry keyset outages map to `503`; CRL outages map to `503` when stale behavior is `fail-closed`.
+- Keep auth failure semantics stable: auth-invalid requests map to `401`; verified-but-not-allowlisted requests map to `403`; registry keyset outages map to `503`; CRL outages map to `503` when stale behavior is `fail-closed`.
 - Keep `X-Claw-Timestamp` parsing strict: accept digit-only unix-seconds strings and reject mixed/decimal formats.
 - Keep AIT verification resilient to routine key rotation: retry once with a forced keyset refresh on `UNKNOWN_AIT_KID` before rejecting.
 - Keep CRL verification resilient to routine key rotation: retry once with a forced keyset refresh on `UNKNOWN_CRL_KID` before dependency-failure mapping.

--- a/apps/proxy/src/auth-middleware.test.ts
+++ b/apps/proxy/src/auth-middleware.test.ts
@@ -25,6 +25,8 @@ type AuthHarnessOptions = {
   crlStaleBehavior?: "fail-open" | "fail-closed";
   fetchCrlFails?: boolean;
   fetchKeysFails?: boolean;
+  allowCurrentAgent?: boolean;
+  allowCurrentOwner?: boolean;
   revoked?: boolean;
 };
 
@@ -195,9 +197,19 @@ async function createAuthHarness(
     registryPublicKeyX: encodedRegistry.publicKey,
   });
 
+  const allowListAgents =
+    options.allowCurrentAgent === false ? [] : [claims.sub];
+  const allowListOwners = options.allowCurrentOwner ? [claims.ownerDid] : [];
+
   const app = createProxyApp({
     config: parseProxyConfig({
       OPENCLAW_HOOK_TOKEN: "openclaw-hook-token",
+      ...(allowListAgents.length > 0
+        ? { ALLOWLIST_AGENTS: allowListAgents.join(",") }
+        : {}),
+      ...(allowListOwners.length > 0
+        ? { ALLOWLIST_OWNERS: allowListOwners.join(",") }
+        : {}),
       ...(options.crlStaleBehavior
         ? { CRL_STALE_BEHAVIOR: options.crlStaleBehavior }
         : {}),
@@ -275,6 +287,43 @@ describe("proxy auth middleware", () => {
     expect(body.auth.agentDid).toBe(harness.claims.sub);
     expect(body.auth.ownerDid).toBe(harness.claims.ownerDid);
     expect(body.auth.aitJti).toBe(harness.claims.jti);
+  });
+
+  it("returns 403 when a verified caller is not allowlisted by agent DID", async () => {
+    const harness = await createAuthHarness({
+      allowCurrentAgent: false,
+    });
+    const headers = await harness.createSignedHeaders({
+      nonce: "nonce-not-allowlisted",
+    });
+    const response = await harness.app.request("/protected", {
+      method: "POST",
+      headers,
+      body: BODY_JSON,
+    });
+
+    expect(response.status).toBe(403);
+    const body = (await response.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("PROXY_AUTH_FORBIDDEN");
+  });
+
+  it("returns 403 when only owner DID is allowlisted", async () => {
+    const harness = await createAuthHarness({
+      allowCurrentAgent: false,
+      allowCurrentOwner: true,
+    });
+    const headers = await harness.createSignedHeaders({
+      nonce: "nonce-owner-only-allowlisted",
+    });
+    const response = await harness.app.request("/protected", {
+      method: "POST",
+      headers,
+      body: BODY_JSON,
+    });
+
+    expect(response.status).toBe(403);
+    const body = (await response.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("PROXY_AUTH_FORBIDDEN");
   });
 
   it("refreshes keyset and accepts valid AIT after registry key rotation", async () => {
@@ -362,6 +411,7 @@ describe("proxy auth middleware", () => {
     const app = createProxyApp({
       config: parseProxyConfig({
         OPENCLAW_HOOK_TOKEN: "openclaw-hook-token",
+        ALLOWLIST_AGENTS: claims.sub,
       }),
       auth: {
         fetchImpl: fetchMock as typeof fetch,
@@ -479,6 +529,7 @@ describe("proxy auth middleware", () => {
     const app = createProxyApp({
       config: parseProxyConfig({
         OPENCLAW_HOOK_TOKEN: "openclaw-hook-token",
+        ALLOWLIST_AGENTS: claims.sub,
       }),
       auth: {
         fetchImpl: fetchMock as typeof fetch,

--- a/apps/proxy/src/auth-middleware.ts
+++ b/apps/proxy/src/auth-middleware.ts
@@ -122,6 +122,24 @@ function dependencyUnavailableError(options: {
   });
 }
 
+function forbiddenError(options: {
+  code: string;
+  message: string;
+  details?: Record<string, unknown>;
+}): AppError {
+  return new AppError({
+    code: options.code,
+    message: options.message,
+    status: 403,
+    details: options.details,
+    expose: true,
+  });
+}
+
+function isAgentDidAllowed(config: ProxyConfig, agentDid: string): boolean {
+  return config.allowList.agents.includes(agentDid);
+}
+
 export function parseClawAuthorizationHeader(authorization?: string): string {
   if (typeof authorization !== "string" || authorization.trim().length === 0) {
     throw unauthorizedError({
@@ -556,6 +574,16 @@ export function createProxyAuthMiddleware(options: ProxyAuthMiddlewareOptions) {
         throw unauthorizedError({
           code: "PROXY_AUTH_REVOKED",
           message: "AIT has been revoked",
+        });
+      }
+
+      if (!isAgentDidAllowed(options.config, claims.sub)) {
+        throw forbiddenError({
+          code: "PROXY_AUTH_FORBIDDEN",
+          message: "Verified caller is not allowlisted",
+          details: {
+            agentDid: claims.sub,
+          },
         });
       }
 

--- a/apps/proxy/src/config.test.ts
+++ b/apps/proxy/src/config.test.ts
@@ -31,7 +31,6 @@ describe("proxy config", () => {
       allowList: {
         owners: [],
         agents: [],
-        allowAllVerified: false,
       },
       crlRefreshIntervalMs: DEFAULT_CRL_REFRESH_INTERVAL_MS,
       crlMaxAgeMs: DEFAULT_CRL_MAX_AGE_MS,
@@ -55,22 +54,19 @@ describe("proxy config", () => {
     expect(config.crlStaleBehavior).toBe("fail-closed");
   });
 
-  it("parses allow list object and override env flags", () => {
+  it("parses allow list object and override env lists", () => {
     const config = parseProxyConfig({
       OPENCLAW_HOOK_TOKEN: "token",
       ALLOW_LIST: JSON.stringify({
         owners: ["did:claw:owner:1"],
         agents: ["did:claw:agent:1"],
-        allowAllVerified: false,
       }),
       ALLOWLIST_OWNERS: "did:claw:owner:2,did:claw:owner:3",
-      ALLOW_ALL_VERIFIED: "true",
     });
 
     expect(config.allowList).toEqual({
       owners: ["did:claw:owner:2", "did:claw:owner:3"],
       agents: ["did:claw:agent:1"],
-      allowAllVerified: true,
     });
   });
 
@@ -87,11 +83,24 @@ describe("proxy config", () => {
     ).toThrow(ProxyConfigError);
   });
 
-  it("throws on invalid boolean override", () => {
+  it("throws when deprecated ALLOW_ALL_VERIFIED is set", () => {
     expect(() =>
       parseProxyConfig({
         OPENCLAW_HOOK_TOKEN: "token",
-        ALLOW_ALL_VERIFIED: "maybe",
+        ALLOW_ALL_VERIFIED: "true",
+      }),
+    ).toThrow(ProxyConfigError);
+  });
+
+  it("throws when ALLOW_LIST includes unknown keys", () => {
+    expect(() =>
+      parseProxyConfig({
+        OPENCLAW_HOOK_TOKEN: "token",
+        ALLOW_LIST: JSON.stringify({
+          owners: [],
+          agents: [],
+          allowAllVerified: true,
+        }),
       }),
     ).toThrow(ProxyConfigError);
   });

--- a/apps/proxy/src/config.ts
+++ b/apps/proxy/src/config.ts
@@ -40,8 +40,6 @@ export class ProxyConfigError extends Error {
   }
 }
 
-const BOOLEAN_TRUE_VALUES = new Set(["1", "true", "yes", "on"]);
-const BOOLEAN_FALSE_VALUES = new Set(["0", "false", "no", "off"]);
 const OPENCLAW_CONFIG_FILENAME = "openclaw.json";
 const LEGACY_STATE_DIR_NAMES = [".clawdbot", ".moldbot", ".moltbot"] as const;
 
@@ -61,7 +59,6 @@ const proxyRuntimeEnvSchema = z.object({
   ALLOW_LIST: z.string().optional(),
   ALLOWLIST_OWNERS: z.string().optional(),
   ALLOWLIST_AGENTS: z.string().optional(),
-  ALLOW_ALL_VERIFIED: z.string().optional(),
   CRL_REFRESH_INTERVAL_MS: z.coerce
     .number()
     .int()
@@ -77,11 +74,12 @@ const proxyRuntimeEnvSchema = z.object({
     .default(DEFAULT_CRL_STALE_BEHAVIOR),
 });
 
-const proxyAllowListSchema = z.object({
-  owners: z.array(z.string().trim().min(1)).default([]),
-  agents: z.array(z.string().trim().min(1)).default([]),
-  allowAllVerified: z.boolean().default(false),
-});
+const proxyAllowListSchema = z
+  .object({
+    owners: z.array(z.string().trim().min(1)).default([]),
+    agents: z.array(z.string().trim().min(1)).default([]),
+  })
+  .strict();
 
 export const proxyConfigSchema = z.object({
   listenPort: z.number().int().min(1).max(65535),
@@ -396,7 +394,6 @@ function normalizeRuntimeEnv(input: unknown): Record<string, unknown> {
     ALLOW_LIST: firstNonEmpty(env, ["ALLOW_LIST"]),
     ALLOWLIST_OWNERS: firstNonEmpty(env, ["ALLOWLIST_OWNERS"]),
     ALLOWLIST_AGENTS: firstNonEmpty(env, ["ALLOWLIST_AGENTS"]),
-    ALLOW_ALL_VERIFIED: firstNonEmpty(env, ["ALLOW_ALL_VERIFIED"]),
     CRL_REFRESH_INTERVAL_MS: firstNonEmpty(env, ["CRL_REFRESH_INTERVAL_MS"]),
     CRL_MAX_AGE_MS: firstNonEmpty(env, ["CRL_MAX_AGE_MS"]),
     CRL_STALE_BEHAVIOR: firstNonEmpty(env, ["CRL_STALE_BEHAVIOR"]),
@@ -416,38 +413,12 @@ function parseDidList(input: string): string[] {
   );
 }
 
-function parseOptionalBoolean(
-  value: string | undefined,
-  field: string,
-): boolean | undefined {
-  if (value === undefined) {
-    return undefined;
-  }
-
-  const normalized = value.trim().toLowerCase();
-  if (BOOLEAN_TRUE_VALUES.has(normalized)) {
-    return true;
-  }
-
-  if (BOOLEAN_FALSE_VALUES.has(normalized)) {
-    return false;
-  }
-
-  throw toConfigValidationError({
-    fieldErrors: {
-      [field]: ["Expected one of true/false/1/0/yes/no/on/off"],
-    },
-    formErrors: [],
-  });
-}
-
 function parseAllowList(
   env: z.infer<typeof proxyRuntimeEnvSchema>,
 ): ProxyAllowList {
   let allowList: ProxyAllowList = {
     owners: [],
     agents: [],
-    allowAllVerified: false,
   };
 
   if (env.ALLOW_LIST !== undefined) {
@@ -482,15 +453,27 @@ function parseAllowList(
     allowList = { ...allowList, agents: parseDidList(env.ALLOWLIST_AGENTS) };
   }
 
-  const allowAllVerified = parseOptionalBoolean(
-    env.ALLOW_ALL_VERIFIED,
-    "ALLOW_ALL_VERIFIED",
-  );
-  if (allowAllVerified !== undefined) {
-    allowList = { ...allowList, allowAllVerified };
+  return allowList;
+}
+
+function assertNoDeprecatedAllowAllVerified(env: RuntimeEnvInput): void {
+  const value = env.ALLOW_ALL_VERIFIED;
+  if (
+    value === undefined ||
+    value === null ||
+    (typeof value === "string" && value.trim().length === 0)
+  ) {
+    return;
   }
 
-  return allowList;
+  throw toConfigValidationError({
+    fieldErrors: {
+      ALLOW_ALL_VERIFIED: [
+        "ALLOW_ALL_VERIFIED is no longer supported. Use ALLOWLIST_AGENTS.",
+      ],
+    },
+    formErrors: [],
+  });
 }
 
 function loadHookTokenFromFallback(
@@ -516,8 +499,11 @@ function loadHookTokenFromFallback(
 }
 
 export function parseProxyConfig(env: unknown): ProxyConfig {
+  const inputEnv: RuntimeEnvInput = isRuntimeEnvInput(env) ? env : {};
+  assertNoDeprecatedAllowAllVerified(inputEnv);
+
   const parsedRuntimeEnv = proxyRuntimeEnvSchema.safeParse(
-    normalizeRuntimeEnv(env),
+    normalizeRuntimeEnv(inputEnv),
   );
   if (!parsedRuntimeEnv.success) {
     throw toConfigValidationError({

--- a/issues/T28.md
+++ b/issues/T28.md
@@ -1,7 +1,7 @@
 Source: `T28.md`
 
 ## Goal
-Enforce allowlist by agent DID and/or owner DID after verification.
+Enforce allowlist by agent DID after verification.
 
 ## In Scope
 - Implement the ticket objective described in `Goal`.
@@ -33,7 +33,7 @@ Enforce allowlist by agent DID and/or owner DID after verification.
 
 ## Deliverables
 - Allowlist config: owners[], agents[]
-- Optional `allowAllVerified` (default false)
+- Remove support for `allowAllVerified`/`ALLOW_ALL_VERIFIED`
 - Return 403 when verified but not allowed
 
 ## Refactor Opportunities


### PR DESCRIPTION
## Summary
- enforce post-verification proxy authorization using explicit `allowList.agents` membership
- return `403` (`PROXY_AUTH_FORBIDDEN`) for verified callers that are not allowlisted
- remove `allowAllVerified` support from config/runtime and reject deprecated `ALLOW_ALL_VERIFIED`
- make allowlist JSON schema strict and update docs/specs for agent-DID-only behavior in current phase

## Validation
- `pnpm -F @clawdentity/proxy test`
- `pnpm -F @clawdentity/proxy typecheck`
- `pnpm lint`
- `pnpm -r typecheck`
- `pnpm -r test`
- `pnpm -r build`
- `pnpm issues:validate`

Closes #30
