### PR TITLE
[T03] Add admin invite create/redeem onboarding + PAT issuance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,26 +2,22 @@
 
 ## Purpose
 - Define repository-wide engineering and documentation guardrails for Clawdentity.
-- Keep product docs, issue specs, and execution order in sync.
+- Keep product docs and issue governance in sync with the active GitHub tracker.
 
 ## Core Rules
 - Ship maintainable, non-duplicative changes.
 - Prefer small, testable increments tied to explicit issue IDs.
 - If a simplification/refactor is obvious, include it in the plan and ticket notes.
 
-## Deployment-First Execution
-- Enforce `T00 -> T37 -> T38` before feature implementation.
-- Feature tickets `T01`-`T36` must not proceed until `T38` is complete.
-- Source of truth for sequencing: `issues/EXECUTION_PLAN.md`.
-
-## Issue Governance
-- Ticket schema and quality rules are maintained in `issues/AGENTS.md`.
-- Any dependency/wave changes must update both affected `T*.md` files and `issues/EXECUTION_PLAN.md` in the same change.
+## Execution Governance
+- GitHub issues are the source of truth for sequencing, blockers, and rollout updates.
+- Primary execution tracker: https://github.com/vrknetha/clawdentity/issues/74.
+- Do not use local execution-order files as governance source.
 
 ## Ticket Lifecycle Workflow
 - Operate in a self-serve loop for ticket delivery: pick an issue, execute, and keep GitHub status accurate without waiting for manual reminders.
 - Standard sequence for every ticket:
-  - Select the target issue and confirm blockers from `issues/EXECUTION_PLAN.md` and `issues/T*.md`.
+  - Select the target issue and confirm blockers from the GitHub issue tracker.
   - Start from latest `develop`: `git checkout develop && git pull --ff-only`.
   - Create a feature branch with `feature/` prefix scoped to the ticket.
   - Implement the ticket with tests/docs updates required by the issue definition.
@@ -37,12 +33,12 @@
 ## Documentation Sync
 - `README.md` must reflect current execution model and links to issue governance.
 - `PRD.md` must reflect current rollout order, deployment gating, and verification strategy.
-- If backlog shape changes (`Txx` additions/removals), update README + PRD + execution plan together.
+- If backlog shape changes, update README + PRD + the relevant GitHub issue threads in the same change.
 
 ## Validation Baseline
 - Run and pass: `pnpm lint`, `pnpm -r typecheck`, `pnpm -r test`, `pnpm -r build` for implementation changes.
 - Lint runs at root (`pnpm lint` via `biome check .`), not per-package.
-- For planning/doc changes, verify dependency/order consistency against the current execution source of truth (the in-repo execution plan if present, otherwise the active issue tracker plan).
+- For planning/doc changes, verify dependency/order consistency against the active GitHub issue tracker.
 
 ## Cloudflare Worker & Wrangler Conventions
 - Registry is a **Hono** app deployed as a Cloudflare Worker. Wrangler handles bundling — tsup is only for type generation and local build validation.
@@ -105,13 +101,13 @@
 - Use a full reset only when required for identity reprovisioning, and then also clear `~/.clawdentity/agents/<agent-name>/` before re-onboarding.
 - Skill-only policy: no direct `clawdentity openclaw setup` execution by humans during E2E validation; the agent must run the skill flow and prompt the human only for missing invite code or confirmations.
 
-## T00 Scaffold Best Practices
-- Start T00 by confirming the deployment-first order (`T00 -> T37 -> T38`) and reviewing README/PRD/`issues/EXECUTION_PLAN.md` so documentation mirrors the execution model.
+## Scaffold Best Practices
+- Start by reviewing README, PRD, and the active execution tracker issue so documentation mirrors the execution model.
 - Define the workspace layout now: `apps/registry`, `apps/proxy`, `apps/cli`, `packages/sdk`, and `packages/protocol` (with shared tooling such as `pnpm-workspace.yaml`, `tsconfig.base.json`, and `biome.json`) so downstream tickets have a known structure.
 - Declare placeholder scripts for lint/test/build (e.g., `pnpm -r lint`, `pnpm -r test`, `pnpm -r build`) and identify the expected toolchain (Biome, Vitest, tsup, etc.) so future work can fill implementations without duplication.
-- Document the CI entrypoints (GitHub Actions or another pipeline) that will run the above scripts, so deployment scaffolding (T37/T38) can wire the baseline checks without guessing what belongs in T00.
+- Document the CI entrypoints (GitHub Actions or another pipeline) that will run the above scripts, so deployment scaffolding can wire the baseline checks without guessing what belongs in initial setup.
 
-## T37/T38 Deployment Scaffold Best Practices
+## Deployment Scaffold Best Practices
 - Always separate dev and production via wrangler environments — never use a single top-level D1 binding.
 - Keep `wrangler.jsonc` database IDs in version control (they are not secrets). Secrets go via `wrangler secret put`.
 - Deploy scripts should always run migrations before deploy (`db:migrate:remote && wrangler deploy`) for atomic one-touch deploys.

--- a/PRD.md
+++ b/PRD.md
@@ -179,40 +179,23 @@ Verifier must enforce:
 
 ## 9) Rollout plan
 
-1) **Scaffold baseline (`T00`)**
-2) **Define deployment scaffolding (`T37`)**
-3) **Deploy and verify baseline (`T38`)**
-4) Implement feature backlog (`T01`-`T36`) after deploy gate passes
-5) Execute Phase 2/3 enhancements from HLD after MVP stability
+1) Establish workspace and deployment baseline
+2) Deploy and verify baseline environments and health checks
+3) Execute MVP feature backlog after the deployment gate passes
+4) Execute Phase 2/3 enhancements from HLD after MVP stability
 
 ---
 
 ## 10) Execution plan
 
-Execution plan is defined in [`issues/EXECUTION_PLAN.md`](./issues/EXECUTION_PLAN.md).
+Execution sequencing, dependency management, and wave planning are maintained in the GitHub issue tracker.
 
-### Canonical sequential order
-`T00 -> T37 -> T38 -> T01 -> T02 -> T03 -> T04 -> T05 -> T06 -> T07 -> T08 -> T09 -> T10 -> T11 -> T12 -> T13 -> T14 -> T15 -> T16 -> T17 -> T18 -> T19 -> T20 -> T21 -> T22 -> T23 -> T24 -> T25 -> T26 -> T27 -> T28 -> T29 -> T30 -> T31 -> T32 -> T33 -> T34 -> T35 -> T36`
+Primary tracker: https://github.com/vrknetha/clawdentity/issues/74.
 
-### Parallel waves (after deployment gate)
-- Wave 0: `T00`
-- Wave 1: `T37`
-- Wave 2: `T38`
-- Wave 3: `T01, T10, T20, T25`
-- Wave 4: `T02, T03, T04, T11, T26`
-- Wave 5: `T05, T06, T07, T12, T13, T19`
-- Wave 6: `T08, T09, T14, T15, T22`
-- Wave 7: `T16, T21, T24, T27, T34`
-- Wave 8: `T17, T18, T23, T28, T30, T31, T32, T35`
-- Wave 9: `T29, T36`
-- Wave 10: `T33`
-
-### Issue governance
-Issue authoring and quality rules are enforced in [`issues/AGENTS.md`](./issues/AGENTS.md):
-- standardized schema for each ticket
-- dependency blockers line required
-- refactor opportunities required
-- validation commands required
+Governance rules:
+- Treat GitHub issues as the source of truth for rollout order and blockers.
+- Record dependency or wave changes in tracker issues at the time of change.
+- Keep this PRD and `README.md` aligned with tracker-level execution decisions.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ This repo is a monorepo:
 - Handled by: `apps/registry`, `apps/cli`
 - Invite-gated registration model with admin-issued invite codes.
 - One-agent-per-invite policy for simple quota and abuse control.
-- Feature work is deployment-gated (`T00 -> T37 -> T38`) before backlog execution.
+- Feature work follows a deployment-first gate tracked in GitHub issues.
 
 ### 6) Discovery and first-contact options
 
@@ -288,43 +288,25 @@ No one shares keys/files between agents. Identity is presented per request.
 
 ## Documentation
 
-- **PRD:** see [`PRD.md`](./PRD.md) (MVP product requirements + execution plan)
-- **Issue execution plan:** see [`issues/EXECUTION_PLAN.md`](./issues/EXECUTION_PLAN.md) (deployment-first ordering + waves)
-- **Issue authoring rules:** see [`issues/AGENTS.md`](./issues/AGENTS.md) (required issue schema + blockers policy)
-- **Canonical ticket specs:** `issues/T00.md` through `issues/T38.md` are versioned in-repo.
+- **PRD:** see [`PRD.md`](./PRD.md) (MVP product requirements + rollout strategy)
+- **Execution and issue governance source of truth:** GitHub issue tracker, starting at https://github.com/vrknetha/clawdentity/issues/74.
 
 ---
 
 ## Contributing / Execution
 
-This repo is built as a sequence of small issues with a **deployment-first gate**:
+This repo is delivered through small GitHub issues with a **deployment-first gate**:
 
-1. `T00` — workspace scaffolding
-2. `T37` — deployment scaffolding contract
-3. `T38` — baseline deployment verification
-4. `T01`–`T36` — feature implementation after deploy gate passes
+1. Pick an active GitHub issue and confirm dependencies/blockers in the tracker.
+2. Implement in a feature branch with tests/docs updates.
+3. Run required validation commands.
+4. Open a PR to `develop` and post implementation evidence back on the issue.
 
-### Backlog shape
+### Governance expectations
 
-- Total issue set: `T00`–`T38`
-- Feature tickets `T01`–`T36` explicitly depend on `T38`
-- Parallel execution starts only after Wave 2 (`T38`) completes
-
-### Issue schema
-
-Every issue in [`issues/`](./issues) is standardized to include:
-
-- `Goal`
-- `In Scope`
-- `Out of Scope`
-- `Dependencies` + `Blockers`
-- `Execution Mode`
-- `Parallel Wave`
-- `Required Skills`
-- `Deliverables`
-- `Refactor Opportunities`
-- `Definition of Done`
-- `Validation Steps`
+- Keep issue status aligned with reality (`OPEN` while active, close with evidence when complete).
+- Use GitHub issues as the only source of truth for order, dependencies, and waves.
+- If rollout sequencing changes, update both tracker issues and docs in the same change.
 
 ---
 

--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -8,7 +8,7 @@
 - Keep `src/index.ts` as a pure program builder (`createProgram()`); no side effects on import.
 - Keep `src/bin.ts` as a thin runtime entry only (`parseAsync` + top-level error handling).
 - Implement command groups under `src/commands/*` and register them from `createProgram()`.
-- Keep top-level command contracts stable (`config`, `agent`, `admin`, `api-key`, `verify`, `openclaw`) so automation and docs do not drift.
+- Keep top-level command contracts stable (`config`, `agent`, `admin`, `api-key`, `invite`, `verify`, `openclaw`) so automation and docs do not drift.
 - Reuse shared command helpers from `src/commands/helpers.ts` (especially `withErrorHandling`) instead of duplicating command-level try/catch blocks.
 - Use `process.exitCode` instead of `process.exit()`.
 - Use `@clawdentity/sdk` `createLogger` for runtime logging; avoid direct `console.*` calls in CLI app code.

--- a/apps/cli/src/AGENTS.md
+++ b/apps/cli/src/AGENTS.md
@@ -11,6 +11,9 @@
 - Admin bootstrap command logic should stay in `commands/admin.ts` and remain side-effect-safe: only mutate config after a validated successful registry response.
 - Admin bootstrap must print the one-time PAT before attempting to persist it and depend on `persistBootstrapConfig` so config write failures are surfaced via CLI errors while the operator still sees the PAT.
 - API-key lifecycle command logic should stay in `commands/api-key.ts`; keep create/list/revoke request mapping explicit and keep token exposure limited to create output only.
+- Registry invite lifecycle command logic should stay in `commands/invite.ts`; keep it strictly scoped to registry onboarding invites and separate from `commands/openclaw.ts` peer-relay invite codes.
+- `invite redeem` must print the returned PAT once, then persist config in deterministic order (`registryUrl`, then `apiKey`) so bootstrap/onboarding state is predictable.
+- `invite` command routes must use endpoint constants from `@clawdentity/protocol` (`INVITES_PATH`, `INVITES_REDEEM_PATH`) instead of inline path literals.
 
 ## Verification Flow Contract
 - `verify` must support both raw token input and file-path input without requiring extra flags.
@@ -27,4 +30,5 @@
 - Command tests must capture `stdout`/`stderr` and assert exit-code behavior.
 - Include success, revoked, invalid token, keyset failure, CRL failure, and cache-hit scenarios for `verify`.
 - For OpenClaw invite/setup flow, cover invite encode/decode, config patch idempotency, and missing-file validation.
+- For registry invite flow, cover admin-auth create path, public redeem path, config persistence failures, and command exit-code behavior.
 - Keep tests deterministic by mocking network and filesystem dependencies.

--- a/apps/cli/src/commands/AGENTS.md
+++ b/apps/cli/src/commands/AGENTS.md
@@ -23,6 +23,13 @@
 - `openclaw setup --openclaw-base-url` should only be needed when OpenClaw is not reachable on the default `http://127.0.0.1:18789`.
 - Keep error messages static (no interpolated runtime values); include variable context only in error details/log fields.
 
+## Registry Invite Command Rules
+- `invite create` is for registry onboarding invites only (admin-authenticated), not peer-relay invite-code generation.
+- `invite create` must call `INVITES_PATH` from `@clawdentity/protocol` and include PAT bearer auth from resolved CLI config.
+- `invite redeem` must call `INVITES_REDEEM_PATH` from `@clawdentity/protocol` without PAT auth and must persist returned PAT to local config.
+- `invite redeem` must print the plaintext PAT token once before config persistence so operators can recover from local write failures.
+- Keep registry invite error mapping stable for `400`, `401`, `403`, `404`, `409`, and `5xx` responses.
+
 ## Admin Command Rules
 - `admin bootstrap` must call registry `/v1/admin/bootstrap` with `x-bootstrap-secret` and fail with stable CLI error codes/messages.
 - `admin bootstrap` must import `ADMIN_BOOTSTRAP_PATH` from `@clawdentity/protocol` instead of duplicating endpoint literals in command code/tests.

--- a/apps/cli/src/commands/invite.test.ts
+++ b/apps/cli/src/commands/invite.test.ts
@@ -1,0 +1,325 @@
+import { INVITES_PATH, INVITES_REDEEM_PATH } from "@clawdentity/protocol";
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { setConfigValue } from "../config/manager.js";
+import {
+  createInvite,
+  createInviteCommand,
+  persistRedeemConfig,
+  redeemInvite,
+} from "./invite.js";
+
+const mockFetch = vi.fn<typeof fetch>();
+
+const createJsonResponse = (status: number, body: unknown): Response => {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: vi.fn(async () => body),
+  } as unknown as Response;
+};
+
+async function runInviteCommand(
+  args: string[],
+  input: {
+    fetchImpl?: typeof fetch;
+    resolveConfigImpl?: () => Promise<{ registryUrl: string; apiKey?: string }>;
+    setConfigValueImpl?: typeof setConfigValue;
+  } = {},
+) {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const previousExitCode = process.exitCode;
+
+  const stdoutSpy = vi
+    .spyOn(process.stdout, "write")
+    .mockImplementation((chunk: unknown) => {
+      stdout.push(String(chunk));
+      return true;
+    });
+  const stderrSpy = vi
+    .spyOn(process.stderr, "write")
+    .mockImplementation((chunk: unknown) => {
+      stderr.push(String(chunk));
+      return true;
+    });
+
+  process.exitCode = undefined;
+
+  const command = createInviteCommand({
+    fetchImpl: input.fetchImpl ?? (mockFetch as unknown as typeof fetch),
+    resolveConfigImpl:
+      input.resolveConfigImpl ??
+      (async () => ({
+        registryUrl: "https://api.clawdentity.com",
+        apiKey: "clw_pat_local",
+      })),
+    setConfigValueImpl: input.setConfigValueImpl,
+  });
+  command.configureOutput({
+    writeOut: (message) => stdout.push(message),
+    writeErr: (message) => stderr.push(message),
+    outputError: (message) => stderr.push(message),
+  });
+
+  const root = new Command("clawdentity");
+  root.addCommand(command);
+
+  try {
+    await root.parseAsync(["node", "clawdentity", "invite", ...args]);
+  } finally {
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+  }
+
+  const exitCode = process.exitCode;
+  process.exitCode = previousExitCode;
+
+  return {
+    exitCode,
+    stdout: stdout.join(""),
+    stderr: stderr.join(""),
+  };
+}
+
+describe("invite command helpers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    process.exitCode = undefined;
+  });
+
+  it("creates invite with PAT auth", async () => {
+    mockFetch.mockResolvedValueOnce(
+      createJsonResponse(201, {
+        invite: {
+          id: "01KJ8E2A4F8B10V8R8A6T8XKZ9",
+          code: "clw_invite_123",
+          createdAt: "2026-02-16T00:00:00.000Z",
+          expiresAt: null,
+        },
+      }),
+    );
+
+    const result = await createInvite(
+      {
+        expiresAt: "2026-02-20T00:00:00.000Z",
+      },
+      {
+        fetchImpl: mockFetch as unknown as typeof fetch,
+        resolveConfigImpl: async () => ({
+          registryUrl: "https://api.clawdentity.com",
+          apiKey: "clw_pat_admin",
+        }),
+      },
+    );
+
+    expect(result.invite.code).toBe("clw_invite_123");
+    expect(result.registryUrl).toBe("https://api.clawdentity.com/");
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [calledUrl, calledInit] = mockFetch.mock.calls[0] as [
+      string,
+      RequestInit,
+    ];
+    expect(calledUrl).toBe(`https://api.clawdentity.com${INVITES_PATH}`);
+    expect(calledInit.method).toBe("POST");
+    expect((calledInit.headers as Record<string, string>).authorization).toBe(
+      "Bearer clw_pat_admin",
+    );
+    expect(JSON.parse(String(calledInit.body))).toEqual({
+      expiresAt: "2026-02-20T00:00:00.000Z",
+    });
+  });
+
+  it("fails invite create when local API key is missing", async () => {
+    await expect(
+      createInvite(
+        {},
+        {
+          fetchImpl: mockFetch as unknown as typeof fetch,
+          resolveConfigImpl: async () => ({
+            registryUrl: "https://api.clawdentity.com",
+          }),
+        },
+      ),
+    ).rejects.toMatchObject({
+      code: "CLI_INVITE_MISSING_LOCAL_CREDENTIALS",
+    });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("redeems invite and returns PAT payload", async () => {
+    mockFetch.mockResolvedValueOnce(
+      createJsonResponse(201, {
+        apiKey: {
+          id: "01KJ8E2A4F8B10V8R8A6T8XKZA",
+          name: "invite-issued",
+          token: "clw_pat_invite_token",
+        },
+      }),
+    );
+
+    const result = await redeemInvite(
+      "clw_invite_123",
+      {},
+      {
+        fetchImpl: mockFetch as unknown as typeof fetch,
+        resolveConfigImpl: async () => ({
+          registryUrl: "https://api.clawdentity.com",
+        }),
+      },
+    );
+
+    expect(result.apiKeyToken).toBe("clw_pat_invite_token");
+    expect(result.apiKeyName).toBe("invite-issued");
+    const [calledUrl, calledInit] = mockFetch.mock.calls[0] as [
+      string,
+      RequestInit,
+    ];
+    expect(calledUrl).toBe(`https://api.clawdentity.com${INVITES_REDEEM_PATH}`);
+    expect(calledInit.method).toBe("POST");
+    expect((calledInit.headers as Record<string, string>).authorization).toBe(
+      undefined,
+    );
+    expect(JSON.parse(String(calledInit.body))).toEqual({
+      code: "clw_invite_123",
+    });
+  });
+
+  it("maps invalid invite redeem response", async () => {
+    mockFetch.mockResolvedValueOnce(createJsonResponse(201, { apiKey: {} }));
+
+    await expect(
+      redeemInvite(
+        "clw_invite_123",
+        {},
+        {
+          fetchImpl: mockFetch as unknown as typeof fetch,
+          resolveConfigImpl: async () => ({
+            registryUrl: "https://api.clawdentity.com",
+          }),
+        },
+      ),
+    ).rejects.toMatchObject({
+      code: "CLI_INVITE_REDEEM_INVALID_RESPONSE",
+      message: "Invite redeem response is invalid",
+    });
+  });
+});
+
+describe("persist redeem config", () => {
+  it("saves registry url and api key sequentially", async () => {
+    const setConfigValueMock = vi.fn(async () => {});
+
+    await persistRedeemConfig("https://api.clawdentity.com/", "token", {
+      setConfigValueImpl: setConfigValueMock,
+    });
+
+    expect(setConfigValueMock).toHaveBeenNthCalledWith(
+      1,
+      "registryUrl",
+      "https://api.clawdentity.com/",
+    );
+    expect(setConfigValueMock).toHaveBeenNthCalledWith(2, "apiKey", "token");
+  });
+
+  it("throws CLI error when config persistence fails", async () => {
+    const setConfigValueMock = vi.fn(async () => {
+      throw new Error("disk-full");
+    });
+
+    await expect(
+      persistRedeemConfig("https://api.clawdentity.com/", "token", {
+        setConfigValueImpl: setConfigValueMock,
+      }),
+    ).rejects.toMatchObject({
+      code: "CLI_INVITE_REDEEM_CONFIG_PERSISTENCE_FAILED",
+      message: "Failed to save redeemed API key locally",
+    });
+  });
+});
+
+describe("invite command output", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    process.exitCode = undefined;
+  });
+
+  it("prints invite create output", async () => {
+    mockFetch.mockResolvedValueOnce(
+      createJsonResponse(201, {
+        invite: {
+          id: "01KJ8E2A4F8B10V8R8A6T8XKZ9",
+          code: "clw_invite_123",
+          expiresAt: null,
+        },
+      }),
+    );
+
+    const result = await runInviteCommand(["create"]);
+
+    expect(result.exitCode).toBeUndefined();
+    expect(result.stdout).toContain("Invite created");
+    expect(result.stdout).toContain("Code: clw_invite_123");
+    expect(result.stdout).toContain("Expires At: never");
+  });
+
+  it("prints token once and saves config for redeem", async () => {
+    mockFetch.mockResolvedValueOnce(
+      createJsonResponse(201, {
+        apiKey: {
+          id: "01KJ8E2A4F8B10V8R8A6T8XKZA",
+          name: "invite-issued",
+          token: "clw_pat_invite_token",
+        },
+      }),
+    );
+    const setConfigValueMock = vi.fn(async () => {});
+
+    const result = await runInviteCommand(["redeem", "clw_invite_123"], {
+      setConfigValueImpl: setConfigValueMock,
+      resolveConfigImpl: async () => ({
+        registryUrl: "https://api.clawdentity.com",
+      }),
+    });
+
+    expect(result.exitCode).toBeUndefined();
+    expect(result.stdout).toContain("Invite redeemed");
+    expect(result.stdout).toContain("API key token (shown once):");
+    expect(result.stdout).toContain("clw_pat_invite_token");
+    expect(result.stdout).toContain("API key saved to local config");
+    expect(setConfigValueMock).toHaveBeenNthCalledWith(
+      1,
+      "registryUrl",
+      "https://api.clawdentity.com/",
+    );
+    expect(setConfigValueMock).toHaveBeenNthCalledWith(
+      2,
+      "apiKey",
+      "clw_pat_invite_token",
+    );
+  });
+
+  it("sets exit code and stderr on create failure", async () => {
+    mockFetch.mockResolvedValueOnce(
+      createJsonResponse(403, {
+        error: {
+          code: "ADMIN_ONLY",
+          message: "admin role required",
+        },
+      }),
+    );
+
+    const result = await runInviteCommand(["create"]);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("Invite creation requires admin access");
+  });
+});

--- a/apps/cli/src/commands/invite.ts
+++ b/apps/cli/src/commands/invite.ts
@@ -1,0 +1,505 @@
+import { INVITES_PATH, INVITES_REDEEM_PATH } from "@clawdentity/protocol";
+import { AppError, createLogger } from "@clawdentity/sdk";
+import { Command } from "commander";
+import {
+  type CliConfig,
+  resolveConfig,
+  setConfigValue,
+} from "../config/manager.js";
+import { writeStdoutLine } from "../io.js";
+import { withErrorHandling } from "./helpers.js";
+
+const logger = createLogger({ service: "cli", module: "invite" });
+
+type InviteCreateOptions = {
+  expiresAt?: string;
+  registryUrl?: string;
+};
+
+type InviteRedeemOptions = {
+  registryUrl?: string;
+};
+
+type InviteRecord = {
+  code: string;
+  id?: string;
+  createdAt?: string;
+  expiresAt?: string | null;
+};
+
+export type InviteCreateResult = {
+  invite: InviteRecord;
+  registryUrl: string;
+};
+
+export type InviteRedeemResult = {
+  apiKeyToken: string;
+  apiKeyId?: string;
+  apiKeyName?: string;
+  registryUrl: string;
+};
+
+type RegistryErrorEnvelope = {
+  error?: {
+    code?: string;
+    message?: string;
+  };
+};
+
+type InviteDependencies = {
+  fetchImpl?: typeof fetch;
+  resolveConfigImpl?: () => Promise<CliConfig>;
+};
+
+type InvitePersistenceDependencies = {
+  setConfigValueImpl?: typeof setConfigValue;
+};
+
+type InviteCommandDependencies = InviteDependencies &
+  InvitePersistenceDependencies;
+
+type InviteRuntime = {
+  fetchImpl: typeof fetch;
+  registryUrl: string;
+  config: CliConfig;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+  return typeof value === "object" && value !== null;
+};
+
+function parseNonEmptyString(value: unknown): string {
+  if (typeof value !== "string") {
+    return "";
+  }
+
+  return value.trim();
+}
+
+function createCliError(code: string, message: string): AppError {
+  return new AppError({
+    code,
+    message,
+    status: 400,
+  });
+}
+
+function resolveRegistryUrl(input: {
+  overrideRegistryUrl: string | undefined;
+  configRegistryUrl: string;
+}): string {
+  const candidate =
+    parseNonEmptyString(input.overrideRegistryUrl) || input.configRegistryUrl;
+
+  try {
+    return new URL(candidate).toString();
+  } catch {
+    throw createCliError(
+      "CLI_INVITE_INVALID_REGISTRY_URL",
+      "Registry URL is invalid",
+    );
+  }
+}
+
+function requireApiKey(config: CliConfig): string {
+  if (typeof config.apiKey === "string" && config.apiKey.trim().length > 0) {
+    return config.apiKey;
+  }
+
+  throw createCliError(
+    "CLI_INVITE_MISSING_LOCAL_CREDENTIALS",
+    "API key is not configured. Run `clawdentity config set apiKey <token>` or set CLAWDENTITY_API_KEY.",
+  );
+}
+
+function toRegistryRequestUrl(registryUrl: string, path: string): string {
+  const normalizedBaseUrl = registryUrl.endsWith("/")
+    ? registryUrl
+    : `${registryUrl}/`;
+
+  return new URL(path.slice(1), normalizedBaseUrl).toString();
+}
+
+function extractRegistryErrorCode(payload: unknown): string | undefined {
+  if (!isRecord(payload)) {
+    return undefined;
+  }
+
+  const envelope = payload as RegistryErrorEnvelope;
+  if (!envelope.error || typeof envelope.error.code !== "string") {
+    return undefined;
+  }
+
+  const trimmed = envelope.error.code.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function extractRegistryErrorMessage(payload: unknown): string | undefined {
+  if (!isRecord(payload)) {
+    return undefined;
+  }
+
+  const envelope = payload as RegistryErrorEnvelope;
+  if (!envelope.error || typeof envelope.error.message !== "string") {
+    return undefined;
+  }
+
+  const trimmed = envelope.error.message.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+async function parseJsonResponse(response: Response): Promise<unknown> {
+  try {
+    return await response.json();
+  } catch {
+    return undefined;
+  }
+}
+
+async function executeInviteRequest(input: {
+  fetchImpl: typeof fetch;
+  url: string;
+  init: RequestInit;
+}): Promise<Response> {
+  try {
+    return await input.fetchImpl(input.url, input.init);
+  } catch {
+    throw createCliError(
+      "CLI_INVITE_REQUEST_FAILED",
+      "Unable to connect to the registry. Check network access and registryUrl.",
+    );
+  }
+}
+
+function mapCreateInviteError(status: number, payload: unknown): string {
+  const errorCode = extractRegistryErrorCode(payload);
+  const registryMessage = extractRegistryErrorMessage(payload);
+
+  if (status === 401) {
+    return registryMessage
+      ? `Registry authentication failed (401): ${registryMessage}`
+      : "Registry authentication failed (401). Check your API key.";
+  }
+
+  if (status === 403) {
+    return registryMessage
+      ? `Invite creation requires admin access (403): ${registryMessage}`
+      : "Invite creation requires admin access (403).";
+  }
+
+  if (status === 400) {
+    return registryMessage
+      ? `Registry rejected invite request (400): ${registryMessage}`
+      : "Registry rejected invite request (400).";
+  }
+
+  if (status >= 500) {
+    return `Registry server error (${status}). Try again later.`;
+  }
+
+  if (errorCode && registryMessage) {
+    return `Invite creation failed (${errorCode}): ${registryMessage}`;
+  }
+
+  if (registryMessage) {
+    return `Invite creation failed (${status}): ${registryMessage}`;
+  }
+
+  return `Invite creation failed (${status})`;
+}
+
+function mapRedeemInviteError(status: number, payload: unknown): string {
+  const errorCode = extractRegistryErrorCode(payload);
+  const registryMessage = extractRegistryErrorMessage(payload);
+
+  if (
+    errorCode === "INVITE_REDEEM_ALREADY_USED" ||
+    errorCode === "INVITE_REDEEM_ALREADY_REDEEMED"
+  ) {
+    return "Invite code has already been redeemed";
+  }
+
+  if (errorCode === "INVITE_REDEEM_EXPIRED") {
+    return "Invite code has expired";
+  }
+
+  if (
+    errorCode === "INVITE_REDEEM_CODE_INVALID" ||
+    errorCode === "INVITE_REDEEM_INVALID_CODE"
+  ) {
+    return "Invite code is invalid";
+  }
+
+  if (status === 400 || status === 404 || status === 409) {
+    return registryMessage
+      ? `Invite redeem failed (${status}): ${registryMessage}`
+      : "Invite code is invalid or unavailable";
+  }
+
+  if (status >= 500) {
+    return `Registry server error (${status}). Try again later.`;
+  }
+
+  if (registryMessage) {
+    return `Invite redeem failed (${status}): ${registryMessage}`;
+  }
+
+  return `Invite redeem failed (${status})`;
+}
+
+function parseInviteRecord(payload: unknown): InviteRecord {
+  if (!isRecord(payload)) {
+    throw createCliError(
+      "CLI_INVITE_CREATE_INVALID_RESPONSE",
+      "Invite response is invalid",
+    );
+  }
+
+  const source = isRecord(payload.invite) ? payload.invite : payload;
+  const code = parseNonEmptyString(source.code);
+  if (code.length === 0) {
+    throw createCliError(
+      "CLI_INVITE_CREATE_INVALID_RESPONSE",
+      "Invite response is invalid",
+    );
+  }
+
+  const invite: InviteRecord = {
+    code,
+  };
+
+  const id = parseNonEmptyString(source.id);
+  if (id.length > 0) {
+    invite.id = id;
+  }
+
+  const createdAt = parseNonEmptyString(source.createdAt);
+  if (createdAt.length > 0) {
+    invite.createdAt = createdAt;
+  }
+
+  if (source.expiresAt === null || typeof source.expiresAt === "string") {
+    invite.expiresAt = source.expiresAt;
+  }
+
+  return invite;
+}
+
+function parseInviteRedeemResponse(
+  payload: unknown,
+): Omit<InviteRedeemResult, "registryUrl"> {
+  if (!isRecord(payload)) {
+    throw createCliError(
+      "CLI_INVITE_REDEEM_INVALID_RESPONSE",
+      "Invite redeem response is invalid",
+    );
+  }
+
+  const apiKeySource = isRecord(payload.apiKey) ? payload.apiKey : payload;
+  const apiKeyToken = parseNonEmptyString(
+    isRecord(payload.apiKey) ? payload.apiKey.token : payload.token,
+  );
+  if (apiKeyToken.length === 0) {
+    throw createCliError(
+      "CLI_INVITE_REDEEM_INVALID_RESPONSE",
+      "Invite redeem response is invalid",
+    );
+  }
+
+  const apiKeyId = parseNonEmptyString(apiKeySource.id);
+  const apiKeyName = parseNonEmptyString(apiKeySource.name);
+
+  return {
+    apiKeyToken,
+    apiKeyId: apiKeyId.length > 0 ? apiKeyId : undefined,
+    apiKeyName: apiKeyName.length > 0 ? apiKeyName : undefined,
+  };
+}
+
+async function resolveInviteRuntime(
+  overrideRegistryUrl: string | undefined,
+  dependencies: InviteDependencies,
+): Promise<InviteRuntime> {
+  const fetchImpl = dependencies.fetchImpl ?? fetch;
+  const resolveConfigImpl = dependencies.resolveConfigImpl ?? resolveConfig;
+  const config = await resolveConfigImpl();
+  const registryUrl = resolveRegistryUrl({
+    overrideRegistryUrl,
+    configRegistryUrl: config.registryUrl,
+  });
+
+  return {
+    fetchImpl,
+    registryUrl,
+    config,
+  };
+}
+
+export async function createInvite(
+  options: InviteCreateOptions,
+  dependencies: InviteDependencies = {},
+): Promise<InviteCreateResult> {
+  const runtime = await resolveInviteRuntime(options.registryUrl, dependencies);
+  const apiKey = requireApiKey(runtime.config);
+
+  const response = await executeInviteRequest({
+    fetchImpl: runtime.fetchImpl,
+    url: toRegistryRequestUrl(runtime.registryUrl, INVITES_PATH),
+    init: {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${apiKey}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        expiresAt: parseNonEmptyString(options.expiresAt) || undefined,
+      }),
+    },
+  });
+
+  const responseBody = await parseJsonResponse(response);
+  if (!response.ok) {
+    throw createCliError(
+      "CLI_INVITE_CREATE_FAILED",
+      mapCreateInviteError(response.status, responseBody),
+    );
+  }
+
+  return {
+    invite: parseInviteRecord(responseBody),
+    registryUrl: runtime.registryUrl,
+  };
+}
+
+export async function redeemInvite(
+  code: string,
+  options: InviteRedeemOptions,
+  dependencies: InviteDependencies = {},
+): Promise<InviteRedeemResult> {
+  const inviteCode = parseNonEmptyString(code);
+  if (inviteCode.length === 0) {
+    throw createCliError(
+      "CLI_INVITE_REDEEM_CODE_REQUIRED",
+      "Invite code is required",
+    );
+  }
+
+  const runtime = await resolveInviteRuntime(options.registryUrl, dependencies);
+  const response = await executeInviteRequest({
+    fetchImpl: runtime.fetchImpl,
+    url: toRegistryRequestUrl(runtime.registryUrl, INVITES_REDEEM_PATH),
+    init: {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ code: inviteCode }),
+    },
+  });
+
+  const responseBody = await parseJsonResponse(response);
+  if (!response.ok) {
+    throw createCliError(
+      "CLI_INVITE_REDEEM_FAILED",
+      mapRedeemInviteError(response.status, responseBody),
+    );
+  }
+
+  return {
+    ...parseInviteRedeemResponse(responseBody),
+    registryUrl: runtime.registryUrl,
+  };
+}
+
+export async function persistRedeemConfig(
+  registryUrl: string,
+  apiKeyToken: string,
+  dependencies: InvitePersistenceDependencies = {},
+): Promise<void> {
+  const setConfigValueImpl = dependencies.setConfigValueImpl ?? setConfigValue;
+
+  try {
+    await setConfigValueImpl("registryUrl", registryUrl);
+    await setConfigValueImpl("apiKey", apiKeyToken);
+  } catch (error) {
+    logger.warn("cli.invite_redeem_config_persist_failed", {
+      errorName: error instanceof Error ? error.name : "unknown",
+    });
+    throw createCliError(
+      "CLI_INVITE_REDEEM_CONFIG_PERSISTENCE_FAILED",
+      "Failed to save redeemed API key locally",
+    );
+  }
+}
+
+export const createInviteCommand = (
+  dependencies: InviteCommandDependencies = {},
+): Command => {
+  const inviteCommand = new Command("invite").description(
+    "Manage registry onboarding invites (not OpenClaw peer relay invites)",
+  );
+
+  inviteCommand
+    .command("create")
+    .description("Create a registry invite code (admin only)")
+    .option("--expires-at <timestamp>", "Optional invite expiry (ISO-8601)")
+    .option("--registry-url <url>", "Override registry URL")
+    .action(
+      withErrorHandling(
+        "invite create",
+        async (options: InviteCreateOptions) => {
+          const result = await createInvite(options, dependencies);
+
+          logger.info("cli.invite_created", {
+            code: result.invite.code,
+            id: result.invite.id,
+            registryUrl: result.registryUrl,
+          });
+
+          writeStdoutLine("Invite created");
+          writeStdoutLine(`Code: ${result.invite.code}`);
+          if (result.invite.id) {
+            writeStdoutLine(`ID: ${result.invite.id}`);
+          }
+
+          writeStdoutLine(`Expires At: ${result.invite.expiresAt ?? "never"}`);
+        },
+      ),
+    );
+
+  inviteCommand
+    .command("redeem <code>")
+    .description("Redeem a registry invite code and store PAT locally")
+    .option("--registry-url <url>", "Override registry URL")
+    .action(
+      withErrorHandling(
+        "invite redeem",
+        async (code: string, options: InviteRedeemOptions) => {
+          const result = await redeemInvite(code, options, dependencies);
+
+          logger.info("cli.invite_redeemed", {
+            apiKeyId: result.apiKeyId,
+            apiKeyName: result.apiKeyName,
+            registryUrl: result.registryUrl,
+          });
+
+          writeStdoutLine("Invite redeemed");
+          if (result.apiKeyName) {
+            writeStdoutLine(`API key name: ${result.apiKeyName}`);
+          }
+
+          writeStdoutLine("API key token (shown once):");
+          writeStdoutLine(result.apiKeyToken);
+
+          await persistRedeemConfig(
+            result.registryUrl,
+            result.apiKeyToken,
+            dependencies,
+          );
+          writeStdoutLine("API key saved to local config");
+        },
+      ),
+    );
+
+  return inviteCommand;
+};

--- a/apps/cli/src/index.test.ts
+++ b/apps/cli/src/index.test.ts
@@ -58,6 +58,14 @@ describe("cli", () => {
     expect(hasOpenclawCommand).toBe(true);
   });
 
+  it("registers the invite command", () => {
+    const hasInviteCommand = createProgram()
+      .commands.map((command) => command.name())
+      .includes("invite");
+
+    expect(hasInviteCommand).toBe(true);
+  });
+
   it("prints version output", async () => {
     const output: string[] = [];
     const program = createProgram();

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -3,6 +3,7 @@ import { createAdminCommand } from "./commands/admin.js";
 import { createAgentCommand } from "./commands/agent.js";
 import { createApiKeyCommand } from "./commands/api-key.js";
 import { createConfigCommand } from "./commands/config.js";
+import { createInviteCommand } from "./commands/invite.js";
 import { createOpenclawCommand } from "./commands/openclaw.js";
 import { createVerifyCommand } from "./commands/verify.js";
 
@@ -16,6 +17,7 @@ export const createProgram = (): Command => {
     .addCommand(createAgentCommand())
     .addCommand(createApiKeyCommand())
     .addCommand(createConfigCommand())
+    .addCommand(createInviteCommand())
     .addCommand(createOpenclawCommand())
     .addCommand(createVerifyCommand());
 };

--- a/apps/registry/src/AGENTS.md
+++ b/apps/registry/src/AGENTS.md
@@ -62,6 +62,21 @@
 - Keep ordering deterministic (`id` descending) and compute `nextCursor` from the last item in the returned page.
 - Keep error detail exposure environment-aware via `shouldExposeVerboseErrors`: generic 400 message in `production`, detailed `fieldErrors` in `development`/`test`.
 
+## POST /v1/invites Contract
+- Require PAT auth via `createApiKeyAuth`.
+- Enforce admin-only access with explicit `403 INVITE_CREATE_FORBIDDEN` for authenticated non-admin callers.
+- Validate payload in a dedicated helper module (`invite-lifecycle.ts`) and keep malformed-json handling environment-aware (`INVITE_CREATE_INVALID`).
+- Generate invite codes server-side only; never accept client-supplied codes for create.
+- Persist one invite row per request in `invites` with `redeemed_by = null` and optional `expires_at`.
+
+## POST /v1/invites/redeem Contract
+- Public endpoint: no PAT required.
+- Validate payload in `invite-lifecycle.ts` with explicit error code `INVITE_REDEEM_INVALID`.
+- One-time semantics are enforced by guarded update (`redeemed_by IS NULL`); repeated redeem attempts must return explicit invite lifecycle errors.
+- Expired invites must be rejected with `INVITE_REDEEM_EXPIRED` before token issuance.
+- Successful redeem must create a new active user human and mint a PAT in the same mutation unit as invite consumption.
+- Keep mutation flow transaction-first; on local fallback (no transaction support), apply compensation rollback so failed redeem attempts do not leave partially-created humans or consumed invites.
+
 ## POST /v1/me/api-keys Contract
 - Require PAT auth via `createApiKeyAuth`; unauthenticated calls must fail before payload parsing.
 - Accept optional `{ name }`; default to `api-key` when omitted.

--- a/apps/registry/src/invite-lifecycle.ts
+++ b/apps/registry/src/invite-lifecycle.ts
@@ -1,0 +1,287 @@
+import { encodeBase64url } from "@clawdentity/protocol";
+import {
+  AppError,
+  type RegistryConfig,
+  shouldExposeVerboseErrors,
+} from "@clawdentity/sdk";
+
+const DEFAULT_INVITE_REDEEM_DISPLAY_NAME = "User";
+const DEFAULT_INVITE_REDEEM_API_KEY_NAME = "invite";
+const MAX_DISPLAY_NAME_LENGTH = 64;
+const MAX_API_KEY_NAME_LENGTH = 64;
+const MAX_INVITE_CODE_LENGTH = 128;
+const INVITE_CODE_PREFIX = "clw_inv_";
+const INVITE_CODE_RANDOM_BYTES = 24;
+
+type InviteCreatePayload = {
+  expiresAt: string | null;
+};
+
+type InviteRedeemPayload = {
+  code: string;
+  displayName: string;
+  apiKeyName: string;
+};
+
+function hasControlChars(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code <= 31 || code === 127) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function parseOptionalTrimmedString(value: unknown): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function inviteCreateInvalidError(options: {
+  environment: RegistryConfig["ENVIRONMENT"];
+  details?: {
+    fieldErrors: Record<string, string[]>;
+    formErrors: string[];
+  };
+}): AppError {
+  const exposeDetails = shouldExposeVerboseErrors(options.environment);
+  return new AppError({
+    code: "INVITE_CREATE_INVALID",
+    message: exposeDetails
+      ? "Invite create payload is invalid"
+      : "Request could not be processed",
+    status: 400,
+    expose: exposeDetails,
+    details: exposeDetails ? options.details : undefined,
+  });
+}
+
+function inviteRedeemInvalidError(options: {
+  environment: RegistryConfig["ENVIRONMENT"];
+  details?: {
+    fieldErrors: Record<string, string[]>;
+    formErrors: string[];
+  };
+}): AppError {
+  const exposeDetails = shouldExposeVerboseErrors(options.environment);
+  return new AppError({
+    code: "INVITE_REDEEM_INVALID",
+    message: exposeDetails
+      ? "Invite redeem payload is invalid"
+      : "Request could not be processed",
+    status: 400,
+    expose: exposeDetails,
+    details: exposeDetails ? options.details : undefined,
+  });
+}
+
+export function parseInviteCreatePayload(input: {
+  payload: unknown;
+  environment: RegistryConfig["ENVIRONMENT"];
+  now: Date;
+}): InviteCreatePayload {
+  if (
+    typeof input.payload !== "object" ||
+    input.payload === null ||
+    Array.isArray(input.payload)
+  ) {
+    throw inviteCreateInvalidError({
+      environment: input.environment,
+      details: {
+        fieldErrors: {
+          body: ["body must be a JSON object"],
+        },
+        formErrors: [],
+      },
+    });
+  }
+
+  const payload = input.payload as Record<string, unknown>;
+  const fieldErrors: Record<string, string[]> = {};
+
+  if (
+    payload.expiresAt !== undefined &&
+    payload.expiresAt !== null &&
+    typeof payload.expiresAt !== "string"
+  ) {
+    fieldErrors.expiresAt = ["expiresAt must be a string or null"];
+  }
+
+  let expiresAt: string | null = null;
+  if (typeof payload.expiresAt === "string") {
+    const expiresAtInput = payload.expiresAt.trim();
+    if (expiresAtInput.length === 0) {
+      fieldErrors.expiresAt = ["expiresAt must not be empty"];
+    } else {
+      const expiresAtMillis = Date.parse(expiresAtInput);
+      if (!Number.isFinite(expiresAtMillis)) {
+        fieldErrors.expiresAt = ["expiresAt must be a valid ISO-8601 datetime"];
+      } else if (expiresAtMillis <= input.now.getTime()) {
+        fieldErrors.expiresAt = ["expiresAt must be in the future"];
+      } else {
+        expiresAt = new Date(expiresAtMillis).toISOString();
+      }
+    }
+  }
+
+  if (Object.keys(fieldErrors).length > 0) {
+    throw inviteCreateInvalidError({
+      environment: input.environment,
+      details: { fieldErrors, formErrors: [] },
+    });
+  }
+
+  return { expiresAt };
+}
+
+export function parseInviteRedeemPayload(input: {
+  payload: unknown;
+  environment: RegistryConfig["ENVIRONMENT"];
+}): InviteRedeemPayload {
+  if (
+    typeof input.payload !== "object" ||
+    input.payload === null ||
+    Array.isArray(input.payload)
+  ) {
+    throw inviteRedeemInvalidError({
+      environment: input.environment,
+      details: {
+        fieldErrors: {
+          body: ["body must be a JSON object"],
+        },
+        formErrors: [],
+      },
+    });
+  }
+
+  const payload = input.payload as Record<string, unknown>;
+  const fieldErrors: Record<string, string[]> = {};
+
+  if (typeof payload.code !== "string") {
+    fieldErrors.code = ["code is required"];
+  }
+
+  const code = typeof payload.code === "string" ? payload.code.trim() : "";
+  if (code.length === 0 && !fieldErrors.code) {
+    fieldErrors.code = ["code is required"];
+  } else if (code.length > MAX_INVITE_CODE_LENGTH) {
+    fieldErrors.code = [
+      `code must be at most ${MAX_INVITE_CODE_LENGTH} characters`,
+    ];
+  }
+
+  if (
+    payload.displayName !== undefined &&
+    typeof payload.displayName !== "string"
+  ) {
+    fieldErrors.displayName = ["displayName must be a string"];
+  }
+
+  if (
+    payload.apiKeyName !== undefined &&
+    typeof payload.apiKeyName !== "string"
+  ) {
+    fieldErrors.apiKeyName = ["apiKeyName must be a string"];
+  }
+
+  const displayNameInput = parseOptionalTrimmedString(payload.displayName);
+  if (
+    payload.displayName !== undefined &&
+    displayNameInput === undefined &&
+    !fieldErrors.displayName
+  ) {
+    fieldErrors.displayName = ["displayName must not be empty"];
+  }
+
+  const apiKeyNameInput = parseOptionalTrimmedString(payload.apiKeyName);
+  if (
+    payload.apiKeyName !== undefined &&
+    apiKeyNameInput === undefined &&
+    !fieldErrors.apiKeyName
+  ) {
+    fieldErrors.apiKeyName = ["apiKeyName must not be empty"];
+  }
+
+  const displayName = displayNameInput ?? DEFAULT_INVITE_REDEEM_DISPLAY_NAME;
+  const apiKeyName = apiKeyNameInput ?? DEFAULT_INVITE_REDEEM_API_KEY_NAME;
+
+  if (displayName.length > MAX_DISPLAY_NAME_LENGTH) {
+    fieldErrors.displayName = [
+      `displayName must be at most ${MAX_DISPLAY_NAME_LENGTH} characters`,
+    ];
+  } else if (hasControlChars(displayName)) {
+    fieldErrors.displayName = ["displayName contains control characters"];
+  }
+
+  if (apiKeyName.length > MAX_API_KEY_NAME_LENGTH) {
+    fieldErrors.apiKeyName = [
+      `apiKeyName must be at most ${MAX_API_KEY_NAME_LENGTH} characters`,
+    ];
+  } else if (hasControlChars(apiKeyName)) {
+    fieldErrors.apiKeyName = ["apiKeyName contains control characters"];
+  }
+
+  if (Object.keys(fieldErrors).length > 0) {
+    throw inviteRedeemInvalidError({
+      environment: input.environment,
+      details: { fieldErrors, formErrors: [] },
+    });
+  }
+
+  return {
+    code,
+    displayName,
+    apiKeyName,
+  };
+}
+
+export function generateInviteCode(): string {
+  const bytes = new Uint8Array(INVITE_CODE_RANDOM_BYTES);
+  crypto.getRandomValues(bytes);
+  return `${INVITE_CODE_PREFIX}${encodeBase64url(bytes)}`;
+}
+
+export function inviteCreateForbiddenError(): AppError {
+  return new AppError({
+    code: "INVITE_CREATE_FORBIDDEN",
+    message: "Admin role is required",
+    status: 403,
+    expose: true,
+  });
+}
+
+export function inviteRedeemCodeInvalidError(): AppError {
+  return new AppError({
+    code: "INVITE_REDEEM_CODE_INVALID",
+    message: "Invite code is invalid",
+    status: 400,
+    expose: true,
+  });
+}
+
+export function inviteRedeemExpiredError(): AppError {
+  return new AppError({
+    code: "INVITE_REDEEM_EXPIRED",
+    message: "Invite code has expired",
+    status: 400,
+    expose: true,
+  });
+}
+
+export function inviteRedeemAlreadyUsedError(): AppError {
+  return new AppError({
+    code: "INVITE_REDEEM_ALREADY_USED",
+    message: "Invite code has already been redeemed",
+    status: 409,
+    expose: true,
+  });
+}

--- a/apps/registry/src/server.test.ts
+++ b/apps/registry/src/server.test.ts
@@ -5,6 +5,8 @@ import {
   canonicalizeAgentRegistrationProof,
   encodeBase64url,
   generateUlid,
+  INVITES_PATH,
+  INVITES_REDEEM_PATH,
   ME_API_KEYS_PATH,
   makeAgentDid,
   makeHumanDid,
@@ -105,6 +107,8 @@ type FakeAgentUpdateRow = Record<string, unknown>;
 type FakeRevocationInsertRow = Record<string, unknown>;
 type FakeAgentRegistrationChallengeInsertRow = Record<string, unknown>;
 type FakeAgentRegistrationChallengeUpdateRow = Record<string, unknown>;
+type FakeInviteInsertRow = Record<string, unknown>;
+type FakeInviteUpdateRow = Record<string, unknown>;
 type FakeRevocationRow = {
   id: string;
   jti: string;
@@ -136,6 +140,15 @@ type FakeAgentRegistrationChallengeRow = {
   createdAt: string;
   updatedAt: string;
 };
+type FakeInviteRow = {
+  id: string;
+  code: string;
+  createdBy: string;
+  redeemedBy: string | null;
+  agentId: string | null;
+  expiresAt: string | null;
+  createdAt: string;
+};
 
 type FakeAgentSelectRow = {
   id: string;
@@ -156,6 +169,7 @@ type FakeDbOptions = {
   beforeFirstAgentUpdate?: (agentRows: FakeAgentRow[]) => void;
   failApiKeyInsertCount?: number;
   failBeginTransaction?: boolean;
+  inviteRows?: FakeInviteRow[];
   revocationRows?: FakeRevocationRow[];
   registrationChallengeRows?: FakeAgentRegistrationChallengeRow[];
 };
@@ -706,6 +720,83 @@ function resolveAgentRegistrationChallengeSelectRows(options: {
     .slice(0, limit);
 }
 
+function getInviteSelectColumnValue(
+  row: FakeInviteRow,
+  column: string,
+): unknown {
+  if (column === "id") {
+    return row.id;
+  }
+  if (column === "code") {
+    return row.code;
+  }
+  if (column === "created_by") {
+    return row.createdBy;
+  }
+  if (column === "redeemed_by") {
+    return row.redeemedBy;
+  }
+  if (column === "agent_id") {
+    return row.agentId;
+  }
+  if (column === "expires_at") {
+    return row.expiresAt;
+  }
+  if (column === "created_at") {
+    return row.createdAt;
+  }
+  return undefined;
+}
+
+function resolveInviteSelectRows(options: {
+  query: string;
+  params: unknown[];
+  inviteRows: FakeInviteRow[];
+}): FakeInviteRow[] {
+  const whereClause = extractWhereClause(options.query);
+  const equalityParams = parseWhereEqualityParams({
+    whereClause,
+    params: options.params,
+  });
+  const hasCodeFilter = hasFilter(whereClause, "code");
+  const hasIdFilter = hasFilter(whereClause, "id");
+  const hasRedeemedByFilter = hasFilter(whereClause, "redeemed_by");
+  const hasLimitClause = options.query.toLowerCase().includes(" limit ");
+
+  const codeFilter =
+    hasCodeFilter && typeof equalityParams.values.code?.[0] === "string"
+      ? String(equalityParams.values.code[0])
+      : undefined;
+  const idFilter =
+    hasIdFilter && typeof equalityParams.values.id?.[0] === "string"
+      ? String(equalityParams.values.id[0])
+      : undefined;
+  const redeemedByFilter = hasRedeemedByFilter
+    ? (equalityParams.values.redeemed_by?.[0] as string | null | undefined)
+    : undefined;
+
+  const requiresRedeemedByNull =
+    whereClause.includes("redeemed_by") && whereClause.includes("is null");
+
+  const maybeLimit = hasLimitClause
+    ? Number(options.params[options.params.length - 1])
+    : Number.NaN;
+  const limit = Number.isFinite(maybeLimit)
+    ? maybeLimit
+    : options.inviteRows.length;
+
+  return options.inviteRows
+    .filter((row) => (codeFilter ? row.code === codeFilter : true))
+    .filter((row) => (idFilter ? row.id === idFilter : true))
+    .filter((row) =>
+      redeemedByFilter !== undefined
+        ? row.redeemedBy === redeemedByFilter
+        : true,
+    )
+    .filter((row) => (requiresRedeemedByNull ? row.redeemedBy === null : true))
+    .slice(0, limit);
+}
+
 function getCrlSelectColumnValue(
   row: FakeCrlSelectRow,
   column: string,
@@ -781,10 +872,13 @@ function createFakeDb(
     [];
   const agentRegistrationChallengeUpdates: FakeAgentRegistrationChallengeUpdateRow[] =
     [];
+  const inviteInserts: FakeInviteInsertRow[] = [];
+  const inviteUpdates: FakeInviteUpdateRow[] = [];
   const revocationRows = [...(options.revocationRows ?? [])];
   const registrationChallengeRows = [
     ...(options.registrationChallengeRows ?? []),
   ];
+  const inviteRows = [...(options.inviteRows ?? [])];
   const humanRows = rows.reduce<FakeHumanRow[]>((acc, row) => {
     if (acc.some((item) => item.id === row.humanId)) {
       return acc;
@@ -980,6 +1074,35 @@ function createFakeDb(
             };
           }
           if (
+            (normalizedQuery.includes('from "invites"') ||
+              normalizedQuery.includes("from invites")) &&
+            (normalizedQuery.includes("select") ||
+              normalizedQuery.includes("returning"))
+          ) {
+            const resultRows = resolveInviteSelectRows({
+              query,
+              params,
+              inviteRows,
+            });
+            const selectedColumns = parseSelectedColumns(query);
+
+            return {
+              results: resultRows.map((row) => {
+                if (selectedColumns.length === 0) {
+                  return row;
+                }
+
+                return selectedColumns.reduce<Record<string, unknown>>(
+                  (acc, column) => {
+                    acc[column] = getInviteSelectColumnValue(row, column);
+                    return acc;
+                  },
+                  {},
+                );
+              }),
+            };
+          }
+          if (
             (normalizedQuery.includes('from "revocations"') ||
               normalizedQuery.includes("from revocations")) &&
             normalizedQuery.includes("select")
@@ -1091,6 +1214,22 @@ function createFakeDb(
             return resultRows.map((row) =>
               selectedColumns.map((column) =>
                 getAgentRegistrationChallengeSelectColumnValue(row, column),
+              ),
+            );
+          }
+          if (
+            normalizedQuery.includes('from "invites"') ||
+            normalizedQuery.includes("from invites")
+          ) {
+            const resultRows = resolveInviteSelectRows({
+              query,
+              params,
+              inviteRows,
+            });
+            const selectedColumns = parseSelectedColumns(query);
+            return resultRows.map((row) =>
+              selectedColumns.map((column) =>
+                getInviteSelectColumnValue(row, column),
               ),
             );
           }
@@ -1276,6 +1415,107 @@ function createFakeDb(
             }
 
             changes = 1;
+          }
+          if (
+            normalizedQuery.includes('insert into "invites"') ||
+            normalizedQuery.includes("insert into invites")
+          ) {
+            const columns = parseInsertColumns(query, "invites");
+            const row = columns.reduce<FakeInviteInsertRow>(
+              (acc, column, index) => {
+                acc[column] = params[index];
+                return acc;
+              },
+              {},
+            );
+            inviteInserts.push(row);
+
+            if (
+              typeof row.id === "string" &&
+              typeof row.code === "string" &&
+              typeof row.created_by === "string" &&
+              typeof row.created_at === "string"
+            ) {
+              inviteRows.push({
+                id: row.id,
+                code: row.code,
+                createdBy: row.created_by,
+                redeemedBy:
+                  typeof row.redeemed_by === "string" ? row.redeemed_by : null,
+                agentId: typeof row.agent_id === "string" ? row.agent_id : null,
+                expiresAt:
+                  typeof row.expires_at === "string" ? row.expires_at : null,
+                createdAt: row.created_at,
+              });
+            }
+
+            changes = 1;
+          }
+          if (
+            normalizedQuery.includes('update "invites"') ||
+            normalizedQuery.includes("update invites")
+          ) {
+            const setColumns = parseUpdateSetColumns(query, "invites");
+            const nextValues = setColumns.reduce<Record<string, unknown>>(
+              (acc, column, index) => {
+                acc[column] = params[index];
+                return acc;
+              },
+              {},
+            );
+            const whereClause = extractWhereClause(query);
+            const whereParams = params.slice(setColumns.length);
+            const equalityParams = parseWhereEqualityParams({
+              whereClause,
+              params: whereParams,
+            });
+
+            const idFilter =
+              typeof equalityParams.values.id?.[0] === "string"
+                ? String(equalityParams.values.id[0])
+                : undefined;
+            const redeemedByFilter = hasFilter(whereClause, "redeemed_by")
+              ? (equalityParams.values.redeemed_by?.[0] as
+                  | string
+                  | null
+                  | undefined)
+              : undefined;
+            const requiresRedeemedByNull =
+              whereClause.includes("redeemed_by") &&
+              whereClause.includes("is null");
+
+            let matchedRows = 0;
+            for (const row of inviteRows) {
+              if (idFilter && row.id !== idFilter) {
+                continue;
+              }
+              if (requiresRedeemedByNull && row.redeemedBy !== null) {
+                continue;
+              }
+              if (
+                redeemedByFilter !== undefined &&
+                row.redeemedBy !== redeemedByFilter
+              ) {
+                continue;
+              }
+
+              matchedRows += 1;
+              if (
+                typeof nextValues.redeemed_by === "string" ||
+                nextValues.redeemed_by === null
+              ) {
+                row.redeemedBy = nextValues.redeemed_by;
+              }
+            }
+
+            inviteUpdates.push({
+              ...nextValues,
+              id: idFilter,
+              redeemed_by_where: redeemedByFilter,
+              redeemed_by_is_null_where: requiresRedeemedByNull,
+              matched_rows: matchedRows,
+            });
+            changes = matchedRows;
           }
           if (
             normalizedQuery.includes('delete from "humans"') ||
@@ -1588,6 +1828,9 @@ function createFakeDb(
     agentUpdates,
     agentRegistrationChallengeInserts,
     agentRegistrationChallengeUpdates,
+    inviteInserts,
+    inviteUpdates,
+    inviteRows,
     revocationInserts,
     registrationChallengeRows,
   };
@@ -2659,6 +2902,388 @@ describe("GET /v1/me", () => {
     });
     expect(updates).toHaveLength(1);
     expect(updates[0]?.apiKeyId).toBe("key-1");
+  });
+});
+
+describe(`POST ${INVITES_PATH}`, () => {
+  it("returns 401 when PAT is missing", async () => {
+    const response = await createRegistryApp().request(
+      INVITES_PATH,
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({}),
+      },
+      { DB: {} as D1Database, ENVIRONMENT: "test" },
+    );
+
+    expect(response.status).toBe(401);
+    const body = (await response.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("API_KEY_MISSING");
+  });
+
+  it("returns 403 when PAT owner is not an admin", async () => {
+    const { token, authRow } = await makeValidPatContext();
+    const { database } = createFakeDb([
+      {
+        ...authRow,
+        humanRole: "user",
+      },
+    ]);
+
+    const response = await createRegistryApp().request(
+      INVITES_PATH,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({}),
+      },
+      { DB: database, ENVIRONMENT: "test" },
+    );
+
+    expect(response.status).toBe(403);
+    const body = (await response.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("INVITE_CREATE_FORBIDDEN");
+  });
+
+  it("returns 400 when payload is invalid", async () => {
+    const { token, authRow } = await makeValidPatContext();
+    const { database } = createFakeDb([authRow]);
+
+    const response = await createRegistryApp().request(
+      INVITES_PATH,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          expiresAt: "not-an-iso-date",
+        }),
+      },
+      { DB: database, ENVIRONMENT: "test" },
+    );
+
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as {
+      error: {
+        code: string;
+        details?: { fieldErrors?: Record<string, string[]> };
+      };
+    };
+    expect(body.error.code).toBe("INVITE_CREATE_INVALID");
+    expect(body.error.details?.fieldErrors?.expiresAt).toEqual([
+      "expiresAt must be a valid ISO-8601 datetime",
+    ]);
+  });
+
+  it("creates invite code and persists invite row", async () => {
+    const { token, authRow } = await makeValidPatContext();
+    const { database, inviteInserts } = createFakeDb([authRow]);
+    const expiresAt = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+
+    const response = await createRegistryApp().request(
+      INVITES_PATH,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          expiresAt,
+        }),
+      },
+      { DB: database, ENVIRONMENT: "test" },
+    );
+
+    expect(response.status).toBe(201);
+    const body = (await response.json()) as {
+      invite: {
+        id: string;
+        code: string;
+        createdBy: string;
+        expiresAt: string | null;
+        createdAt: string;
+      };
+    };
+    expect(body.invite.code.startsWith("clw_inv_")).toBe(true);
+    expect(body.invite.createdBy).toBe("human-1");
+    expect(body.invite.expiresAt).toBe(expiresAt);
+    expect(body.invite.createdAt).toEqual(expect.any(String));
+
+    expect(inviteInserts).toHaveLength(1);
+    expect(inviteInserts[0]?.id).toBe(body.invite.id);
+    expect(inviteInserts[0]?.code).toBe(body.invite.code);
+    expect(inviteInserts[0]?.created_by).toBe("human-1");
+    expect(inviteInserts[0]?.expires_at).toBe(expiresAt);
+  });
+});
+
+describe(`POST ${INVITES_REDEEM_PATH}`, () => {
+  it("returns 400 when payload is invalid", async () => {
+    const response = await createRegistryApp().request(
+      INVITES_REDEEM_PATH,
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({}),
+      },
+      { DB: {} as D1Database, ENVIRONMENT: "test" },
+    );
+
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as {
+      error: {
+        code: string;
+        details?: { fieldErrors?: Record<string, string[]> };
+      };
+    };
+    expect(body.error.code).toBe("INVITE_REDEEM_INVALID");
+    expect(body.error.details?.fieldErrors?.code).toEqual(["code is required"]);
+  });
+
+  it("returns 400 when invite code does not exist", async () => {
+    const { database } = createFakeDb([]);
+
+    const response = await createRegistryApp().request(
+      INVITES_REDEEM_PATH,
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          code: "clw_inv_missing",
+        }),
+      },
+      { DB: database, ENVIRONMENT: "test" },
+    );
+
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("INVITE_REDEEM_CODE_INVALID");
+  });
+
+  it("returns 400 when invite is expired", async () => {
+    const { authRow } = await makeValidPatContext();
+    const { database } = createFakeDb([authRow], [], {
+      inviteRows: [
+        {
+          id: generateUlid(1700700000000),
+          code: "clw_inv_expired",
+          createdBy: "human-1",
+          redeemedBy: null,
+          agentId: null,
+          expiresAt: new Date(Date.now() - 60 * 1000).toISOString(),
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      ],
+    });
+
+    const response = await createRegistryApp().request(
+      INVITES_REDEEM_PATH,
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          code: "clw_inv_expired",
+        }),
+      },
+      { DB: database, ENVIRONMENT: "test" },
+    );
+
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("INVITE_REDEEM_EXPIRED");
+  });
+
+  it("returns 409 when invite is already redeemed", async () => {
+    const { authRow } = await makeValidPatContext();
+    const { database } = createFakeDb([authRow], [], {
+      inviteRows: [
+        {
+          id: generateUlid(1700700001000),
+          code: "clw_inv_redeemed",
+          createdBy: "human-1",
+          redeemedBy: "human-2",
+          agentId: null,
+          expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      ],
+    });
+
+    const response = await createRegistryApp().request(
+      INVITES_REDEEM_PATH,
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          code: "clw_inv_redeemed",
+        }),
+      },
+      { DB: database, ENVIRONMENT: "test" },
+    );
+
+    expect(response.status).toBe(409);
+    const body = (await response.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("INVITE_REDEEM_ALREADY_USED");
+  });
+
+  it("redeems invite and returns PAT that authenticates /v1/me", async () => {
+    const { authRow } = await makeValidPatContext();
+    const inviteCode = "clw_inv_redeem_success";
+    const { database, humanInserts, apiKeyInserts, inviteRows, inviteUpdates } =
+      createFakeDb([authRow], [], {
+        inviteRows: [
+          {
+            id: generateUlid(1700700002000),
+            code: inviteCode,
+            createdBy: "human-1",
+            redeemedBy: null,
+            agentId: null,
+            expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+            createdAt: "2026-01-01T00:00:00.000Z",
+          },
+        ],
+      });
+    const appInstance = createRegistryApp();
+
+    const redeemResponse = await appInstance.request(
+      INVITES_REDEEM_PATH,
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          code: inviteCode,
+          displayName: "Invitee Alpha",
+          apiKeyName: "primary-invite-key",
+        }),
+      },
+      { DB: database, ENVIRONMENT: "test" },
+    );
+
+    expect(redeemResponse.status).toBe(201);
+    const redeemBody = (await redeemResponse.json()) as {
+      human: {
+        id: string;
+        did: string;
+        displayName: string;
+        role: "admin" | "user";
+        status: "active" | "suspended";
+      };
+      apiKey: {
+        id: string;
+        name: string;
+        token: string;
+      };
+    };
+    expect(redeemBody.human.displayName).toBe("Invitee Alpha");
+    expect(redeemBody.human.role).toBe("user");
+    expect(redeemBody.apiKey.name).toBe("primary-invite-key");
+    expect(redeemBody.apiKey.token.startsWith("clw_pat_")).toBe(true);
+
+    expect(humanInserts).toHaveLength(1);
+    expect(apiKeyInserts).toHaveLength(1);
+    expect(apiKeyInserts[0]?.human_id).toBe(redeemBody.human.id);
+    expect(inviteUpdates).toHaveLength(1);
+    expect(inviteRows[0]?.redeemedBy).toBe(redeemBody.human.id);
+
+    const meResponse = await appInstance.request(
+      "/v1/me",
+      {
+        headers: {
+          Authorization: `Bearer ${redeemBody.apiKey.token}`,
+        },
+      },
+      { DB: database, ENVIRONMENT: "test" },
+    );
+
+    expect(meResponse.status).toBe(200);
+    const meBody = (await meResponse.json()) as {
+      human: {
+        id: string;
+        displayName: string;
+        role: "admin" | "user";
+      };
+    };
+    expect(meBody.human.id).toBe(redeemBody.human.id);
+    expect(meBody.human.displayName).toBe("Invitee Alpha");
+    expect(meBody.human.role).toBe("user");
+  });
+
+  it("rolls back fallback mutations when api key insert fails", async () => {
+    const { authRow } = await makeValidPatContext();
+    const inviteCode = "clw_inv_fallback_rollback";
+    const { database, humanRows, inviteRows } = createFakeDb([authRow], [], {
+      failBeginTransaction: true,
+      failApiKeyInsertCount: 1,
+      inviteRows: [
+        {
+          id: generateUlid(1700700003000),
+          code: inviteCode,
+          createdBy: "human-1",
+          redeemedBy: null,
+          agentId: null,
+          expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      ],
+    });
+    const appInstance = createRegistryApp();
+
+    const firstResponse = await appInstance.request(
+      INVITES_REDEEM_PATH,
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          code: inviteCode,
+          displayName: "Fallback Invitee",
+        }),
+      },
+      { DB: database, ENVIRONMENT: "test" },
+    );
+
+    expect(firstResponse.status).toBe(500);
+    expect(humanRows).toHaveLength(1);
+    expect(inviteRows[0]?.redeemedBy).toBeNull();
+
+    const secondResponse = await appInstance.request(
+      INVITES_REDEEM_PATH,
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          code: inviteCode,
+          displayName: "Fallback Invitee",
+        }),
+      },
+      { DB: database, ENVIRONMENT: "test" },
+    );
+
+    expect(secondResponse.status).toBe(201);
+    expect(humanRows).toHaveLength(2);
+    expect(inviteRows[0]?.redeemedBy).toEqual(expect.any(String));
   });
 });
 

--- a/apps/registry/src/server.ts
+++ b/apps/registry/src/server.ts
@@ -2,6 +2,8 @@ import {
   ADMIN_BOOTSTRAP_PATH,
   AGENT_REGISTRATION_CHALLENGE_PATH,
   generateUlid,
+  INVITES_PATH,
+  INVITES_REDEEM_PATH,
   ME_API_KEYS_PATH,
   makeHumanDid,
 } from "@clawdentity/protocol";
@@ -18,7 +20,7 @@ import {
   signAIT,
   signCRL,
 } from "@clawdentity/sdk";
-import { and, desc, eq, lt } from "drizzle-orm";
+import { and, desc, eq, isNull, lt } from "drizzle-orm";
 import { Hono } from "hono";
 import { parseAdminBootstrapPayload } from "./admin-bootstrap.js";
 import { mapAgentListRow, parseAgentListQuery } from "./agent-list.js";
@@ -63,8 +65,18 @@ import {
   agents,
   api_keys,
   humans,
+  invites,
   revocations,
 } from "./db/schema.js";
+import {
+  generateInviteCode,
+  inviteCreateForbiddenError,
+  inviteRedeemAlreadyUsedError,
+  inviteRedeemCodeInvalidError,
+  inviteRedeemExpiredError,
+  parseInviteCreatePayload,
+  parseInviteRedeemPayload,
+} from "./invite-lifecycle.js";
 import {
   createInMemoryRateLimit,
   RESOLVE_RATE_LIMIT_MAX_REQUESTS,
@@ -112,6 +124,15 @@ type OwnedAgentRegistrationChallenge = {
   status: "pending" | "used";
   expires_at: string;
   used_at: string | null;
+};
+
+type InviteRow = {
+  id: string;
+  code: string;
+  created_by: string;
+  redeemed_by: string | null;
+  expires_at: string | null;
+  created_at: string;
 };
 
 type CrlSnapshotRow = {
@@ -250,6 +271,92 @@ async function findOwnedAgentRegistrationChallenge(input: {
     .limit(1);
 
   return rows[0];
+}
+
+async function findInviteByCode(input: {
+  db: ReturnType<typeof createDb>;
+  code: string;
+}): Promise<InviteRow | undefined> {
+  const rows = await input.db
+    .select({
+      id: invites.id,
+      code: invites.code,
+      created_by: invites.created_by,
+      redeemed_by: invites.redeemed_by,
+      expires_at: invites.expires_at,
+      created_at: invites.created_at,
+    })
+    .from(invites)
+    .where(eq(invites.code, input.code))
+    .limit(1);
+
+  return rows[0];
+}
+
+async function findInviteById(input: {
+  db: ReturnType<typeof createDb>;
+  id: string;
+}): Promise<InviteRow | undefined> {
+  const rows = await input.db
+    .select({
+      id: invites.id,
+      code: invites.code,
+      created_by: invites.created_by,
+      redeemed_by: invites.redeemed_by,
+      expires_at: invites.expires_at,
+      created_at: invites.created_at,
+    })
+    .from(invites)
+    .where(eq(invites.id, input.id))
+    .limit(1);
+
+  return rows[0];
+}
+
+function isInviteExpired(input: {
+  expiresAt: string | null;
+  nowMillis: number;
+}) {
+  if (typeof input.expiresAt !== "string") {
+    return false;
+  }
+
+  const expiresAtMillis = Date.parse(input.expiresAt);
+  if (!Number.isFinite(expiresAtMillis)) {
+    return true;
+  }
+
+  return expiresAtMillis <= input.nowMillis;
+}
+
+async function resolveInviteRedeemStateError(input: {
+  db: ReturnType<typeof createDb>;
+  inviteId: string;
+  nowMillis: number;
+}): Promise<AppError> {
+  const latestInvite = await findInviteById({
+    db: input.db,
+    id: input.inviteId,
+  });
+
+  if (!latestInvite) {
+    return inviteRedeemCodeInvalidError();
+  }
+
+  if (latestInvite.redeemed_by !== null) {
+    return inviteRedeemAlreadyUsedError();
+  }
+
+  if (
+    isInviteExpired({
+      expiresAt: latestInvite.expires_at,
+      nowMillis: input.nowMillis,
+    })
+  ) {
+    return inviteRedeemExpiredError();
+  }
+
+  return inviteRedeemCodeInvalidError();
 }
 
 function requireCurrentJti(input: {
@@ -599,6 +706,237 @@ function createRegistryApp() {
 
   app.get("/v1/me", createApiKeyAuth(), (c) => {
     return c.json({ human: c.get("human") });
+  });
+
+  app.post(INVITES_PATH, createApiKeyAuth(), async (c) => {
+    const config = getConfig(c.env);
+    const exposeDetails = shouldExposeVerboseErrors(config.ENVIRONMENT);
+
+    let payload: unknown;
+    try {
+      payload = await c.req.json();
+    } catch {
+      throw new AppError({
+        code: "INVITE_CREATE_INVALID",
+        message: exposeDetails
+          ? "Request body must be valid JSON"
+          : "Request could not be processed",
+        status: 400,
+        expose: exposeDetails,
+      });
+    }
+
+    const human = c.get("human");
+    if (human.role !== "admin") {
+      throw inviteCreateForbiddenError();
+    }
+
+    const parsedPayload = parseInviteCreatePayload({
+      payload,
+      environment: config.ENVIRONMENT,
+      now: new Date(),
+    });
+
+    const inviteId = generateUlid(Date.now());
+    const inviteCode = generateInviteCode();
+    const createdAt = nowIso();
+    const db = createDb(c.env.DB);
+    await db.insert(invites).values({
+      id: inviteId,
+      code: inviteCode,
+      created_by: human.id,
+      redeemed_by: null,
+      agent_id: null,
+      expires_at: parsedPayload.expiresAt,
+      created_at: createdAt,
+    });
+
+    return c.json(
+      {
+        invite: {
+          id: inviteId,
+          code: inviteCode,
+          createdBy: human.id,
+          expiresAt: parsedPayload.expiresAt,
+          createdAt,
+        },
+      },
+      201,
+    );
+  });
+
+  app.post(INVITES_REDEEM_PATH, async (c) => {
+    const config = getConfig(c.env);
+    const exposeDetails = shouldExposeVerboseErrors(config.ENVIRONMENT);
+
+    let payload: unknown;
+    try {
+      payload = await c.req.json();
+    } catch {
+      throw new AppError({
+        code: "INVITE_REDEEM_INVALID",
+        message: exposeDetails
+          ? "Request body must be valid JSON"
+          : "Request could not be processed",
+        status: 400,
+        expose: exposeDetails,
+      });
+    }
+
+    const parsedPayload = parseInviteRedeemPayload({
+      payload,
+      environment: config.ENVIRONMENT,
+    });
+
+    const db = createDb(c.env.DB);
+    const invite = await findInviteByCode({
+      db,
+      code: parsedPayload.code,
+    });
+
+    if (!invite) {
+      throw inviteRedeemCodeInvalidError();
+    }
+
+    const nowMillis = Date.now();
+    if (invite.redeemed_by !== null) {
+      throw inviteRedeemAlreadyUsedError();
+    }
+
+    if (
+      isInviteExpired({
+        expiresAt: invite.expires_at,
+        nowMillis,
+      })
+    ) {
+      throw inviteRedeemExpiredError();
+    }
+
+    const humanId = generateUlid(nowMillis);
+    const humanDid = makeHumanDid(humanId);
+    const apiKeyToken = generateApiKeyToken();
+    const apiKeyHash = await hashApiKeyToken(apiKeyToken);
+    const apiKeyPrefix = deriveApiKeyLookupPrefix(apiKeyToken);
+    const apiKeyId = generateUlid(nowMillis + 1);
+    const createdAt = nowIso();
+
+    const applyRedeemMutation = async (
+      executor: typeof db,
+      options: { rollbackOnFailure: boolean },
+    ): Promise<void> => {
+      await executor.insert(humans).values({
+        id: humanId,
+        did: humanDid,
+        display_name: parsedPayload.displayName,
+        role: "user",
+        status: "active",
+        created_at: createdAt,
+        updated_at: createdAt,
+      });
+
+      let inviteRedeemed = false;
+      try {
+        const inviteUpdateResult = await executor
+          .update(invites)
+          .set({
+            redeemed_by: humanId,
+          })
+          .where(and(eq(invites.id, invite.id), isNull(invites.redeemed_by)));
+
+        const updatedRows = getMutationRowCount(inviteUpdateResult);
+        if (updatedRows === 0) {
+          throw await resolveInviteRedeemStateError({
+            db: executor,
+            inviteId: invite.id,
+            nowMillis,
+          });
+        }
+        inviteRedeemed = true;
+
+        await executor.insert(api_keys).values({
+          id: apiKeyId,
+          human_id: humanId,
+          key_hash: apiKeyHash,
+          key_prefix: apiKeyPrefix,
+          name: parsedPayload.apiKeyName,
+          status: "active",
+          created_at: createdAt,
+          last_used_at: null,
+        });
+      } catch (error) {
+        if (options.rollbackOnFailure) {
+          if (inviteRedeemed) {
+            try {
+              await executor
+                .update(invites)
+                .set({
+                  redeemed_by: null,
+                })
+                .where(
+                  and(
+                    eq(invites.id, invite.id),
+                    eq(invites.redeemed_by, humanId),
+                  ),
+                );
+            } catch (rollbackError) {
+              logger.error("registry.invite_redeem_rollback_failed", {
+                rollbackErrorName:
+                  rollbackError instanceof Error
+                    ? rollbackError.name
+                    : "unknown",
+                stage: "invite_unlink",
+              });
+            }
+          }
+
+          try {
+            await executor.delete(humans).where(eq(humans.id, humanId));
+          } catch (rollbackError) {
+            logger.error("registry.invite_redeem_rollback_failed", {
+              rollbackErrorName:
+                rollbackError instanceof Error ? rollbackError.name : "unknown",
+              stage: "human_delete",
+            });
+          }
+        }
+
+        throw error;
+      }
+    };
+
+    try {
+      await db.transaction(async (tx) => {
+        await applyRedeemMutation(tx as unknown as typeof db, {
+          rollbackOnFailure: false,
+        });
+      });
+    } catch (error) {
+      if (!isUnsupportedLocalTransactionError(error)) {
+        throw error;
+      }
+
+      await applyRedeemMutation(db, {
+        rollbackOnFailure: true,
+      });
+    }
+
+    return c.json(
+      {
+        human: {
+          id: humanId,
+          did: humanDid,
+          displayName: parsedPayload.displayName,
+          role: "user",
+          status: "active",
+        },
+        apiKey: {
+          id: apiKeyId,
+          name: parsedPayload.apiKeyName,
+          token: apiKeyToken,
+        },
+      },
+      201,
+    );
   });
 
   app.post(ME_API_KEYS_PATH, createApiKeyAuth(), async (c) => {

--- a/packages/protocol/src/endpoints.ts
+++ b/packages/protocol/src/endpoints.ts
@@ -1,3 +1,5 @@
 export const ADMIN_BOOTSTRAP_PATH = "/v1/admin/bootstrap";
 export const AGENT_REGISTRATION_CHALLENGE_PATH = "/v1/agents/challenge";
+export const INVITES_PATH = "/v1/invites";
+export const INVITES_REDEEM_PATH = "/v1/invites/redeem";
 export const ME_API_KEYS_PATH = "/v1/me/api-keys";

--- a/packages/protocol/src/index.test.ts
+++ b/packages/protocol/src/index.test.ts
@@ -13,6 +13,8 @@ import {
   decodeBase64url,
   encodeBase64url,
   generateUlid,
+  INVITES_PATH,
+  INVITES_REDEEM_PATH,
   MAX_AGENT_DESCRIPTION_LENGTH,
   MAX_AGENT_NAME_LENGTH,
   ME_API_KEYS_PATH,
@@ -35,6 +37,8 @@ describe("protocol", () => {
   it("exports shared endpoint constants", () => {
     expect(ADMIN_BOOTSTRAP_PATH).toBe("/v1/admin/bootstrap");
     expect(AGENT_REGISTRATION_CHALLENGE_PATH).toBe("/v1/agents/challenge");
+    expect(INVITES_PATH).toBe("/v1/invites");
+    expect(INVITES_REDEEM_PATH).toBe("/v1/invites/redeem");
     expect(ME_API_KEYS_PATH).toBe("/v1/me/api-keys");
   });
 

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -23,6 +23,8 @@ export { makeAgentDid, makeHumanDid, parseDid } from "./did.js";
 export {
   ADMIN_BOOTSTRAP_PATH,
   AGENT_REGISTRATION_CHALLENGE_PATH,
+  INVITES_PATH,
+  INVITES_REDEEM_PATH,
   ME_API_KEYS_PATH,
 } from "./endpoints.js";
 export type { ProtocolParseErrorCode } from "./errors.js";


### PR DESCRIPTION
## Summary
- implement admin onboarding invite APIs in registry:
  - `POST /v1/invites` (admin-only create with optional expiry)
  - `POST /v1/invites/redeem` (public redeem with one-time semantics + expiry enforcement)
- add invite lifecycle helper module with centralized validation and explicit error codes
- issue PAT on successful redeem and ensure rollback-safe behavior in local non-transaction fallback paths
- add CLI invite command group:
  - `clawdentity invite create`
  - `clawdentity invite redeem <code>`
- persist redeemed PAT to local config in CLI (`registryUrl` then `apiKey`) and print token once
- add protocol route constants:
  - `INVITES_PATH`
  - `INVITES_REDEEM_PATH`
- update docs/governance references to GitHub issue tracker (remove local `issues/*` execution-order governance)

## Validation
- `pnpm lint`
- `pnpm -r typecheck`
- `pnpm -r test`
- `pnpm -r build`

## Notes
- `openclaw invite` flow remains separate (peer relay invite flow), as intended.

Closes #74
