### PR TITLE
feat(proxy): add worker runtime + cloud env relay config plumbing

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ OpenClaw Gateway  (normal /hooks/agent handling)
 This repo is a monorepo:
 
 - `apps/registry` — issues AITs, serves CRL + public keys (Worker config: `apps/registry/wrangler.jsonc`)
-- `apps/proxy` — verifies Clawdentity headers then forwards to OpenClaw hooks
+- `apps/proxy` — verifies Clawdentity headers then forwards to OpenClaw hooks (Worker config: `apps/proxy/wrangler.jsonc`)
 - `apps/cli` — operator workflow (`claw create`, `claw revoke`, `claw share`)
 - `packages/sdk` — TS SDK (sign + verify + CRL cache)
 - `packages/protocol` — shared types + canonical signing rules
@@ -180,10 +180,21 @@ This repo is a monorepo:
 ### 3) Proxy enforcement before OpenClaw
 
 - Handled by: `apps/proxy`
-- Sidecar proxy verifies AIT + CRL + PoP before forwarding to OpenClaw.
+- Proxy Worker verifies AIT + CRL + PoP before forwarding to OpenClaw.
 - Enforces caller allowlist policy by DID.
 - Applies per-agent rate limiting.
 - Keeps `hooks.token` private and only injects it internally during forward.
+- Optional: set `INJECT_IDENTITY_INTO_MESSAGE=true` to prepend a sanitized identity block
+  (`agentDid`, `ownerDid`, `issuer`, `aitJti`) into `/hooks/agent` payload `message`.
+  Default is `false`, which keeps payloads unchanged.
+
+### Proxy Worker local runs
+
+- Local env (`ENVIRONMENT=local`): `pnpm dev:proxy`
+- Development env (`ENVIRONMENT=development`): `pnpm dev:proxy:development`
+- Fresh deploy-like env: `pnpm dev:proxy:fresh`
+- Production deploy command: `pnpm -F @clawdentity/proxy run deploy:production`
+- Environment intent: `local` is local Wrangler development only; `development` and `production` are cloud deployment environments.
 
 ### 4) Operator lifecycle tooling (CLI)
 

--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -21,6 +21,7 @@
 - Local CLI config lives at `~/.clawdentity/config.json`.
 - CLI verification caches live under `~/.clawdentity/cache/` and must never include private keys or PATs.
 - Agent identities live at `~/.clawdentity/agents/<name>/` and must include `secret.key`, `public.key`, `identity.json`, and `ait.jwt`.
+- OpenClaw setup runtime hint lives at `~/.clawdentity/openclaw-relay.json` and stores `openclawBaseUrl` for proxy fallback.
 - Reject `.` and `..` as agent names before any filesystem operation to prevent directory traversal outside `~/.clawdentity/agents/`.
 - Resolve values with explicit precedence: environment variables > config file > built-in defaults.
 - Keep API tokens masked in human-facing output (`show`, success logs, debug prints).

--- a/apps/cli/src/commands/AGENTS.md
+++ b/apps/cli/src/commands/AGENTS.md
@@ -19,6 +19,8 @@
 ## OpenClaw Command Rules
 - `openclaw invite` must generate self-contained invite code from admin-provided DID + proxy URL.
 - `openclaw setup` must be idempotent for relay mapping updates and peer map writes.
+- `openclaw setup` must persist/update `~/.clawdentity/openclaw-relay.json` with the resolved `openclawBaseUrl` so downstream proxy runtime can boot without manual env edits.
+- `openclaw setup --openclaw-base-url` should only be needed when OpenClaw is not reachable on the default `http://127.0.0.1:18789`.
 - Keep error messages static (no interpolated runtime values); include variable context only in error details/log fields.
 
 ## Admin Command Rules

--- a/apps/cli/src/commands/openclaw.test.ts
+++ b/apps/cli/src/commands/openclaw.test.ts
@@ -158,7 +158,94 @@ describe("openclaw command helpers", () => {
         "utf8",
       ).trim();
       expect(selectedAgent).toBe("alpha");
+
+      expect(result.openclawBaseUrl).toBe("http://127.0.0.1:18789");
+      const relayRuntimeConfig = JSON.parse(
+        readFileSync(
+          join(sandbox.homeDir, ".clawdentity", "openclaw-relay.json"),
+          "utf8",
+        ),
+      ) as {
+        openclawBaseUrl: string;
+        updatedAt: string;
+      };
+      expect(relayRuntimeConfig.openclawBaseUrl).toBe("http://127.0.0.1:18789");
+      expect(relayRuntimeConfig.updatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
     } finally {
+      sandbox.cleanup();
+    }
+  });
+
+  it("stores explicit OpenClaw base URL in relay runtime config", async () => {
+    const sandbox = createSandbox();
+    seedLocalAgentCredentials(sandbox.homeDir, "alpha");
+
+    try {
+      const invite = createOpenclawInviteCode({
+        did: "did:claw:agent:01HF7YAT31JZHSMW1CG6Q6MHB7",
+        proxyUrl: "https://beta.example.com/hooks/agent",
+        peerAlias: "beta",
+      });
+
+      const result = await setupOpenclawRelayFromInvite("alpha", {
+        inviteCode: invite.code,
+        homeDir: sandbox.homeDir,
+        openclawDir: sandbox.openclawDir,
+        transformSource: sandbox.transformSourcePath,
+        openclawBaseUrl: "http://127.0.0.1:19001",
+      });
+
+      expect(result.openclawBaseUrl).toBe("http://127.0.0.1:19001");
+      const relayRuntimeConfig = JSON.parse(
+        readFileSync(
+          join(sandbox.homeDir, ".clawdentity", "openclaw-relay.json"),
+          "utf8",
+        ),
+      ) as {
+        openclawBaseUrl: string;
+      };
+      expect(relayRuntimeConfig.openclawBaseUrl).toBe("http://127.0.0.1:19001");
+    } finally {
+      sandbox.cleanup();
+    }
+  });
+
+  it("uses OPENCLAW_BASE_URL env when setup option is omitted", async () => {
+    const sandbox = createSandbox();
+    seedLocalAgentCredentials(sandbox.homeDir, "alpha");
+    const previousBaseUrl = process.env.OPENCLAW_BASE_URL;
+    process.env.OPENCLAW_BASE_URL = "http://127.0.0.1:19555";
+
+    try {
+      const invite = createOpenclawInviteCode({
+        did: "did:claw:agent:01HF7YAT31JZHSMW1CG6Q6MHB7",
+        proxyUrl: "https://beta.example.com/hooks/agent",
+        peerAlias: "beta",
+      });
+
+      const result = await setupOpenclawRelayFromInvite("alpha", {
+        inviteCode: invite.code,
+        homeDir: sandbox.homeDir,
+        openclawDir: sandbox.openclawDir,
+        transformSource: sandbox.transformSourcePath,
+      });
+
+      expect(result.openclawBaseUrl).toBe("http://127.0.0.1:19555");
+      const relayRuntimeConfig = JSON.parse(
+        readFileSync(
+          join(sandbox.homeDir, ".clawdentity", "openclaw-relay.json"),
+          "utf8",
+        ),
+      ) as {
+        openclawBaseUrl: string;
+      };
+      expect(relayRuntimeConfig.openclawBaseUrl).toBe("http://127.0.0.1:19555");
+    } finally {
+      if (previousBaseUrl === undefined) {
+        delete process.env.OPENCLAW_BASE_URL;
+      } else {
+        process.env.OPENCLAW_BASE_URL = previousBaseUrl;
+      }
       sandbox.cleanup();
     }
   });

--- a/apps/cli/src/commands/openclaw.ts
+++ b/apps/cli/src/commands/openclaw.ts
@@ -14,6 +14,7 @@ import { withErrorHandling } from "./helpers.js";
 
 const logger = createLogger({ service: "cli", module: "openclaw" });
 
+const CLAWDENTITY_DIR_NAME = ".clawdentity";
 const AGENTS_DIR_NAME = "agents";
 const AIT_FILE_NAME = "ait.jwt";
 const SECRET_KEY_FILE_NAME = "secret.key";
@@ -21,10 +22,12 @@ const PEERS_FILE_NAME = "peers.json";
 const OPENCLAW_DIR_NAME = ".openclaw";
 const OPENCLAW_CONFIG_FILE_NAME = "openclaw.json";
 const OPENCLAW_AGENT_FILE_NAME = "openclaw-agent-name";
+const OPENCLAW_RELAY_RUNTIME_FILE_NAME = "openclaw-relay.json";
 const SKILL_DIR_NAME = "clawdentity-openclaw-relay";
 const RELAY_MODULE_FILE_NAME = "relay-to-peer.mjs";
 const HOOK_MAPPING_ID = "clawdentity-send-to-peer";
 const HOOK_PATH_SEND_TO_PEER = "send-to-peer";
+const DEFAULT_OPENCLAW_BASE_URL = "http://127.0.0.1:18789";
 const INVITE_CODE_PREFIX = "clawd1_";
 const PEER_ALIAS_PATTERN = /^[a-zA-Z0-9._-]+$/;
 const FILE_MODE = 0o600;
@@ -52,6 +55,7 @@ type OpenclawSetupOptions = {
   peerAlias?: string;
   openclawDir?: string;
   transformSource?: string;
+  openclawBaseUrl?: string;
   homeDir?: string;
 };
 
@@ -79,6 +83,13 @@ export type OpenclawSetupResult = {
   peerProxyUrl: string;
   openclawConfigPath: string;
   transformTargetPath: string;
+  openclawBaseUrl: string;
+  relayRuntimeConfigPath: string;
+};
+
+type OpenclawRelayRuntimeConfig = {
+  openclawBaseUrl: string;
+  updatedAt?: string;
 };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -157,26 +168,50 @@ function parsePeerAlias(value: unknown): string {
 }
 
 function parseProxyUrl(value: unknown): string {
-  const candidate = parseNonEmptyString(value, "proxy URL");
+  return parseHttpUrl(value, {
+    label: "proxy URL",
+    code: "CLI_OPENCLAW_INVALID_PROXY_URL",
+    message: "proxy URL must be a valid URL",
+  });
+}
 
+function parseHttpUrl(
+  value: unknown,
+  input: {
+    label: string;
+    code: string;
+    message: string;
+  },
+): string {
+  const candidate = parseNonEmptyString(value, input.label);
   let parsedUrl: URL;
   try {
     parsedUrl = new URL(candidate);
   } catch {
-    throw createCliError(
-      "CLI_OPENCLAW_INVALID_PROXY_URL",
-      "proxy URL must be a valid URL",
-    );
+    throw createCliError(input.code, input.message);
   }
 
   if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
-    throw createCliError(
-      "CLI_OPENCLAW_INVALID_PROXY_URL",
-      "proxy URL must use http or https",
-    );
+    throw createCliError(input.code, `${input.label} must use http or https`);
+  }
+
+  if (
+    parsedUrl.pathname === "/" &&
+    parsedUrl.search.length === 0 &&
+    parsedUrl.hash.length === 0
+  ) {
+    return parsedUrl.origin;
   }
 
   return parsedUrl.toString();
+}
+
+function parseOpenclawBaseUrl(value: unknown): string {
+  return parseHttpUrl(value, {
+    label: "OpenClaw base URL",
+    code: "CLI_OPENCLAW_INVALID_OPENCLAW_BASE_URL",
+    message: "OpenClaw base URL must be a valid URL",
+  });
 }
 
 function parseAgentDid(value: unknown, label: string): string {
@@ -267,11 +302,11 @@ function resolveOpenclawDir(openclawDir: string | undefined, homeDir: string) {
 }
 
 function resolveAgentDirectory(homeDir: string, agentName: string): string {
-  return join(homeDir, ".clawdentity", AGENTS_DIR_NAME, agentName);
+  return join(homeDir, CLAWDENTITY_DIR_NAME, AGENTS_DIR_NAME, agentName);
 }
 
 function resolvePeersPath(homeDir: string): string {
-  return join(homeDir, ".clawdentity", PEERS_FILE_NAME);
+  return join(homeDir, CLAWDENTITY_DIR_NAME, PEERS_FILE_NAME);
 }
 
 function resolveOpenclawConfigPath(openclawDir: string): string {
@@ -293,7 +328,11 @@ function resolveTransformTargetPath(openclawDir: string): string {
 }
 
 function resolveOpenclawAgentNamePath(homeDir: string): string {
-  return join(homeDir, ".clawdentity", OPENCLAW_AGENT_FILE_NAME);
+  return join(homeDir, CLAWDENTITY_DIR_NAME, OPENCLAW_AGENT_FILE_NAME);
+}
+
+function resolveRelayRuntimeConfigPath(homeDir: string): string {
+  return join(homeDir, CLAWDENTITY_DIR_NAME, OPENCLAW_RELAY_RUNTIME_FILE_NAME);
 }
 
 async function readJsonFile(filePath: string): Promise<unknown> {
@@ -465,6 +504,90 @@ async function savePeersConfig(
   await writeSecureFile(peersPath, `${JSON.stringify(config, null, 2)}\n`);
 }
 
+function parseRelayRuntimeConfig(
+  value: unknown,
+  relayRuntimeConfigPath: string,
+): OpenclawRelayRuntimeConfig {
+  if (!isRecord(value)) {
+    throw createCliError(
+      "CLI_OPENCLAW_INVALID_RELAY_RUNTIME_CONFIG",
+      "Relay runtime config must be an object",
+      { relayRuntimeConfigPath },
+    );
+  }
+
+  const updatedAt =
+    typeof value.updatedAt === "string" && value.updatedAt.trim().length > 0
+      ? value.updatedAt.trim()
+      : undefined;
+
+  return {
+    openclawBaseUrl: parseOpenclawBaseUrl(value.openclawBaseUrl),
+    updatedAt,
+  };
+}
+
+async function loadRelayRuntimeConfig(
+  relayRuntimeConfigPath: string,
+): Promise<OpenclawRelayRuntimeConfig | undefined> {
+  let parsed: unknown;
+  try {
+    parsed = await readJsonFile(relayRuntimeConfigPath);
+  } catch (error) {
+    if (getErrorCode(error) === "ENOENT") {
+      return undefined;
+    }
+
+    throw error;
+  }
+
+  return parseRelayRuntimeConfig(parsed, relayRuntimeConfigPath);
+}
+
+async function saveRelayRuntimeConfig(
+  relayRuntimeConfigPath: string,
+  openclawBaseUrl: string,
+): Promise<void> {
+  const config: OpenclawRelayRuntimeConfig = {
+    openclawBaseUrl,
+    updatedAt: nowIso(),
+  };
+
+  await writeSecureFile(
+    relayRuntimeConfigPath,
+    `${JSON.stringify(config, null, 2)}\n`,
+  );
+}
+
+async function resolveOpenclawBaseUrl(input: {
+  optionValue?: string;
+  relayRuntimeConfigPath: string;
+}): Promise<string> {
+  if (
+    typeof input.optionValue === "string" &&
+    input.optionValue.trim().length > 0
+  ) {
+    return parseOpenclawBaseUrl(input.optionValue);
+  }
+
+  const envOpenclawBaseUrl = process.env.OPENCLAW_BASE_URL;
+  if (
+    typeof envOpenclawBaseUrl === "string" &&
+    envOpenclawBaseUrl.trim().length > 0
+  ) {
+    return parseOpenclawBaseUrl(envOpenclawBaseUrl);
+  }
+
+  const existingConfig = await loadRelayRuntimeConfig(
+    input.relayRuntimeConfigPath,
+  );
+  if (existingConfig !== undefined) {
+    return existingConfig.openclawBaseUrl;
+  }
+
+  return DEFAULT_OPENCLAW_BASE_URL;
+}
+
 function normalizeStringArrayWithValue(
   value: unknown,
   requiredValue: string,
@@ -634,6 +757,11 @@ export async function setupOpenclawRelayFromInvite(
       ? options.transformSource.trim()
       : resolveDefaultTransformSource(openclawDir);
   const transformTargetPath = resolveTransformTargetPath(openclawDir);
+  const relayRuntimeConfigPath = resolveRelayRuntimeConfigPath(homeDir);
+  const openclawBaseUrl = await resolveOpenclawBaseUrl({
+    optionValue: options.openclawBaseUrl,
+    relayRuntimeConfigPath,
+  });
   const invite = decodeInvitePayload(options.inviteCode);
   const peerAliasCandidate = options.peerAlias ?? invite.alias;
 
@@ -674,6 +802,7 @@ export async function setupOpenclawRelayFromInvite(
 
   const agentNamePath = resolveOpenclawAgentNamePath(homeDir);
   await writeSecureFile(agentNamePath, `${normalizedAgentName}\n`);
+  await saveRelayRuntimeConfig(relayRuntimeConfigPath, openclawBaseUrl);
 
   logger.info("cli.openclaw_setup_completed", {
     agentName: normalizedAgentName,
@@ -681,6 +810,8 @@ export async function setupOpenclawRelayFromInvite(
     peerDid: invite.did,
     openclawConfigPath,
     transformTargetPath,
+    openclawBaseUrl,
+    relayRuntimeConfigPath,
   });
 
   return {
@@ -689,6 +820,8 @@ export async function setupOpenclawRelayFromInvite(
     peerProxyUrl: invite.proxyUrl,
     openclawConfigPath,
     transformTargetPath,
+    openclawBaseUrl,
+    relayRuntimeConfigPath,
   };
 }
 
@@ -739,6 +872,10 @@ export const createOpenclawCommand = (): Command => {
       "--transform-source <path>",
       "Path to relay-to-peer.mjs (default <openclaw-dir>/workspace/skills/clawdentity-openclaw-relay/relay-to-peer.mjs)",
     )
+    .option(
+      "--openclaw-base-url <url>",
+      "Base URL for local OpenClaw hook API (default http://127.0.0.1:18789)",
+    )
     .action(
       withErrorHandling(
         "openclaw setup",
@@ -751,6 +888,10 @@ export const createOpenclawCommand = (): Command => {
             `Updated OpenClaw config: ${result.openclawConfigPath}`,
           );
           writeStdoutLine(`Installed transform: ${result.transformTargetPath}`);
+          writeStdoutLine(`OpenClaw base URL: ${result.openclawBaseUrl}`);
+          writeStdoutLine(
+            `Relay runtime config: ${result.relayRuntimeConfigPath}`,
+          );
         },
       ),
     );

--- a/apps/openclaw-skill/AGENTS.md
+++ b/apps/openclaw-skill/AGENTS.md
@@ -12,6 +12,7 @@
   - environment (`CLAWDENTITY_AGENT_NAME`)
   - `~/.clawdentity/openclaw-agent-name`
   - single local agent auto-detection
+- Relay setup should preserve local OpenClaw upstream URL in `~/.clawdentity/openclaw-relay.json` for proxy runtime fallback.
 - Never commit local runtime files (`peers.json`, `secret.key`, `ait.jwt`) to the repository.
 
 ## Transform Rules
@@ -43,5 +44,5 @@
 - Install and execute onboarding through skill flow only (`npm install clawdentity --skill` plus agent-executed skill steps).
 - Human role in E2E is limited to supplying invite code and confirmations requested by the agent.
 - Do not edit relay hooks, peer config, or selected-agent files manually during validation.
-- After skill setup, verify these artifacts exist and are agent-generated: `~/.clawdentity/peers.json`, `~/.clawdentity/openclaw-agent-name`, `~/.openclaw/hooks/transforms/relay-to-peer.mjs`.
+- After skill setup, verify these artifacts exist and are agent-generated: `~/.clawdentity/peers.json`, `~/.clawdentity/openclaw-agent-name`, `~/.clawdentity/openclaw-relay.json`, `~/.openclaw/hooks/transforms/relay-to-peer.mjs`.
 - For reruns after failures, clear skill-generated artifacts first; only perform full identity reset (`~/.clawdentity/agents/<agent-name>/`) when identity reprovisioning is needed.

--- a/apps/openclaw-skill/skill/SKILL.md
+++ b/apps/openclaw-skill/skill/SKILL.md
@@ -34,6 +34,7 @@ Use this skill when any of the following are requested:
 - Agent AIT token: `~/.clawdentity/agents/<agent-name>/ait.jwt`
 - Peer map: `~/.clawdentity/peers.json`
 - Local selected agent marker: `~/.clawdentity/openclaw-agent-name`
+- Relay runtime config: `~/.clawdentity/openclaw-relay.json`
 
 ## Operator Split
 
@@ -52,6 +53,7 @@ Follow this order. Do not skip steps.
 - Confirm `clawdentity` CLI is installed and runnable.
 - Confirm API key exists for this agent (if missing, ask the human for it).
 - Confirm OpenClaw state directory path if non-default.
+- Confirm OpenClaw base URL if local endpoint is non-default.
 
 2. Confirm skill artifact exists in workspace skills directory.
 - Ensure `~/.openclaw/workspace/skills/clawdentity-openclaw-relay/relay-to-peer.mjs` exists.
@@ -71,6 +73,7 @@ Follow this order. Do not skip steps.
 - Execute:
   `clawdentity openclaw setup <agent-name> --invite-code <invite-code>`
 - Use `--openclaw-dir <path>` when state directory is non-default.
+- Use `--openclaw-base-url <url>` when local OpenClaw HTTP endpoint is non-default.
 - Use `--peer-alias <alias>` only when alias override is required.
 
 6. Verify setup outputs.
@@ -79,6 +82,8 @@ Follow this order. Do not skip steps.
   - peer DID
   - updated OpenClaw config path
   - installed transform path
+  - OpenClaw base URL
+  - relay runtime config path
 - Confirm `~/.clawdentity/openclaw-agent-name` is set to the local agent name.
 
 7. Validate with user-style relay test.
@@ -92,6 +97,7 @@ Follow this order. Do not skip steps.
 Ask the human only when required inputs are missing:
 - Missing Clawdentity API key.
 - Unclear OpenClaw state directory.
+- Non-default OpenClaw base URL.
 - Missing invite code.
 
 ## Failure Handling

--- a/apps/openclaw-skill/skill/references/clawdentity-protocol.md
+++ b/apps/openclaw-skill/skill/references/clawdentity-protocol.md
@@ -17,6 +17,7 @@ Define the exact runtime contract used by `relay-to-peer.mjs`.
 - `~/.clawdentity/agents/<agent-name>/ait.jwt`
 - `~/.clawdentity/peers.json`
 - `~/.clawdentity/openclaw-agent-name`
+- `~/.clawdentity/openclaw-relay.json`
 
 ## Invite Code Contract
 
@@ -82,6 +83,22 @@ Relay resolves local agent name in this order:
 2. `CLAWDENTITY_AGENT_NAME`
 3. `~/.clawdentity/openclaw-agent-name`
 4. single local agent fallback from `~/.clawdentity/agents/`
+
+## Local OpenClaw Base URL Contract
+
+`~/.clawdentity/openclaw-relay.json` stores the OpenClaw upstream base URL used by local proxy runtime fallback:
+
+```json
+{
+  "openclawBaseUrl": "http://127.0.0.1:18789",
+  "updatedAt": "2026-02-15T20:00:00.000Z"
+}
+```
+
+Rules:
+- `openclawBaseUrl` must be absolute `http` or `https`.
+- `updatedAt` is ISO-8601 UTC timestamp.
+- Proxy runtime precedence is: `OPENCLAW_BASE_URL` env first, then `openclaw-relay.json`, then built-in default.
 
 ## Outbound Auth Contract
 

--- a/apps/proxy/.env.example
+++ b/apps/proxy/.env.example
@@ -1,0 +1,26 @@
+# Proxy local/development template
+# For local Wrangler development, copy values into .dev.vars.
+# For cloud deploys, set OPENCLAW_HOOK_TOKEN as a Wrangler secret:
+#   wrangler secret put OPENCLAW_HOOK_TOKEN --env <env>
+# For cloud deploy scripts, export a reachable upstream first:
+#   export OPENCLAW_BASE_URL=https://openclaw-<env>.example.com
+
+# Required
+OPENCLAW_HOOK_TOKEN=replace-with-openclaw-hook-token
+
+# Runtime vars
+ENVIRONMENT=local
+REGISTRY_URL=https://dev.api.clawdentity.com
+# Optional when ~/.clawdentity/openclaw-relay.json exists from `clawdentity openclaw setup`
+OPENCLAW_BASE_URL=http://127.0.0.1:18789
+INJECT_IDENTITY_INTO_MESSAGE=false
+
+# Optional policy/runtime overrides
+# ALLOW_LIST={"owners":[],"agents":[]}
+# ALLOWLIST_OWNERS=did:claw:human:example
+# ALLOWLIST_AGENTS=did:claw:agent:example
+# CRL_REFRESH_INTERVAL_MS=300000
+# CRL_MAX_AGE_MS=900000
+# CRL_STALE_BEHAVIOR=fail-open
+# AGENT_RATE_LIMIT_REQUESTS_PER_MINUTE=60
+# AGENT_RATE_LIMIT_WINDOW_MS=60000

--- a/apps/proxy/AGENTS.md
+++ b/apps/proxy/AGENTS.md
@@ -6,15 +6,22 @@
 
 ## Runtime Configuration
 - Keep runtime config centralized in `src/config.ts`.
+- Keep Cloudflare Worker deployment config in `wrangler.jsonc` with explicit `local`, `development`, and `production` environments.
 - Parse config with a schema and fail fast with `CONFIG_VALIDATION_FAILED` before startup proceeds.
 - Keep defaults explicit for non-secret settings (`listenPort`, `openclawBaseUrl`, `registryUrl`, CRL timings, stale behavior).
 - Keep agent DID limiter defaults explicit in `src/config.ts` (`AGENT_RATE_LIMIT_REQUESTS_PER_MINUTE=60`, `AGENT_RATE_LIMIT_WINDOW_MS=60000`) unless explicitly overridden.
 - Keep runtime `ENVIRONMENT` explicit and validated to supported values: `local`, `development`, `production`, `test` (default `development`).
+- Keep deployment intent explicit: `local` is for local Wrangler dev runs only; `development` and `production` are remote cloud environments.
+- For remote Worker deployments (`development`/`production`), require `OPENCLAW_BASE_URL` to be an externally reachable non-loopback URL; never rely on local loopback defaults.
+- Keep `INJECT_IDENTITY_INTO_MESSAGE` explicit and default-off (`false`); only enable when operators need webhook `message` augmentation with verified identity context.
 - Require hook token input via env (`OPENCLAW_HOOK_TOKEN` or OpenClaw-compatible alias `OPENCLAW_HOOKS_TOKEN`) and never log the token value.
+- For Worker deploys, set hook tokens via Wrangler secrets for remote environments (`wrangler secret put ... --env <env>`); use CLI `--var` overrides only for local dev runs.
+- Keep `.dev.vars` and `.env.example` synchronized when adding/changing proxy config fields (required token, registry URL, base URL, and optional policy/rate-limit vars).
 - Load env files with OpenClaw precedence and no overrides:
   - first `./.env` from the proxy working directory
   - then `$OPENCLAW_STATE_DIR/.env` (or default state dir: `~/.openclaw`, with legacy fallback to existing `~/.clawdbot` / `~/.moldbot` / `~/.moltbot`)
   - existing environment variables always win over `.env` values.
+- If `OPENCLAW_BASE_URL` is still missing after env loading, fallback to `~/.clawdentity/openclaw-relay.json` (`openclawBaseUrl`) before applying the built-in default.
 - Treat blank env values as unset for fallback resolution:
   - empty/whitespace values (and null-like values) in inherited env must not block `.env` or config-file fallbacks
   - dotenv merge semantics must match parser semantics (non-empty value wins).
@@ -58,6 +65,8 @@
 
 ## Server Runtime
 - Keep `src/server.ts` as the HTTP app/runtime entry.
+- Keep `src/worker.ts` as the Cloudflare Worker fetch entry and `src/node-server.ts` as the Node compatibility entry.
 - Keep middleware order stable: request context -> request logging -> auth verification -> agent DID rate limit -> error handler.
 - Keep `/health` response contract stable: `{ status, version, environment }` with HTTP 200.
 - Log startup and request completion with structured JSON logs; never log secrets or tokens.
+- If identity injection is enabled, mutate only `payload.message` when it is a string; preserve all other payload fields unchanged.

--- a/apps/proxy/package.json
+++ b/apps/proxy/package.json
@@ -13,10 +13,23 @@
     "./server": {
       "import": "./dist/server.js",
       "types": "./dist/server.d.ts"
+    },
+    "./node-server": {
+      "import": "./dist/node-server.js",
+      "types": "./dist/node-server.d.ts"
+    },
+    "./worker": {
+      "import": "./dist/worker.js",
+      "types": "./dist/worker.d.ts"
     }
   },
   "scripts": {
     "build": "tsup",
+    "deploy:dev": "wrangler deploy --env development --var OPENCLAW_BASE_URL:${OPENCLAW_BASE_URL:?set OPENCLAW_BASE_URL}",
+    "deploy:production": "wrangler deploy --env production --var OPENCLAW_BASE_URL:${OPENCLAW_BASE_URL:?set OPENCLAW_BASE_URL}",
+    "dev": "wrangler dev --env local --var OPENCLAW_HOOK_TOKEN:dev-proxy-hook-token",
+    "dev:development": "wrangler dev --env development --var OPENCLAW_HOOK_TOKEN:dev-proxy-hook-token",
+    "dev:fresh": "wrangler dev --env local --name clawdentity-proxy-local-fresh --port 8789 --persist-to .wrangler/state-fresh --var OPENCLAW_HOOK_TOKEN:fresh-proxy-hook-token",
     "format": "biome format .",
     "lint": "biome lint .",
     "start": "node ./dist/bin.js",
@@ -31,5 +44,9 @@
     "hono": "^4.11.9",
     "json5": "^2.2.3",
     "zod": "^4.1.12"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20260210.0",
+    "@types/node": "^22.17.2"
   }
 }

--- a/apps/proxy/src/AGENTS.md
+++ b/apps/proxy/src/AGENTS.md
@@ -4,10 +4,14 @@
 - Keep `index.ts` as runtime bootstrap surface and version export.
 - Keep runtime env parsing and defaults in `config.ts`; do not scatter `process.env` reads across handlers.
 - Keep agent DID rate-limit env parsing in `config.ts` (`AGENT_RATE_LIMIT_REQUESTS_PER_MINUTE`, `AGENT_RATE_LIMIT_WINDOW_MS`) and validate as positive integers.
-- Keep HTTP app/startup concerns in `server.ts`; use `bin.ts` as process entrypoint for Node runtime startup.
+- Keep HTTP app composition in `server.ts`.
+- Keep Cloudflare Worker fetch startup in `worker.ts`.
+- Keep Node runtime startup in `node-server.ts`; use `bin.ts` as Node process entrypoint.
 - Keep inbound auth verification in `auth-middleware.ts` with focused helpers for token parsing, registry material loading, CRL checks, and replay protection.
 - Keep per-agent DID throttling in `agent-rate-limit-middleware.ts`; do not blend rate-limit state or counters into `auth-middleware.ts`.
 - Keep `.env` fallback loading and OpenClaw config (`hooks.token`) fallback logic inside `config.ts` so runtime behavior is deterministic.
+- Keep OpenClaw base URL fallback logic in `config.ts`: `OPENCLAW_BASE_URL` env -> `~/.clawdentity/openclaw-relay.json` -> default.
+- Keep Worker runtime guardrails in `worker.ts`: block loopback/default OpenClaw upstream URLs for `development`/`production` so cloud deploys fail fast with config errors.
 - Keep fallback semantics consistent across merge + parse stages: empty/whitespace env values are treated as missing, so non-empty `.env`/file values can be used.
 - Do not derive runtime environment from `NODE_ENV`; use validated `ENVIRONMENT` from proxy config.
 
@@ -22,6 +26,7 @@
 - Keep `ALLOW_ALL_VERIFIED` removed; fail fast when deprecated bypass flags are provided.
 - Keep server middleware composable and single-responsibility to reduce churn in later T27-T31 auth/forwarding work.
 - Keep `/hooks/agent` forwarding logic isolated in `agent-hook-route.ts`; `server.ts` should only compose middleware/routes.
+- Do not import Node-only startup helpers into `worker.ts`; Worker runtime must stay free of process/port startup concerns.
 - Keep auth failure semantics stable: auth-invalid requests map to `401`; verified-but-not-allowlisted requests map to `403`; registry keyset outages map to `503`; CRL outages map to `503` when stale behavior is `fail-closed`.
 - Keep rate-limit failure semantics stable: verified requests over budget map to `429` with code `PROXY_RATE_LIMIT_EXCEEDED` and structured warn log event `proxy.rate_limit.exceeded`.
 - Keep `X-Claw-Timestamp` parsing strict: accept digit-only unix-seconds strings and reject mixed/decimal formats.
@@ -29,3 +34,6 @@
 - Keep CRL verification resilient to routine key rotation: retry once with a forced keyset refresh on `UNKNOWN_CRL_KID` before dependency-failure mapping.
 - Keep `/hooks/agent` input contract strict: require `Content-Type: application/json` and reject malformed JSON with explicit client errors.
 - Keep `/hooks/agent` upstream failure mapping explicit: timeout errors -> `504`, network errors -> `502`, and never log `openclawHookToken` or request payload.
+- Keep identity message injection optional and default-off (`INJECT_IDENTITY_INTO_MESSAGE=false`) so forwarding behavior is unchanged unless explicitly enabled.
+- Keep identity augmentation logic in small pure helpers (`sanitizeIdentityField`, `buildIdentityBlock`, payload mutation helper) inside `agent-hook-route.ts`; avoid spreading identity-format logic into `server.ts`.
+- When identity injection is enabled, sanitize identity fields (strip control chars, normalize whitespace, enforce max lengths) and mutate only string `message` fields.

--- a/apps/proxy/src/agent-hook-route.test.ts
+++ b/apps/proxy/src/agent-hook-route.test.ts
@@ -5,7 +5,24 @@ vi.mock("./auth-middleware.js", async () => {
 
   return {
     createProxyAuthMiddleware: () =>
-      createMiddleware(async (_c, next) => {
+      createMiddleware(async (c, next) => {
+        const missingAuth = c.req.header("x-test-missing-auth") === "1";
+        if (!missingAuth) {
+          const dirtyAuth = c.req.header("x-test-dirty-auth") === "1";
+          c.set("auth", {
+            agentDid: dirtyAuth
+              ? `\u0000 did:claw:agent:${"a".repeat(200)} \n`
+              : "did:claw:agent:alpha",
+            ownerDid: dirtyAuth
+              ? " \t did:claw:owner:alpha\u0007"
+              : "did:claw:owner:alpha",
+            issuer: dirtyAuth
+              ? ` https://registry.example.com/${"b".repeat(260)} `
+              : "https://registry.example.com",
+            aitJti: dirtyAuth ? `\u0001${"j".repeat(100)}` : "ait-jti-alpha",
+            cnfPublicKey: "test-public-key",
+          });
+        }
         await next();
       }),
   };
@@ -14,15 +31,31 @@ vi.mock("./auth-middleware.js", async () => {
 import { parseProxyConfig } from "./config.js";
 import { createProxyApp } from "./server.js";
 
+function hasDisallowedControlCharacter(value: string): boolean {
+  for (const char of value) {
+    const code = char.charCodeAt(0);
+    if ((code >= 0 && code <= 8) || code === 11 || code === 12) {
+      return true;
+    }
+    if ((code >= 14 && code <= 31) || code === 127) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 function createHookRouteApp(input: {
   fetchImpl: typeof fetch;
   timeoutMs?: number;
   openclawBaseUrl?: string;
+  injectIdentityIntoMessage?: boolean;
 }) {
   return createProxyApp({
     config: parseProxyConfig({
       OPENCLAW_BASE_URL: input.openclawBaseUrl ?? "http://openclaw.local",
       OPENCLAW_HOOK_TOKEN: "openclaw-secret",
+      INJECT_IDENTITY_INTO_MESSAGE: input.injectIdentityIntoMessage,
     }),
     hooks: {
       fetchImpl: input.fetchImpl,
@@ -130,6 +163,177 @@ describe("POST /hooks/agent", () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(forwardedUrl).toBe("http://openclaw.local/api/hooks/agent");
+  });
+
+  it("prepends sanitized identity block when message injection is enabled", async () => {
+    const fetchMock = vi.fn(async (_input: unknown, init?: RequestInit) => {
+      return new Response(
+        JSON.stringify({
+          echoedBody: init?.body,
+        }),
+        {
+          status: 202,
+          headers: {
+            "content-type": "application/json",
+          },
+        },
+      );
+    });
+    const app = createHookRouteApp({
+      fetchImpl: fetchMock as unknown as typeof fetch,
+      injectIdentityIntoMessage: true,
+    });
+
+    const response = await app.request("/hooks/agent", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        message: "Summarize this payload",
+      }),
+    });
+
+    expect(response.status).toBe(202);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const [, calledInit] = fetchMock.mock.calls[0] as [
+      unknown,
+      RequestInit | undefined,
+    ];
+    const forwardedPayload = JSON.parse(String(calledInit?.body)) as {
+      message: string;
+    };
+    expect(forwardedPayload.message).toBe(
+      [
+        "[Clawdentity Identity]",
+        "agentDid: did:claw:agent:alpha",
+        "ownerDid: did:claw:owner:alpha",
+        "issuer: https://registry.example.com",
+        "aitJti: ait-jti-alpha",
+        "",
+        "Summarize this payload",
+      ].join("\n"),
+    );
+  });
+
+  it("keeps payload unchanged when message injection is enabled but auth is missing", async () => {
+    const fetchMock = vi.fn(async (_input: unknown, init?: RequestInit) => {
+      return new Response(String(init?.body), { status: 202 });
+    });
+    const app = createHookRouteApp({
+      fetchImpl: fetchMock as unknown as typeof fetch,
+      injectIdentityIntoMessage: true,
+    });
+    const rawPayload = {
+      message: "No auth context here",
+      event: "agent.started",
+    };
+
+    const response = await app.request("/hooks/agent", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-test-missing-auth": "1",
+      },
+      body: JSON.stringify(rawPayload),
+    });
+
+    expect(response.status).toBe(202);
+    const [, calledInit] = fetchMock.mock.calls[0] as [
+      unknown,
+      RequestInit | undefined,
+    ];
+    expect(String(calledInit?.body)).toBe(JSON.stringify(rawPayload));
+  });
+
+  it("keeps payload unchanged when message is missing or non-string", async () => {
+    const fetchMock = vi.fn(async (_input: unknown, init?: RequestInit) => {
+      return new Response(String(init?.body), { status: 202 });
+    });
+    const app = createHookRouteApp({
+      fetchImpl: fetchMock as unknown as typeof fetch,
+      injectIdentityIntoMessage: true,
+    });
+
+    await app.request("/hooks/agent", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        event: "agent.started",
+      }),
+    });
+
+    await app.request("/hooks/agent", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        message: { nested: true },
+      }),
+    });
+
+    const [, firstInit] = fetchMock.mock.calls[0] as [unknown, RequestInit];
+    const [, secondInit] = fetchMock.mock.calls[1] as [unknown, RequestInit];
+    expect(String(firstInit.body)).toBe(
+      JSON.stringify({ event: "agent.started" }),
+    );
+    expect(String(secondInit.body)).toBe(
+      JSON.stringify({ message: { nested: true } }),
+    );
+  });
+
+  it("sanitizes identity fields and enforces length limits", async () => {
+    const fetchMock = vi.fn(async (_input: unknown, init?: RequestInit) => {
+      return new Response(
+        JSON.stringify({
+          echoedBody: init?.body,
+        }),
+        {
+          status: 202,
+          headers: {
+            "content-type": "application/json",
+          },
+        },
+      );
+    });
+    const app = createHookRouteApp({
+      fetchImpl: fetchMock as unknown as typeof fetch,
+      injectIdentityIntoMessage: true,
+    });
+
+    const response = await app.request("/hooks/agent", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-test-dirty-auth": "1",
+      },
+      body: JSON.stringify({
+        message: "Hello world",
+      }),
+    });
+
+    expect(response.status).toBe(202);
+    const [, calledInit] = fetchMock.mock.calls[0] as [
+      unknown,
+      RequestInit | undefined,
+    ];
+    const forwardedPayload = JSON.parse(String(calledInit?.body)) as {
+      message: string;
+    };
+    expect(forwardedPayload.message).toContain("[Clawdentity Identity]");
+
+    const identityBlock = forwardedPayload.message.split("\n\n")[0];
+    expect(hasDisallowedControlCharacter(identityBlock)).toBe(false);
+
+    const identityLines = identityBlock.split("\n");
+    expect(identityLines[1].length).toBeLessThanOrEqual(171);
+    expect(identityLines[2].length).toBeLessThanOrEqual(171);
+    expect(identityLines[3].length).toBeLessThanOrEqual(208);
+    expect(identityLines[4].length).toBeLessThanOrEqual(72);
   });
 
   it("rejects non-json content types", async () => {

--- a/apps/proxy/src/agent-hook-route.ts
+++ b/apps/proxy/src/agent-hook-route.ts
@@ -4,10 +4,15 @@ import type { ProxyRequestVariables } from "./auth-middleware.js";
 
 const AGENT_HOOK_PATH = "hooks/agent";
 export const DEFAULT_AGENT_HOOK_TIMEOUT_MS = 10_000;
+const MAX_AGENT_DID_LENGTH = 160;
+const MAX_OWNER_DID_LENGTH = 160;
+const MAX_ISSUER_LENGTH = 200;
+const MAX_AIT_JTI_LENGTH = 64;
 
 export type AgentHookRuntimeOptions = {
   fetchImpl?: typeof fetch;
   timeoutMs?: number;
+  injectIdentityIntoMessage?: boolean;
 };
 
 type CreateAgentHookHandlerOptions = AgentHookRuntimeOptions & {
@@ -48,11 +53,70 @@ function isAbortError(error: unknown): boolean {
   return toErrorName(error) === "AbortError";
 }
 
+function stripControlChars(value: string): string {
+  let result = "";
+  for (const char of value) {
+    const code = char.charCodeAt(0);
+    if ((code >= 0 && code <= 31) || code === 127) {
+      continue;
+    }
+    result += char;
+  }
+
+  return result;
+}
+
+function sanitizeIdentityField(value: string, maxLength: number): string {
+  const sanitized = stripControlChars(value).replaceAll(/\s+/g, " ").trim();
+
+  if (sanitized.length === 0) {
+    return "unknown";
+  }
+
+  return sanitized.slice(0, maxLength);
+}
+
+function buildIdentityBlock(
+  auth: NonNullable<ProxyRequestVariables["auth"]>,
+): string {
+  return [
+    "[Clawdentity Identity]",
+    `agentDid: ${sanitizeIdentityField(auth.agentDid, MAX_AGENT_DID_LENGTH)}`,
+    `ownerDid: ${sanitizeIdentityField(auth.ownerDid, MAX_OWNER_DID_LENGTH)}`,
+    `issuer: ${sanitizeIdentityField(auth.issuer, MAX_ISSUER_LENGTH)}`,
+    `aitJti: ${sanitizeIdentityField(auth.aitJti, MAX_AIT_JTI_LENGTH)}`,
+  ].join("\n");
+}
+
+function injectIdentityBlockIntoPayload(
+  payload: unknown,
+  auth: ProxyRequestVariables["auth"],
+): unknown {
+  if (auth === undefined || typeof payload !== "object" || payload === null) {
+    return payload;
+  }
+
+  if (!("message" in payload)) {
+    return payload;
+  }
+
+  const message = (payload as { message?: unknown }).message;
+  if (typeof message !== "string") {
+    return payload;
+  }
+
+  return {
+    ...(payload as Record<string, unknown>),
+    message: `${buildIdentityBlock(auth)}\n\n${message}`,
+  };
+}
+
 export function createAgentHookHandler(
   options: CreateAgentHookHandlerOptions,
 ): (c: ProxyContext) => Promise<Response> {
   const fetchImpl = options.fetchImpl ?? fetch;
   const timeoutMs = options.timeoutMs ?? DEFAULT_AGENT_HOOK_TIMEOUT_MS;
+  const injectIdentityIntoMessage = options.injectIdentityIntoMessage ?? false;
   const hookUrl = toOpenclawHookUrl(options.openclawBaseUrl);
 
   return async (c) => {
@@ -75,6 +139,10 @@ export function createAgentHookHandler(
         status: 400,
         expose: true,
       });
+    }
+
+    if (injectIdentityIntoMessage) {
+      payload = injectIdentityBlockIntoPayload(payload, c.get("auth"));
     }
 
     const requestId = c.get("requestId");

--- a/apps/proxy/src/bin.ts
+++ b/apps/proxy/src/bin.ts
@@ -1,3 +1,3 @@
-import { startProxyServer } from "./server.js";
+import { startProxyServer } from "./node-server.js";
 
 startProxyServer();

--- a/apps/proxy/src/config.test.ts
+++ b/apps/proxy/src/config.test.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_AGENT_RATE_LIMIT_WINDOW_MS,
   DEFAULT_CRL_MAX_AGE_MS,
   DEFAULT_CRL_REFRESH_INTERVAL_MS,
+  DEFAULT_INJECT_IDENTITY_INTO_MESSAGE,
   DEFAULT_OPENCLAW_BASE_URL,
   DEFAULT_PROXY_ENVIRONMENT,
   DEFAULT_PROXY_LISTEN_PORT,
@@ -40,6 +41,7 @@ describe("proxy config", () => {
       agentRateLimitRequestsPerMinute:
         DEFAULT_AGENT_RATE_LIMIT_REQUESTS_PER_MINUTE,
       agentRateLimitWindowMs: DEFAULT_AGENT_RATE_LIMIT_WINDOW_MS,
+      injectIdentityIntoMessage: DEFAULT_INJECT_IDENTITY_INTO_MESSAGE,
     });
   });
 
@@ -52,6 +54,7 @@ describe("proxy config", () => {
       CRL_STALE_BEHAVIOR: "fail-closed",
       AGENT_RATE_LIMIT_REQUESTS_PER_MINUTE: "75",
       AGENT_RATE_LIMIT_WINDOW_MS: "90000",
+      INJECT_IDENTITY_INTO_MESSAGE: "true",
     });
 
     expect(config.listenPort).toBe(4100);
@@ -61,6 +64,7 @@ describe("proxy config", () => {
     expect(config.crlStaleBehavior).toBe("fail-closed");
     expect(config.agentRateLimitRequestsPerMinute).toBe(75);
     expect(config.agentRateLimitWindowMs).toBe(90000);
+    expect(config.injectIdentityIntoMessage).toBe(true);
   });
 
   it("parses allow list object and override env lists", () => {
@@ -137,6 +141,15 @@ describe("proxy config", () => {
       }),
     ).toThrow(ProxyConfigError);
   });
+
+  it("throws on invalid injectIdentityIntoMessage value", () => {
+    expect(() =>
+      parseProxyConfig({
+        OPENCLAW_HOOK_TOKEN: "token",
+        INJECT_IDENTITY_INTO_MESSAGE: "maybe",
+      }),
+    ).toThrow(ProxyConfigError);
+  });
 });
 
 describe("proxy config loading", () => {
@@ -144,14 +157,16 @@ describe("proxy config loading", () => {
     const root = mkdtempSync(join(tmpdir(), "clawdentity-proxy-config-"));
     const cwd = join(root, "workspace");
     const stateDir = join(root, ".openclaw");
+    const clawdentityDir = join(root, ".clawdentity");
     mkdirSync(cwd, { recursive: true });
     mkdirSync(stateDir, { recursive: true });
+    mkdirSync(clawdentityDir, { recursive: true });
 
     const cleanup = () => {
       rmSync(root, { recursive: true, force: true });
     };
 
-    return { root, cwd, stateDir, cleanup };
+    return { root, cwd, stateDir, clawdentityDir, cleanup };
   }
 
   it("loads cwd .env first, then state .env without overriding existing values", () => {
@@ -186,6 +201,31 @@ describe("proxy config loading", () => {
       expect(config.openclawHookToken).toBe("from-cwd-dotenv");
       expect(config.listenPort).toBe(4444);
       expect(config.registryUrl).toBe("https://registry.cwd.example.com");
+    } finally {
+      sandbox.cleanup();
+    }
+  });
+
+  it("loads INJECT_IDENTITY_INTO_MESSAGE from .env", () => {
+    const sandbox = createSandbox();
+    try {
+      writeFileSync(
+        join(sandbox.cwd, ".env"),
+        [
+          "OPENCLAW_HOOK_TOKEN=from-cwd-dotenv",
+          "INJECT_IDENTITY_INTO_MESSAGE=true",
+        ].join("\n"),
+      );
+
+      const config = loadProxyConfig(
+        {},
+        {
+          cwd: sandbox.cwd,
+          homeDir: sandbox.root,
+        },
+      );
+
+      expect(config.injectIdentityIntoMessage).toBe(true);
     } finally {
       sandbox.cleanup();
     }
@@ -239,6 +279,69 @@ describe("proxy config loading", () => {
       );
 
       expect(config.openclawHookToken).toBe("token-from-openclaw-config");
+    } finally {
+      sandbox.cleanup();
+    }
+  });
+
+  it("falls back to ~/.clawdentity/openclaw-relay.json when OPENCLAW_BASE_URL is missing", () => {
+    const sandbox = createSandbox();
+    try {
+      writeFileSync(
+        join(sandbox.clawdentityDir, "openclaw-relay.json"),
+        JSON.stringify(
+          {
+            openclawBaseUrl: "http://127.0.0.1:19111",
+            updatedAt: "2026-02-15T20:00:00.000Z",
+          },
+          null,
+          2,
+        ),
+      );
+
+      const config = loadProxyConfig(
+        {
+          OPENCLAW_HOOK_TOKEN: "token",
+        },
+        {
+          cwd: sandbox.cwd,
+          homeDir: sandbox.root,
+        },
+      );
+
+      expect(config.openclawBaseUrl).toBe("http://127.0.0.1:19111");
+    } finally {
+      sandbox.cleanup();
+    }
+  });
+
+  it("prefers env OPENCLAW_BASE_URL over ~/.clawdentity/openclaw-relay.json", () => {
+    const sandbox = createSandbox();
+    try {
+      writeFileSync(
+        join(sandbox.clawdentityDir, "openclaw-relay.json"),
+        JSON.stringify(
+          {
+            openclawBaseUrl: "http://127.0.0.1:19111",
+            updatedAt: "2026-02-15T20:00:00.000Z",
+          },
+          null,
+          2,
+        ),
+      );
+
+      const config = loadProxyConfig(
+        {
+          OPENCLAW_HOOK_TOKEN: "token",
+          OPENCLAW_BASE_URL: "http://127.0.0.1:19999",
+        },
+        {
+          cwd: sandbox.cwd,
+          homeDir: sandbox.root,
+        },
+      );
+
+      expect(config.openclawBaseUrl).toBe("http://127.0.0.1:19999");
     } finally {
       sandbox.cleanup();
     }

--- a/apps/proxy/src/config.ts
+++ b/apps/proxy/src/config.ts
@@ -28,6 +28,7 @@ export const DEFAULT_CRL_MAX_AGE_MS = 15 * 60 * 1000;
 export const DEFAULT_CRL_STALE_BEHAVIOR: ProxyCrlStaleBehavior = "fail-open";
 export const DEFAULT_AGENT_RATE_LIMIT_REQUESTS_PER_MINUTE = 60;
 export const DEFAULT_AGENT_RATE_LIMIT_WINDOW_MS = 60 * 1000;
+export const DEFAULT_INJECT_IDENTITY_INTO_MESSAGE = false;
 
 export class ProxyConfigError extends Error {
   readonly code = "CONFIG_VALIDATION_FAILED";
@@ -43,7 +44,34 @@ export class ProxyConfigError extends Error {
 }
 
 const OPENCLAW_CONFIG_FILENAME = "openclaw.json";
+const CLAWDENTITY_CONFIG_DIR = ".clawdentity";
+const OPENCLAW_RELAY_CONFIG_FILENAME = "openclaw-relay.json";
 const LEGACY_STATE_DIR_NAMES = [".clawdbot", ".moldbot", ".moltbot"] as const;
+
+const envBooleanSchema = z.preprocess((value) => {
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (
+      normalized === "true" ||
+      normalized === "1" ||
+      normalized === "yes" ||
+      normalized === "on"
+    ) {
+      return true;
+    }
+
+    if (
+      normalized === "false" ||
+      normalized === "0" ||
+      normalized === "no" ||
+      normalized === "off"
+    ) {
+      return false;
+    }
+  }
+
+  return value;
+}, z.boolean());
 
 const proxyRuntimeEnvSchema = z.object({
   LISTEN_PORT: z.coerce
@@ -84,6 +112,9 @@ const proxyRuntimeEnvSchema = z.object({
     .int()
     .positive()
     .default(DEFAULT_AGENT_RATE_LIMIT_WINDOW_MS),
+  INJECT_IDENTITY_INTO_MESSAGE: envBooleanSchema.default(
+    DEFAULT_INJECT_IDENTITY_INTO_MESSAGE,
+  ),
 });
 
 const proxyAllowListSchema = z
@@ -105,6 +136,7 @@ export const proxyConfigSchema = z.object({
   crlStaleBehavior: z.enum(["fail-open", "fail-closed"]),
   agentRateLimitRequestsPerMinute: z.number().int().positive(),
   agentRateLimitWindowMs: z.number().int().positive(),
+  injectIdentityIntoMessage: z.boolean(),
 });
 
 export type ProxyConfig = z.infer<typeof proxyConfigSchema>;
@@ -128,6 +160,7 @@ type RuntimeEnvInput = {
   CRL_STALE_BEHAVIOR?: unknown;
   AGENT_RATE_LIMIT_REQUESTS_PER_MINUTE?: unknown;
   AGENT_RATE_LIMIT_WINDOW_MS?: unknown;
+  INJECT_IDENTITY_INTO_MESSAGE?: unknown;
   OPENCLAW_STATE_DIR?: unknown;
   CLAWDBOT_STATE_DIR?: unknown;
   OPENCLAW_CONFIG_PATH?: unknown;
@@ -282,6 +315,14 @@ function resolveOpenClawConfigPath(
   return join(stateDir, OPENCLAW_CONFIG_FILENAME);
 }
 
+function resolveOpenclawRelayConfigPath(
+  env: RuntimeEnvInput,
+  options: ProxyConfigLoadOptions,
+): string {
+  const home = resolveHomeDir(env, options.homeDir);
+  return join(home, CLAWDENTITY_CONFIG_DIR, OPENCLAW_RELAY_CONFIG_FILENAME);
+}
+
 function mergeMissingEnvValues(
   target: MutableEnv,
   values: Record<string, string>,
@@ -392,6 +433,87 @@ function resolveHookTokenFromOpenClawConfig(
   return trimmedToken.length > 0 ? trimmedToken : undefined;
 }
 
+function resolveBaseUrlFromRelayConfig(
+  env: RuntimeEnvInput,
+  options: ProxyConfigLoadOptions,
+): string | undefined {
+  const configPath = resolveOpenclawRelayConfigPath(env, options);
+  if (!existsSync(configPath)) {
+    return undefined;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(configPath, "utf8"));
+  } catch (error) {
+    throw toConfigValidationError({
+      fieldErrors: {
+        OPENCLAW_RELAY_CONFIG_PATH: [
+          `Unable to parse relay config at ${configPath}`,
+        ],
+      },
+      formErrors: [
+        error instanceof Error ? error.message : "Unknown relay parse error",
+      ],
+    });
+  }
+
+  if (typeof parsed !== "object" || parsed === null) {
+    throw toConfigValidationError({
+      fieldErrors: {
+        OPENCLAW_RELAY_CONFIG_PATH: ["Relay config root must be a JSON object"],
+      },
+      formErrors: [],
+    });
+  }
+
+  const baseUrlValue = (parsed as Record<string, unknown>).openclawBaseUrl;
+  if (typeof baseUrlValue !== "string" || baseUrlValue.trim().length === 0) {
+    throw toConfigValidationError({
+      fieldErrors: {
+        OPENCLAW_RELAY_CONFIG_PATH: [
+          "openclawBaseUrl must be a non-empty string",
+        ],
+      },
+      formErrors: [],
+    });
+  }
+
+  const trimmed = baseUrlValue.trim();
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(trimmed);
+  } catch {
+    throw toConfigValidationError({
+      fieldErrors: {
+        OPENCLAW_RELAY_CONFIG_PATH: [
+          "openclawBaseUrl must be a valid absolute URL",
+        ],
+      },
+      formErrors: [],
+    });
+  }
+
+  if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
+    throw toConfigValidationError({
+      fieldErrors: {
+        OPENCLAW_RELAY_CONFIG_PATH: ["openclawBaseUrl must use http or https"],
+      },
+      formErrors: [],
+    });
+  }
+
+  if (
+    parsedUrl.pathname === "/" &&
+    parsedUrl.search.length === 0 &&
+    parsedUrl.hash.length === 0
+  ) {
+    return parsedUrl.origin;
+  }
+
+  return parsedUrl.toString();
+}
+
 function normalizeRuntimeEnv(input: unknown): Record<string, unknown> {
   const env: RuntimeEnvInput = isRuntimeEnvInput(input) ? input : {};
 
@@ -418,6 +540,9 @@ function normalizeRuntimeEnv(input: unknown): Record<string, unknown> {
     ]),
     AGENT_RATE_LIMIT_WINDOW_MS: firstNonEmpty(env, [
       "AGENT_RATE_LIMIT_WINDOW_MS",
+    ]),
+    INJECT_IDENTITY_INTO_MESSAGE: firstNonEmpty(env, [
+      "INJECT_IDENTITY_INTO_MESSAGE",
     ]),
   };
 }
@@ -520,6 +645,25 @@ function loadHookTokenFromFallback(
   }
 }
 
+function loadOpenclawBaseUrlFromFallback(
+  env: MutableEnv,
+  options: ProxyConfigLoadOptions,
+): void {
+  if (
+    firstNonEmpty(env as RuntimeEnvInput, ["OPENCLAW_BASE_URL"]) !== undefined
+  ) {
+    return;
+  }
+
+  const openclawBaseUrl = resolveBaseUrlFromRelayConfig(
+    env as RuntimeEnvInput,
+    options,
+  );
+  if (openclawBaseUrl !== undefined) {
+    env.OPENCLAW_BASE_URL = openclawBaseUrl;
+  }
+}
+
 export function parseProxyConfig(env: unknown): ProxyConfig {
   const inputEnv: RuntimeEnvInput = isRuntimeEnvInput(env) ? env : {};
   assertNoDeprecatedAllowAllVerified(inputEnv);
@@ -547,6 +691,8 @@ export function parseProxyConfig(env: unknown): ProxyConfig {
     agentRateLimitRequestsPerMinute:
       parsedRuntimeEnv.data.AGENT_RATE_LIMIT_REQUESTS_PER_MINUTE,
     agentRateLimitWindowMs: parsedRuntimeEnv.data.AGENT_RATE_LIMIT_WINDOW_MS,
+    injectIdentityIntoMessage:
+      parsedRuntimeEnv.data.INJECT_IDENTITY_INTO_MESSAGE,
   };
 
   const parsedConfig = proxyConfigSchema.safeParse(candidateConfig);
@@ -565,6 +711,7 @@ export function loadProxyConfig(
   options: ProxyConfigLoadOptions = {},
 ): ProxyConfig {
   const mergedEnv = loadEnvWithDotEnvFallback(env, options);
+  loadOpenclawBaseUrlFromFallback(mergedEnv, options);
   loadHookTokenFromFallback(mergedEnv, options);
   return parseProxyConfig(mergedEnv);
 }

--- a/apps/proxy/src/node-server.ts
+++ b/apps/proxy/src/node-server.ts
@@ -1,0 +1,53 @@
+import { createLogger, type Logger } from "@clawdentity/sdk";
+import { type ServerType, serve } from "@hono/node-server";
+import type { ProxyConfig } from "./config.js";
+import { loadProxyConfig } from "./config.js";
+import { PROXY_VERSION } from "./index.js";
+import { createProxyApp, type ProxyApp } from "./server.js";
+
+type StartProxyServerOptions = {
+  env?: unknown;
+  config?: ProxyConfig;
+  logger?: Logger;
+  port?: number;
+};
+
+export type StartedProxyServer = {
+  app: ProxyApp;
+  config: ProxyConfig;
+  port: number;
+  server: ServerType;
+};
+
+function resolveLogger(logger?: Logger): Logger {
+  return logger ?? createLogger({ service: "proxy" });
+}
+
+export function startProxyServer(
+  options: StartProxyServerOptions = {},
+): StartedProxyServer {
+  const config = options.config ?? loadProxyConfig(options.env);
+  const logger = resolveLogger(options.logger);
+  const app = createProxyApp({
+    config,
+    logger,
+  });
+  const port = options.port ?? config.listenPort;
+  const server = serve({
+    fetch: app.fetch,
+    port,
+  });
+
+  logger.info("proxy.server_started", {
+    port,
+    version: PROXY_VERSION,
+    environment: config.environment,
+  });
+
+  return {
+    app,
+    config,
+    port,
+    server,
+  };
+}

--- a/apps/proxy/src/server.test.ts
+++ b/apps/proxy/src/server.test.ts
@@ -5,7 +5,8 @@ import {
   parseProxyConfig,
 } from "./config.js";
 import { PROXY_VERSION } from "./index.js";
-import { createProxyApp, startProxyServer } from "./server.js";
+import { startProxyServer } from "./node-server.js";
+import { createProxyApp } from "./server.js";
 
 describe("proxy server", () => {
   it("returns health response with status, version, and environment", async () => {

--- a/apps/proxy/src/server.ts
+++ b/apps/proxy/src/server.ts
@@ -7,7 +7,6 @@ import {
   type Logger,
   type NonceCache,
 } from "@clawdentity/sdk";
-import { serve } from "@hono/node-server";
 import { Hono } from "hono";
 import {
   type AgentHookRuntimeOptions,
@@ -19,7 +18,6 @@ import {
   type ProxyRequestVariables,
 } from "./auth-middleware.js";
 import type { ProxyConfig } from "./config.js";
-import { loadProxyConfig } from "./config.js";
 import { PROXY_VERSION } from "./index.js";
 
 type ProxyAuthRuntimeOptions = {
@@ -42,23 +40,9 @@ type CreateProxyAppOptions = {
   hooks?: AgentHookRuntimeOptions;
 };
 
-type StartProxyServerOptions = {
-  env?: unknown;
-  config?: ProxyConfig;
-  logger?: Logger;
-  port?: number;
-};
-
 export type ProxyApp = Hono<{
   Variables: ProxyRequestVariables;
 }>;
-
-export type StartedProxyServer = {
-  app: ProxyApp;
-  config: ProxyConfig;
-  port: number;
-  server: ReturnType<typeof serve>;
-};
 
 function resolveLogger(logger?: Logger): Logger {
   return logger ?? createLogger({ service: "proxy" });
@@ -103,39 +87,11 @@ export function createProxyApp(options: CreateProxyAppOptions): ProxyApp {
       logger,
       openclawBaseUrl: options.config.openclawBaseUrl,
       openclawHookToken: options.config.openclawHookToken,
+      injectIdentityIntoMessage: options.config.injectIdentityIntoMessage,
       ...options.hooks,
     }),
   );
   options.registerRoutes?.(app);
 
   return app;
-}
-
-export function startProxyServer(
-  options: StartProxyServerOptions = {},
-): StartedProxyServer {
-  const config = options.config ?? loadProxyConfig(options.env);
-  const logger = resolveLogger(options.logger);
-  const app = createProxyApp({
-    config,
-    logger,
-  });
-  const port = options.port ?? config.listenPort;
-  const server = serve({
-    fetch: app.fetch,
-    port,
-  });
-
-  logger.info("proxy.server_started", {
-    port,
-    version: PROXY_VERSION,
-    environment: config.environment,
-  });
-
-  return {
-    app,
-    config,
-    port,
-    server,
-  };
 }

--- a/apps/proxy/src/worker.test.ts
+++ b/apps/proxy/src/worker.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from "vitest";
+import { PROXY_VERSION } from "./index.js";
+import worker, { type ProxyWorkerBindings } from "./worker.js";
+
+function createExecutionContext(): ExecutionContext {
+  return {
+    waitUntil: vi.fn(),
+    passThroughOnException: vi.fn(),
+    props: {},
+  } as unknown as ExecutionContext;
+}
+
+describe("proxy worker", () => {
+  it("serves /health with parsed runtime config from bindings", async () => {
+    const response = await worker.fetch(
+      new Request("https://proxy.example.test/health"),
+      {
+        ENVIRONMENT: "local",
+        OPENCLAW_HOOK_TOKEN: "proxy-hook-token",
+      } satisfies ProxyWorkerBindings,
+      createExecutionContext(),
+    );
+
+    expect(response.status).toBe(200);
+    const payload = (await response.json()) as {
+      status: string;
+      version: string;
+      environment: string;
+    };
+    expect(payload).toEqual({
+      status: "ok",
+      version: PROXY_VERSION,
+      environment: "local",
+    });
+  });
+
+  it("returns config validation error when required bindings are missing", async () => {
+    const response = await worker.fetch(
+      new Request("https://proxy.example.test/health"),
+      {} satisfies ProxyWorkerBindings,
+      createExecutionContext(),
+    );
+
+    expect(response.status).toBe(500);
+    const payload = (await response.json()) as {
+      error: {
+        code: string;
+      };
+    };
+    expect(payload.error.code).toBe("CONFIG_VALIDATION_FAILED");
+  });
+
+  it("returns config validation error when deployed env uses loopback upstream", async () => {
+    const response = await worker.fetch(
+      new Request("https://proxy.example.test/health"),
+      {
+        ENVIRONMENT: "development",
+        OPENCLAW_HOOK_TOKEN: "proxy-hook-token",
+      } satisfies ProxyWorkerBindings,
+      createExecutionContext(),
+    );
+
+    expect(response.status).toBe(500);
+    const payload = (await response.json()) as {
+      error: {
+        code: string;
+        details: {
+          fieldErrors?: Record<string, string[]>;
+        };
+      };
+    };
+    expect(payload.error.code).toBe("CONFIG_VALIDATION_FAILED");
+    expect(payload.error.details.fieldErrors?.OPENCLAW_BASE_URL?.[0]).toContain(
+      "externally reachable URL",
+    );
+  });
+
+  it("accepts non-loopback upstream in deployed env", async () => {
+    const response = await worker.fetch(
+      new Request("https://proxy.example.test/health"),
+      {
+        ENVIRONMENT: "development",
+        OPENCLAW_HOOK_TOKEN: "proxy-hook-token",
+        OPENCLAW_BASE_URL: "https://openclaw-dev.internal.example",
+      } satisfies ProxyWorkerBindings,
+      createExecutionContext(),
+    );
+
+    expect(response.status).toBe(200);
+    const payload = (await response.json()) as {
+      status: string;
+      environment: string;
+    };
+    expect(payload.status).toBe("ok");
+    expect(payload.environment).toBe("development");
+  });
+});

--- a/apps/proxy/src/worker.ts
+++ b/apps/proxy/src/worker.ts
@@ -1,0 +1,184 @@
+import { createLogger } from "@clawdentity/sdk";
+import {
+  DEFAULT_OPENCLAW_BASE_URL,
+  type ProxyConfig,
+  ProxyConfigError,
+  parseProxyConfig,
+} from "./config.js";
+import { createProxyApp, type ProxyApp } from "./server.js";
+
+export type ProxyWorkerBindings = {
+  LISTEN_PORT?: string;
+  PORT?: string;
+  OPENCLAW_BASE_URL?: string;
+  OPENCLAW_HOOK_TOKEN?: string;
+  OPENCLAW_HOOKS_TOKEN?: string;
+  REGISTRY_URL?: string;
+  CLAWDENTITY_REGISTRY_URL?: string;
+  ENVIRONMENT?: string;
+  ALLOW_LIST?: string;
+  ALLOWLIST_OWNERS?: string;
+  ALLOWLIST_AGENTS?: string;
+  ALLOW_ALL_VERIFIED?: string;
+  CRL_REFRESH_INTERVAL_MS?: string;
+  CRL_MAX_AGE_MS?: string;
+  CRL_STALE_BEHAVIOR?: string;
+  AGENT_RATE_LIMIT_REQUESTS_PER_MINUTE?: string;
+  AGENT_RATE_LIMIT_WINDOW_MS?: string;
+  INJECT_IDENTITY_INTO_MESSAGE?: string;
+  [key: string]: unknown;
+};
+
+type CachedProxyRuntime = {
+  key: string;
+  app: ProxyApp;
+  config: ProxyConfig;
+};
+
+const logger = createLogger({ service: "proxy" });
+let cachedRuntime: CachedProxyRuntime | undefined;
+
+function toCacheKey(env: ProxyWorkerBindings): string {
+  const keyParts = [
+    env.OPENCLAW_BASE_URL,
+    env.OPENCLAW_HOOK_TOKEN,
+    env.OPENCLAW_HOOKS_TOKEN,
+    env.REGISTRY_URL,
+    env.CLAWDENTITY_REGISTRY_URL,
+    env.ENVIRONMENT,
+    env.ALLOW_LIST,
+    env.ALLOWLIST_OWNERS,
+    env.ALLOWLIST_AGENTS,
+    env.CRL_REFRESH_INTERVAL_MS,
+    env.CRL_MAX_AGE_MS,
+    env.CRL_STALE_BEHAVIOR,
+    env.AGENT_RATE_LIMIT_REQUESTS_PER_MINUTE,
+    env.AGENT_RATE_LIMIT_WINDOW_MS,
+    env.INJECT_IDENTITY_INTO_MESSAGE,
+  ];
+
+  return keyParts.map((value) => String(value ?? "")).join("|");
+}
+
+function buildRuntime(env: ProxyWorkerBindings): CachedProxyRuntime {
+  const key = toCacheKey(env);
+  if (cachedRuntime && cachedRuntime.key === key) {
+    return cachedRuntime;
+  }
+
+  const config = parseProxyConfig(env);
+  assertWorkerOpenclawBaseUrl(config);
+  const app = createProxyApp({ config, logger });
+
+  cachedRuntime = {
+    key,
+    app,
+    config,
+  };
+  return cachedRuntime;
+}
+
+function isLoopbackHostname(hostname: string): boolean {
+  const normalized = hostname.toLowerCase();
+  if (
+    normalized === "localhost" ||
+    normalized === "::1" ||
+    normalized === "0.0.0.0"
+  ) {
+    return true;
+  }
+
+  const ipv4Match = normalized.match(/^(\d{1,3})(?:\.(\d{1,3})){3}$/);
+  if (!ipv4Match) {
+    return false;
+  }
+
+  const segments = normalized.split(".").map(Number);
+  if (segments.some((segment) => Number.isNaN(segment) || segment > 255)) {
+    return false;
+  }
+
+  return segments[0] === 127;
+}
+
+function assertWorkerOpenclawBaseUrl(config: ProxyConfig): void {
+  if (config.environment === "local" || config.environment === "test") {
+    return;
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(config.openclawBaseUrl);
+  } catch {
+    throw new ProxyConfigError("Proxy configuration is invalid", {
+      fieldErrors: {
+        OPENCLAW_BASE_URL: ["OPENCLAW_BASE_URL must be a valid absolute URL"],
+      },
+      formErrors: [],
+    });
+  }
+
+  if (
+    config.openclawBaseUrl === DEFAULT_OPENCLAW_BASE_URL ||
+    isLoopbackHostname(parsed.hostname)
+  ) {
+    throw new ProxyConfigError("Proxy configuration is invalid", {
+      fieldErrors: {
+        OPENCLAW_BASE_URL: [
+          "OPENCLAW_BASE_URL must be an externally reachable URL for deployed Worker environments",
+        ],
+      },
+      formErrors: [],
+    });
+  }
+}
+
+function toConfigErrorResponse(error: ProxyConfigError): Response {
+  logger.error(error.message, {
+    code: error.code,
+    details: error.details,
+  });
+
+  return Response.json(
+    {
+      error: {
+        code: error.code,
+        message: error.message,
+        details: error.details,
+      },
+    },
+    { status: error.status },
+  );
+}
+
+const worker = {
+  fetch(
+    request: Request,
+    env: ProxyWorkerBindings,
+    executionCtx: ExecutionContext,
+  ): Response | Promise<Response> {
+    try {
+      const runtime = buildRuntime(env);
+      return runtime.app.fetch(request, env, executionCtx);
+    } catch (error) {
+      if (error instanceof ProxyConfigError) {
+        return toConfigErrorResponse(error);
+      }
+
+      logger.error("Unhandled proxy worker startup error", {
+        errorName: error instanceof Error ? error.name : "unknown",
+      });
+      return Response.json(
+        {
+          error: {
+            code: "PROXY_WORKER_STARTUP_FAILED",
+            message: "Proxy worker startup failed",
+          },
+        },
+        { status: 500 },
+      );
+    }
+  },
+};
+
+export default worker;

--- a/apps/proxy/tsconfig.json
+++ b/apps/proxy/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "lib": ["esnext"],
+    "types": ["@cloudflare/workers-types", "node"],
     "outDir": "./dist"
   },
   "include": ["src"]

--- a/apps/proxy/tsup.config.ts
+++ b/apps/proxy/tsup.config.ts
@@ -1,7 +1,13 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: ["src/index.ts", "src/server.ts", "src/bin.ts"],
+  entry: [
+    "src/index.ts",
+    "src/server.ts",
+    "src/node-server.ts",
+    "src/worker.ts",
+    "src/bin.ts",
+  ],
   format: ["esm"],
   dts: true,
   clean: true,

--- a/apps/proxy/wrangler.jsonc
+++ b/apps/proxy/wrangler.jsonc
@@ -1,0 +1,34 @@
+{
+  "$schema": "../../node_modules/wrangler/config-schema.json",
+  "name": "clawdentity-proxy",
+  "main": "src/worker.ts",
+  "compatibility_date": "2025-09-01",
+  "compatibility_flags": ["nodejs_compat"],
+  "env": {
+    "local": {
+      "name": "clawdentity-proxy-local",
+      "vars": {
+        "ENVIRONMENT": "local",
+        "REGISTRY_URL": "https://dev.api.clawdentity.com",
+        "OPENCLAW_BASE_URL": "http://127.0.0.1:18789",
+        "INJECT_IDENTITY_INTO_MESSAGE": "false"
+      }
+    },
+    "development": {
+      "name": "clawdentity-proxy-development",
+      "vars": {
+        "ENVIRONMENT": "development",
+        "REGISTRY_URL": "https://dev.api.clawdentity.com",
+        "INJECT_IDENTITY_INTO_MESSAGE": "false"
+      }
+    },
+    "production": {
+      "name": "clawdentity-proxy",
+      "vars": {
+        "ENVIRONMENT": "production",
+        "REGISTRY_URL": "https://api.clawdentity.com",
+        "INJECT_IDENTITY_INTO_MESSAGE": "false"
+      }
+    }
+  }
+}

--- a/apps/registry/.env.example
+++ b/apps/registry/.env.example
@@ -1,7 +1,15 @@
-# Cloudflare (set via wrangler secret)
-# BOOTSTRAP_SECRET=<random 32-byte hex, one-time bootstrap>
-# REGISTRY_SIGNING_KEY=<Ed25519 private key, base64url>
-# REGISTRY_SIGNING_KEYS=<JSON array of public keys, e.g. [{"kid":"reg-key-1","alg":"EdDSA","crv":"Ed25519","x":"<base64url-public-key>","status":"active"}]>
+# Registry local/development template
+# For local Wrangler development, place active values in .dev.vars.
+# For cloud deploys, set secrets with:
+#   wrangler secret put BOOTSTRAP_SECRET --env <env>
+#   wrangler secret put REGISTRY_SIGNING_KEY --env <env>
+#   wrangler secret put REGISTRY_SIGNING_KEYS --env <env>
 
-# wrangler.jsonc vars (non-secret)
-# ENVIRONMENT=production
+# Wrangler vars (non-secret)
+ENVIRONMENT=development
+APP_VERSION=local-dev
+
+# Secrets
+BOOTSTRAP_SECRET=replace-with-random-secret
+REGISTRY_SIGNING_KEY=replace-with-base64url-ed25519-private-key
+REGISTRY_SIGNING_KEYS=[{"kid":"reg-key-1","alg":"EdDSA","crv":"Ed25519","x":"replace-with-base64url-ed25519-public-key","status":"active"}]

--- a/apps/registry/AGENTS.md
+++ b/apps/registry/AGENTS.md
@@ -23,6 +23,7 @@
 - Preserve `/health` response contract: `{ status, version, environment }`.
 - Keep the worker entrypoint in `src/server.ts`; use `src/index.ts` only as the package export wrapper.
 - Keep environment variables non-secret in `wrangler.jsonc` and secret values out of git.
+- Keep `.dev.vars` and `.env.example` synchronized when adding/changing runtime config fields (`ENVIRONMENT`, `APP_VERSION`, `BOOTSTRAP_SECRET`, `REGISTRY_SIGNING_KEY`, `REGISTRY_SIGNING_KEYS`).
 
 ## Validation
 - Validate config changes with `wrangler check` before deployment.

--- a/package.json
+++ b/package.json
@@ -18,7 +18,10 @@
     "affected:test:local": "nx affected -t lint,format,typecheck,test --base=origin/main --head=HEAD",
     "affected:ci": "nx affected -t lint,format,typecheck,test,build --base=$NX_BASE --head=$NX_HEAD",
     "issues:validate": "node issues/scripts/validate-ticket-set.mjs",
-    "dev:registry:local": "pnpm -F @clawdentity/registry run dev:local"
+    "dev:registry:local": "pnpm -F @clawdentity/registry run dev:local",
+    "dev:proxy": "pnpm -F @clawdentity/proxy run dev",
+    "dev:proxy:development": "pnpm -F @clawdentity/proxy run dev:development",
+    "dev:proxy:fresh": "pnpm -F @clawdentity/proxy run dev:fresh"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.3.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,6 +85,13 @@ importers:
       zod:
         specifier: ^4.1.12
         version: 4.3.6
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: ^4.20260210.0
+        version: 4.20260210.0
+      '@types/node':
+        specifier: ^22.17.2
+        version: 22.19.11
 
   apps/registry:
     dependencies:


### PR DESCRIPTION
## Summary
- add Cloudflare Worker entrypoint for proxy (`apps/proxy/src/worker.ts`) with binding-based config loading
- add Node runtime entrypoint split (`apps/proxy/src/node-server.ts`) and keep `apps/proxy/src/bin.ts` as launcher
- add `apps/proxy/wrangler.jsonc` with `local`, `development`, and `production` environments
- enforce deployed-env safety by rejecting loopback `OPENCLAW_BASE_URL` in Worker runtime
- add missing proxy env docs (`apps/proxy/.env.example`) and update AGENTS/docs for env behavior
- extend CLI OpenClaw setup to persist relay runtime config and support explicit/base-url-driven setup
- expand tests across proxy config/worker/hook route and CLI openclaw flow

## Validation
- `pnpm lint`
- `pnpm -r typecheck`
- `pnpm -r test`
- `pnpm -r build`
- pre-push `nx affected -t lint,format,typecheck,test --base=origin/main --head=HEAD` (passed)

## Notes
- `.dev.vars` remains gitignored; only `.env.example` files are tracked.
- deployed Worker environments no longer hardcode loopback upstream values.
