### PR TITLE
feat(proxy): add per-agent DID rate limiting (T30)

### DIFF
--- a/apps/proxy/AGENTS.md
+++ b/apps/proxy/AGENTS.md
@@ -8,6 +8,7 @@
 - Keep runtime config centralized in `src/config.ts`.
 - Parse config with a schema and fail fast with `CONFIG_VALIDATION_FAILED` before startup proceeds.
 - Keep defaults explicit for non-secret settings (`listenPort`, `openclawBaseUrl`, `registryUrl`, CRL timings, stale behavior).
+- Keep agent DID limiter defaults explicit in `src/config.ts` (`AGENT_RATE_LIMIT_REQUESTS_PER_MINUTE=60`, `AGENT_RATE_LIMIT_WINDOW_MS=60000`) unless explicitly overridden.
 - Keep runtime `ENVIRONMENT` explicit and validated to supported values: `local`, `development`, `production`, `test` (default `development`).
 - Require hook token input via env (`OPENCLAW_HOOK_TOKEN` or OpenClaw-compatible alias `OPENCLAW_HOOKS_TOKEN`) and never log the token value.
 - Load env files with OpenClaw precedence and no overrides:
@@ -42,6 +43,7 @@
 - When CRL verification fails with unknown `kid`, refresh registry keyset once and retry verification before returning dependency failure.
 - Return `401` for invalid/expired/replayed/revoked/invalid-proof requests.
 - Return `403` when requests are verified but agent DID is not allowlisted.
+- Return `429` with `PROXY_RATE_LIMIT_EXCEEDED` when an allowlisted verified agent DID exceeds its request budget within the configured window.
 - Return `503` when registry keyset dependency is unavailable, and when CRL dependency is unavailable under `fail-closed` stale policy.
 
 ## CRL Policy
@@ -56,6 +58,6 @@
 
 ## Server Runtime
 - Keep `src/server.ts` as the HTTP app/runtime entry.
-- Keep middleware order stable: request context -> request logging -> error handler.
+- Keep middleware order stable: request context -> request logging -> auth verification -> agent DID rate limit -> error handler.
 - Keep `/health` response contract stable: `{ status, version, environment }` with HTTP 200.
 - Log startup and request completion with structured JSON logs; never log secrets or tokens.

--- a/apps/proxy/src/AGENTS.md
+++ b/apps/proxy/src/AGENTS.md
@@ -3,8 +3,10 @@
 ## Source Layout
 - Keep `index.ts` as runtime bootstrap surface and version export.
 - Keep runtime env parsing and defaults in `config.ts`; do not scatter `process.env` reads across handlers.
+- Keep agent DID rate-limit env parsing in `config.ts` (`AGENT_RATE_LIMIT_REQUESTS_PER_MINUTE`, `AGENT_RATE_LIMIT_WINDOW_MS`) and validate as positive integers.
 - Keep HTTP app/startup concerns in `server.ts`; use `bin.ts` as process entrypoint for Node runtime startup.
 - Keep inbound auth verification in `auth-middleware.ts` with focused helpers for token parsing, registry material loading, CRL checks, and replay protection.
+- Keep per-agent DID throttling in `agent-rate-limit-middleware.ts`; do not blend rate-limit state or counters into `auth-middleware.ts`.
 - Keep `.env` fallback loading and OpenClaw config (`hooks.token`) fallback logic inside `config.ts` so runtime behavior is deterministic.
 - Keep fallback semantics consistent across merge + parse stages: empty/whitespace env values are treated as missing, so non-empty `.env`/file values can be used.
 - Do not derive runtime environment from `NODE_ENV`; use validated `ENVIRONMENT` from proxy config.
@@ -21,6 +23,7 @@
 - Keep server middleware composable and single-responsibility to reduce churn in later T27-T31 auth/forwarding work.
 - Keep `/hooks/agent` forwarding logic isolated in `agent-hook-route.ts`; `server.ts` should only compose middleware/routes.
 - Keep auth failure semantics stable: auth-invalid requests map to `401`; verified-but-not-allowlisted requests map to `403`; registry keyset outages map to `503`; CRL outages map to `503` when stale behavior is `fail-closed`.
+- Keep rate-limit failure semantics stable: verified requests over budget map to `429` with code `PROXY_RATE_LIMIT_EXCEEDED` and structured warn log event `proxy.rate_limit.exceeded`.
 - Keep `X-Claw-Timestamp` parsing strict: accept digit-only unix-seconds strings and reject mixed/decimal formats.
 - Keep AIT verification resilient to routine key rotation: retry once with a forced keyset refresh on `UNKNOWN_AIT_KID` before rejecting.
 - Keep CRL verification resilient to routine key rotation: retry once with a forced keyset refresh on `UNKNOWN_CRL_KID` before dependency-failure mapping.

--- a/apps/proxy/src/agent-rate-limit-middleware.test.ts
+++ b/apps/proxy/src/agent-rate-limit-middleware.test.ts
@@ -1,0 +1,205 @@
+import {
+  createHonoErrorHandler,
+  createRequestContextMiddleware,
+  type Logger,
+} from "@clawdentity/sdk";
+import { Hono } from "hono";
+import { describe, expect, it, vi } from "vitest";
+import { createAgentRateLimitMiddleware } from "./agent-rate-limit-middleware.js";
+import type { ProxyRequestVariables } from "./auth-middleware.js";
+
+type MockLogger = Logger & {
+  warnSpy: ReturnType<typeof vi.fn>;
+};
+
+function createMockLogger(): MockLogger {
+  const warnSpy = vi.fn();
+  const logger: MockLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: warnSpy,
+    error: vi.fn(),
+    child: () => logger,
+    warnSpy,
+  };
+  return logger;
+}
+
+function createRateLimitTestApp(input: {
+  maxRequests: number;
+  windowMs: number;
+  nowMs: () => number;
+  logger: Logger;
+}) {
+  const app = new Hono<{ Variables: ProxyRequestVariables }>();
+  app.use("*", createRequestContextMiddleware());
+  app.use("*", async (c, next) => {
+    const testAgentDid = c.req.header("x-test-agent-did");
+    if (typeof testAgentDid === "string" && testAgentDid.trim().length > 0) {
+      c.set("auth", {
+        agentDid: testAgentDid,
+        ownerDid: "did:claw:human:test-owner",
+        aitJti: "test-jti",
+        issuer: "https://api.clawdentity.com",
+        cnfPublicKey: "test-key",
+      });
+    }
+
+    await next();
+  });
+  app.use(
+    "*",
+    createAgentRateLimitMiddleware({
+      config: {
+        agentRateLimitRequestsPerMinute: input.maxRequests,
+        agentRateLimitWindowMs: input.windowMs,
+      },
+      logger: input.logger,
+      nowMs: input.nowMs,
+    }),
+  );
+  app.onError(createHonoErrorHandler(input.logger));
+  app.get("/health", (c) => c.json({ status: "ok" }));
+  app.post("/protected", (c) =>
+    c.json({ ok: true, agentDid: c.get("auth")?.agentDid }),
+  );
+
+  return app;
+}
+
+describe("proxy agent DID rate limit middleware", () => {
+  it("returns 429 with PROXY_RATE_LIMIT_EXCEEDED when requests exceed limit", async () => {
+    const now = 1_000;
+    const logger = createMockLogger();
+    const app = createRateLimitTestApp({
+      maxRequests: 2,
+      windowMs: 60_000,
+      nowMs: () => now,
+      logger,
+    });
+    const headers = {
+      "content-type": "application/json",
+      "x-test-agent-did": "did:claw:agent:alpha",
+    };
+
+    const first = await app.request("/protected", {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ message: "1" }),
+    });
+    const second = await app.request("/protected", {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ message: "2" }),
+    });
+    const third = await app.request("/protected", {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ message: "3" }),
+    });
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(third.status).toBe(429);
+    const body = (await third.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("PROXY_RATE_LIMIT_EXCEEDED");
+    expect(logger.warnSpy).toHaveBeenCalledWith("proxy.rate_limit.exceeded", {
+      agentDid: "did:claw:agent:alpha",
+      windowMs: 60_000,
+      maxRequests: 2,
+    });
+  });
+
+  it("tracks counters per agent DID independently", async () => {
+    const logger = createMockLogger();
+    const app = createRateLimitTestApp({
+      maxRequests: 1,
+      windowMs: 60_000,
+      nowMs: () => 2_000,
+      logger,
+    });
+
+    const alphaHeaders = {
+      "content-type": "application/json",
+      "x-test-agent-did": "did:claw:agent:alpha",
+    };
+    const betaHeaders = {
+      "content-type": "application/json",
+      "x-test-agent-did": "did:claw:agent:beta",
+    };
+
+    const alphaFirst = await app.request("/protected", {
+      method: "POST",
+      headers: alphaHeaders,
+      body: JSON.stringify({ message: "alpha-1" }),
+    });
+    const betaFirst = await app.request("/protected", {
+      method: "POST",
+      headers: betaHeaders,
+      body: JSON.stringify({ message: "beta-1" }),
+    });
+    const alphaSecond = await app.request("/protected", {
+      method: "POST",
+      headers: alphaHeaders,
+      body: JSON.stringify({ message: "alpha-2" }),
+    });
+
+    expect(alphaFirst.status).toBe(200);
+    expect(betaFirst.status).toBe(200);
+    expect(alphaSecond.status).toBe(429);
+  });
+
+  it("resets counters after window expiry", async () => {
+    let now = 10_000;
+    const logger = createMockLogger();
+    const app = createRateLimitTestApp({
+      maxRequests: 1,
+      windowMs: 1_000,
+      nowMs: () => now,
+      logger,
+    });
+    const headers = {
+      "content-type": "application/json",
+      "x-test-agent-did": "did:claw:agent:alpha",
+    };
+
+    const first = await app.request("/protected", {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ message: "1" }),
+    });
+    const second = await app.request("/protected", {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ message: "2" }),
+    });
+    now += 1_001;
+    const third = await app.request("/protected", {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ message: "3" }),
+    });
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(429);
+    expect(third.status).toBe(200);
+  });
+
+  it("keeps /health unthrottled", async () => {
+    const logger = createMockLogger();
+    const app = createRateLimitTestApp({
+      maxRequests: 1,
+      windowMs: 60_000,
+      nowMs: () => 10_000,
+      logger,
+    });
+
+    const first = await app.request("/health");
+    const second = await app.request("/health");
+    const third = await app.request("/health");
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(third.status).toBe(200);
+  });
+});

--- a/apps/proxy/src/agent-rate-limit-middleware.ts
+++ b/apps/proxy/src/agent-rate-limit-middleware.ts
@@ -1,0 +1,82 @@
+import { AppError, type Logger } from "@clawdentity/sdk";
+import { createMiddleware } from "hono/factory";
+import type { ProxyRequestVariables } from "./auth-middleware.js";
+import type { ProxyConfig } from "./config.js";
+
+type InMemoryBucket = {
+  windowStartedAtMs: number;
+  count: number;
+};
+
+export type AgentRateLimitMiddlewareOptions = {
+  config: Pick<
+    ProxyConfig,
+    "agentRateLimitRequestsPerMinute" | "agentRateLimitWindowMs"
+  >;
+  logger: Logger;
+  nowMs?: () => number;
+};
+
+export function createAgentRateLimitMiddleware(
+  options: AgentRateLimitMiddlewareOptions,
+) {
+  const nowMs = options.nowMs ?? Date.now;
+  const buckets = new Map<string, InMemoryBucket>();
+
+  return createMiddleware<{ Variables: ProxyRequestVariables }>(
+    async (c, next) => {
+      if (c.req.path === "/health") {
+        await next();
+        return;
+      }
+
+      const auth = c.get("auth");
+      if (!auth) {
+        await next();
+        return;
+      }
+
+      const now = nowMs();
+      for (const [agentDid, bucket] of buckets.entries()) {
+        if (
+          now - bucket.windowStartedAtMs >=
+          options.config.agentRateLimitWindowMs
+        ) {
+          buckets.delete(agentDid);
+        }
+      }
+
+      const existing = buckets.get(auth.agentDid);
+      if (
+        !existing ||
+        now - existing.windowStartedAtMs >=
+          options.config.agentRateLimitWindowMs
+      ) {
+        buckets.set(auth.agentDid, {
+          windowStartedAtMs: now,
+          count: 1,
+        });
+        await next();
+        return;
+      }
+
+      if (existing.count >= options.config.agentRateLimitRequestsPerMinute) {
+        options.logger.warn("proxy.rate_limit.exceeded", {
+          agentDid: auth.agentDid,
+          windowMs: options.config.agentRateLimitWindowMs,
+          maxRequests: options.config.agentRateLimitRequestsPerMinute,
+        });
+        throw new AppError({
+          code: "PROXY_RATE_LIMIT_EXCEEDED",
+          message: "Too many requests",
+          status: 429,
+          expose: true,
+        });
+      }
+
+      existing.count += 1;
+      buckets.set(auth.agentDid, existing);
+      await next();
+    },
+  );
+}

--- a/apps/proxy/src/config.test.ts
+++ b/apps/proxy/src/config.test.ts
@@ -3,6 +3,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
+  DEFAULT_AGENT_RATE_LIMIT_REQUESTS_PER_MINUTE,
+  DEFAULT_AGENT_RATE_LIMIT_WINDOW_MS,
   DEFAULT_CRL_MAX_AGE_MS,
   DEFAULT_CRL_REFRESH_INTERVAL_MS,
   DEFAULT_OPENCLAW_BASE_URL,
@@ -35,6 +37,9 @@ describe("proxy config", () => {
       crlRefreshIntervalMs: DEFAULT_CRL_REFRESH_INTERVAL_MS,
       crlMaxAgeMs: DEFAULT_CRL_MAX_AGE_MS,
       crlStaleBehavior: "fail-open",
+      agentRateLimitRequestsPerMinute:
+        DEFAULT_AGENT_RATE_LIMIT_REQUESTS_PER_MINUTE,
+      agentRateLimitWindowMs: DEFAULT_AGENT_RATE_LIMIT_WINDOW_MS,
     });
   });
 
@@ -45,6 +50,8 @@ describe("proxy config", () => {
       CLAWDENTITY_REGISTRY_URL: "https://registry.example.com",
       ENVIRONMENT: "local",
       CRL_STALE_BEHAVIOR: "fail-closed",
+      AGENT_RATE_LIMIT_REQUESTS_PER_MINUTE: "75",
+      AGENT_RATE_LIMIT_WINDOW_MS: "90000",
     });
 
     expect(config.listenPort).toBe(4100);
@@ -52,6 +59,8 @@ describe("proxy config", () => {
     expect(config.registryUrl).toBe("https://registry.example.com");
     expect(config.environment).toBe("local");
     expect(config.crlStaleBehavior).toBe("fail-closed");
+    expect(config.agentRateLimitRequestsPerMinute).toBe(75);
+    expect(config.agentRateLimitWindowMs).toBe(90000);
   });
 
   it("parses allow list object and override env lists", () => {
@@ -110,6 +119,21 @@ describe("proxy config", () => {
       parseProxyConfig({
         OPENCLAW_HOOK_TOKEN: "token",
         ENVIRONMENT: "staging",
+      }),
+    ).toThrow(ProxyConfigError);
+  });
+
+  it("throws on invalid agent DID rate-limit values", () => {
+    expect(() =>
+      parseProxyConfig({
+        OPENCLAW_HOOK_TOKEN: "token",
+        AGENT_RATE_LIMIT_REQUESTS_PER_MINUTE: "0",
+      }),
+    ).toThrow(ProxyConfigError);
+    expect(() =>
+      parseProxyConfig({
+        OPENCLAW_HOOK_TOKEN: "token",
+        AGENT_RATE_LIMIT_WINDOW_MS: "-1",
       }),
     ).toThrow(ProxyConfigError);
   });

--- a/apps/proxy/src/config.ts
+++ b/apps/proxy/src/config.ts
@@ -26,6 +26,8 @@ export const DEFAULT_PROXY_ENVIRONMENT: ProxyEnvironment = "development";
 export const DEFAULT_CRL_REFRESH_INTERVAL_MS = 5 * 60 * 1000;
 export const DEFAULT_CRL_MAX_AGE_MS = 15 * 60 * 1000;
 export const DEFAULT_CRL_STALE_BEHAVIOR: ProxyCrlStaleBehavior = "fail-open";
+export const DEFAULT_AGENT_RATE_LIMIT_REQUESTS_PER_MINUTE = 60;
+export const DEFAULT_AGENT_RATE_LIMIT_WINDOW_MS = 60 * 1000;
 
 export class ProxyConfigError extends Error {
   readonly code = "CONFIG_VALIDATION_FAILED";
@@ -72,6 +74,16 @@ const proxyRuntimeEnvSchema = z.object({
   CRL_STALE_BEHAVIOR: z
     .enum(["fail-open", "fail-closed"])
     .default(DEFAULT_CRL_STALE_BEHAVIOR),
+  AGENT_RATE_LIMIT_REQUESTS_PER_MINUTE: z.coerce
+    .number()
+    .int()
+    .positive()
+    .default(DEFAULT_AGENT_RATE_LIMIT_REQUESTS_PER_MINUTE),
+  AGENT_RATE_LIMIT_WINDOW_MS: z.coerce
+    .number()
+    .int()
+    .positive()
+    .default(DEFAULT_AGENT_RATE_LIMIT_WINDOW_MS),
 });
 
 const proxyAllowListSchema = z
@@ -91,6 +103,8 @@ export const proxyConfigSchema = z.object({
   crlRefreshIntervalMs: z.number().int().positive(),
   crlMaxAgeMs: z.number().int().positive(),
   crlStaleBehavior: z.enum(["fail-open", "fail-closed"]),
+  agentRateLimitRequestsPerMinute: z.number().int().positive(),
+  agentRateLimitWindowMs: z.number().int().positive(),
 });
 
 export type ProxyConfig = z.infer<typeof proxyConfigSchema>;
@@ -112,6 +126,8 @@ type RuntimeEnvInput = {
   CRL_REFRESH_INTERVAL_MS?: unknown;
   CRL_MAX_AGE_MS?: unknown;
   CRL_STALE_BEHAVIOR?: unknown;
+  AGENT_RATE_LIMIT_REQUESTS_PER_MINUTE?: unknown;
+  AGENT_RATE_LIMIT_WINDOW_MS?: unknown;
   OPENCLAW_STATE_DIR?: unknown;
   CLAWDBOT_STATE_DIR?: unknown;
   OPENCLAW_CONFIG_PATH?: unknown;
@@ -397,6 +413,12 @@ function normalizeRuntimeEnv(input: unknown): Record<string, unknown> {
     CRL_REFRESH_INTERVAL_MS: firstNonEmpty(env, ["CRL_REFRESH_INTERVAL_MS"]),
     CRL_MAX_AGE_MS: firstNonEmpty(env, ["CRL_MAX_AGE_MS"]),
     CRL_STALE_BEHAVIOR: firstNonEmpty(env, ["CRL_STALE_BEHAVIOR"]),
+    AGENT_RATE_LIMIT_REQUESTS_PER_MINUTE: firstNonEmpty(env, [
+      "AGENT_RATE_LIMIT_REQUESTS_PER_MINUTE",
+    ]),
+    AGENT_RATE_LIMIT_WINDOW_MS: firstNonEmpty(env, [
+      "AGENT_RATE_LIMIT_WINDOW_MS",
+    ]),
   };
 }
 
@@ -522,6 +544,9 @@ export function parseProxyConfig(env: unknown): ProxyConfig {
     crlRefreshIntervalMs: parsedRuntimeEnv.data.CRL_REFRESH_INTERVAL_MS,
     crlMaxAgeMs: parsedRuntimeEnv.data.CRL_MAX_AGE_MS,
     crlStaleBehavior: parsedRuntimeEnv.data.CRL_STALE_BEHAVIOR,
+    agentRateLimitRequestsPerMinute:
+      parsedRuntimeEnv.data.AGENT_RATE_LIMIT_REQUESTS_PER_MINUTE,
+    agentRateLimitWindowMs: parsedRuntimeEnv.data.AGENT_RATE_LIMIT_WINDOW_MS,
   };
 
   const parsedConfig = proxyConfigSchema.safeParse(candidateConfig);

--- a/apps/proxy/src/server.ts
+++ b/apps/proxy/src/server.ts
@@ -13,6 +13,7 @@ import {
   type AgentHookRuntimeOptions,
   createAgentHookHandler,
 } from "./agent-hook-route.js";
+import { createAgentRateLimitMiddleware } from "./agent-rate-limit-middleware.js";
 import {
   createProxyAuthMiddleware,
   type ProxyRequestVariables,
@@ -28,11 +29,16 @@ type ProxyAuthRuntimeOptions = {
   crlCache?: CrlCache;
 };
 
+type ProxyRateLimitRuntimeOptions = {
+  nowMs?: () => number;
+};
+
 type CreateProxyAppOptions = {
   config: ProxyConfig;
   logger?: Logger;
   registerRoutes?: (app: ProxyApp) => void;
   auth?: ProxyAuthRuntimeOptions;
+  rateLimit?: ProxyRateLimitRuntimeOptions;
   hooks?: AgentHookRuntimeOptions;
 };
 
@@ -72,6 +78,14 @@ export function createProxyApp(options: CreateProxyAppOptions): ProxyApp {
       config: options.config,
       logger,
       ...options.auth,
+    }),
+  );
+  app.use(
+    "*",
+    createAgentRateLimitMiddleware({
+      config: options.config,
+      logger,
+      ...options.rateLimit,
     }),
   );
   app.onError(createHonoErrorHandler(logger));


### PR DESCRIPTION
## Summary
- add configurable proxy rate-limit settings for verified agent DIDs
- add in-memory per-agent DID limiter middleware returning `429 PROXY_RATE_LIMIT_EXCEEDED`
- compose limiter after auth verification in proxy middleware chain
- add focused rate-limit middleware tests and config parsing coverage
- update proxy `AGENTS.md` docs with rate-limit defaults and middleware-order best practices

## Changes
- `apps/proxy/src/config.ts`
  - add defaults and env parsing for:
    - `AGENT_RATE_LIMIT_REQUESTS_PER_MINUTE` (default `60`)
    - `AGENT_RATE_LIMIT_WINDOW_MS` (default `60000`)
  - extend `ProxyConfig` with `agentRateLimitRequestsPerMinute` and `agentRateLimitWindowMs`
- `apps/proxy/src/agent-rate-limit-middleware.ts`
  - new in-memory fixed-window limiter keyed by verified `agentDid`
  - logs `proxy.rate_limit.exceeded`
  - throws `AppError` with `429` and code `PROXY_RATE_LIMIT_EXCEEDED`
- `apps/proxy/src/server.ts`
  - register rate-limit middleware after auth middleware
- `apps/proxy/src/config.test.ts`
  - assert new defaults, env overrides, and invalid-value rejection
- `apps/proxy/src/agent-rate-limit-middleware.test.ts`
  - cover exceed behavior, per-DID isolation, window reset, and `/health` bypass
- `apps/proxy/AGENTS.md`
- `apps/proxy/src/AGENTS.md`

## Validation
- `pnpm lint`
- `pnpm -r typecheck`
- `pnpm -r test`
- `pnpm -r build`
- pre-push hook also passed: `nx affected -t lint,format,typecheck,test --base=origin/main --head=HEAD`

Closes #32
