### PR TITLE
[T05] Add agent-authenticated registry token refresh

### DIFF
--- a/apps/cli/src/AGENTS.md
+++ b/apps/cli/src/AGENTS.md
@@ -14,6 +14,8 @@
 - Registry invite lifecycle command logic should stay in `commands/invite.ts`; keep it strictly scoped to registry onboarding invites and separate from `commands/openclaw.ts` peer-relay invite codes.
 - `invite redeem` must print the returned PAT once, then persist config in deterministic order (`registryUrl`, then `apiKey`) so bootstrap/onboarding state is predictable.
 - `invite` command routes must use endpoint constants from `@clawdentity/protocol` (`INVITES_PATH`, `INVITES_REDEEM_PATH`) instead of inline path literals.
+- Agent auth refresh state is stored per-agent at `~/.clawdentity/agents/<name>/registry-auth.json` and must be written with secure file permissions.
+- `agent auth refresh` must use `Authorization: Claw <AIT>` + PoP headers from local agent keys and must not require PAT config.
 
 ## Verification Flow Contract
 - `verify` must support both raw token input and file-path input without requiring extra flags.

--- a/apps/cli/src/commands/AGENTS.md
+++ b/apps/cli/src/commands/AGENTS.md
@@ -46,6 +46,9 @@
 
 ## Agent Command Rules
 - `agent create` must use a two-step registration handshake: request challenge from registry, sign canonical challenge message locally with agent private key, then submit registration with `challengeId` + `challengeSignature`.
+- `agent create` must persist returned `agentAuth` bootstrap credentials to `registry-auth.json` alongside `identity.json`, `secret.key`, `public.key`, and `ait.jwt`.
+- `agent auth refresh` must call `AGENT_AUTH_REFRESH_PATH` from `@clawdentity/protocol` using Claw + PoP headers and local refresh token payload, and PoP signing must use the resolved request path (including any registry base path prefix).
+- `agent auth refresh` must rewrite `registry-auth.json` atomically on success and keep error mapping stable for `400`, `401`, `409`, and `5xx`.
 - Never send or log agent private keys; only send public key and proof signature.
 - Keep proof canonicalization sourced from `@clawdentity/protocol` helper exports to avoid CLI/registry signature drift.
 - Keep registry error mapping stable for both challenge and register requests so users receive deterministic remediation output.

--- a/apps/cli/src/commands/agent.test.ts
+++ b/apps/cli/src/commands/agent.test.ts
@@ -1,4 +1,12 @@
-import { access, chmod, mkdir, readFile, writeFile } from "node:fs/promises";
+import {
+  access,
+  chmod,
+  mkdir,
+  readFile,
+  rename,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
 import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -7,6 +15,8 @@ vi.mock("node:fs/promises", () => ({
   chmod: vi.fn(),
   mkdir: vi.fn(),
   readFile: vi.fn(),
+  rename: vi.fn(),
+  unlink: vi.fn(),
   writeFile: vi.fn(),
 }));
 
@@ -27,6 +37,7 @@ vi.mock("@clawdentity/sdk", () => ({
   encodeEd25519SignatureBase64url: vi.fn(),
   encodeEd25519KeypairBase64url: vi.fn(),
   generateEd25519Keypair: vi.fn(),
+  signHttpRequest: vi.fn(),
   signEd25519: vi.fn(),
 }));
 
@@ -37,6 +48,7 @@ import {
   encodeEd25519SignatureBase64url,
   generateEd25519Keypair,
   signEd25519,
+  signHttpRequest,
 } from "@clawdentity/sdk";
 import { resolveConfig } from "../config/manager.js";
 import { createAgentCommand } from "./agent.js";
@@ -45,9 +57,12 @@ const mockedAccess = vi.mocked(access);
 const mockedChmod = vi.mocked(chmod);
 const mockedMkdir = vi.mocked(mkdir);
 const mockedReadFile = vi.mocked(readFile);
+const mockedRename = vi.mocked(rename);
+const mockedUnlink = vi.mocked(unlink);
 const mockedWriteFile = vi.mocked(writeFile);
 const mockedResolveConfig = vi.mocked(resolveConfig);
 const mockedGenerateEd25519Keypair = vi.mocked(generateEd25519Keypair);
+const mockedSignHttpRequest = vi.mocked(signHttpRequest);
 const mockedSignEd25519 = vi.mocked(signEd25519);
 const mockedEncodeEd25519SignatureBase64url = vi.mocked(
   encodeEd25519SignatureBase64url,
@@ -134,6 +149,8 @@ describe("agent create command", () => {
     mockedAccess.mockRejectedValue(buildErrnoError("ENOENT"));
     mockedMkdir.mockResolvedValue(undefined);
     mockedWriteFile.mockResolvedValue(undefined);
+    mockedRename.mockResolvedValue(undefined);
+    mockedUnlink.mockResolvedValue(undefined);
     mockedChmod.mockResolvedValue(undefined);
 
     mockedGenerateEd25519Keypair.mockResolvedValue({
@@ -147,6 +164,16 @@ describe("agent create command", () => {
     });
 
     mockedSignEd25519.mockResolvedValue(Uint8Array.from([1, 2, 3]));
+    mockedSignHttpRequest.mockResolvedValue({
+      canonicalRequest: "canonical",
+      proof: "proof",
+      headers: {
+        "X-Claw-Timestamp": "1739364000",
+        "X-Claw-Nonce": "nonce-value",
+        "X-Claw-Body-SHA256": "body-sha",
+        "X-Claw-Proof": "proof",
+      },
+    });
     mockedEncodeEd25519SignatureBase64url.mockReturnValue(
       "challenge-signature-b64url",
     );
@@ -170,6 +197,13 @@ describe("agent create command", () => {
           expiresAt: "2030-01-01T00:00:00.000Z",
         },
         ait: "ait.jwt.value",
+        agentAuth: {
+          tokenType: "Bearer",
+          accessToken: "clw_agt_access_token",
+          accessExpiresAt: "2030-01-01T00:15:00.000Z",
+          refreshToken: "clw_rft_refresh_token",
+          refreshExpiresAt: "2030-01-31T00:00:00.000Z",
+        },
       });
     });
   });
@@ -211,7 +245,7 @@ describe("agent create command", () => {
       }),
     );
 
-    expect(mockedWriteFile).toHaveBeenCalledTimes(4);
+    expect(mockedWriteFile).toHaveBeenCalledTimes(5);
     expect(mockedWriteFile).toHaveBeenCalledWith(
       "/mock-home/.clawdentity/agents/agent-01/secret.key",
       "secret-key-b64url",
@@ -232,6 +266,11 @@ describe("agent create command", () => {
     expect(mockedWriteFile).toHaveBeenCalledWith(
       "/mock-home/.clawdentity/agents/agent-01/ait.jwt",
       "ait.jwt.value",
+      "utf-8",
+    );
+    expect(mockedWriteFile).toHaveBeenCalledWith(
+      "/mock-home/.clawdentity/agents/agent-01/registry-auth.json",
+      expect.stringContaining('"refreshToken": "clw_rft_refresh_token"'),
       "utf-8",
     );
 
@@ -306,7 +345,7 @@ describe("agent create command", () => {
   it("sets 0600 permissions on every identity file", async () => {
     await runAgentCommand(["create", "agent-01"]);
 
-    expect(mockedChmod).toHaveBeenCalledTimes(4);
+    expect(mockedChmod).toHaveBeenCalledTimes(5);
     expect(mockedChmod).toHaveBeenCalledWith(
       "/mock-home/.clawdentity/agents/agent-01/secret.key",
       0o600,
@@ -321,6 +360,10 @@ describe("agent create command", () => {
     );
     expect(mockedChmod).toHaveBeenCalledWith(
       "/mock-home/.clawdentity/agents/agent-01/ait.jwt",
+      0o600,
+    );
+    expect(mockedChmod).toHaveBeenCalledWith(
+      "/mock-home/.clawdentity/agents/agent-01/registry-auth.json",
       0o600,
     );
   });
@@ -357,6 +400,177 @@ describe("agent create command", () => {
     expect(mockFetch).not.toHaveBeenCalled();
     expect(mockedMkdir).not.toHaveBeenCalled();
     expect(mockedWriteFile).not.toHaveBeenCalled();
+  });
+});
+
+describe("agent auth refresh command", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockReset();
+    vi.stubGlobal("fetch", mockFetch);
+    mockedSignHttpRequest.mockResolvedValue({
+      canonicalRequest: "canonical",
+      proof: "proof",
+      headers: {
+        "X-Claw-Timestamp": "1739364000",
+        "X-Claw-Nonce": "nonce-value",
+        "X-Claw-Body-SHA256": "body-sha",
+        "X-Claw-Proof": "proof",
+      },
+    });
+
+    mockedReadFile.mockImplementation(async (path) => {
+      const filePath = String(path);
+      if (filePath.endsWith("/ait.jwt")) {
+        return "ait.jwt.value";
+      }
+      if (filePath.endsWith("/identity.json")) {
+        return JSON.stringify({
+          did: "did:claw:agent:01HF7YAT00W6W7CM7N3W5FDXT4",
+          registryUrl: "https://api.clawdentity.com",
+        });
+      }
+      if (filePath.endsWith("/secret.key")) {
+        return "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+      }
+      if (filePath.endsWith("/registry-auth.json")) {
+        return JSON.stringify({
+          tokenType: "Bearer",
+          accessToken: "clw_agt_old_access",
+          accessExpiresAt: "2030-01-01T00:15:00.000Z",
+          refreshToken: "clw_rft_old_refresh",
+          refreshExpiresAt: "2030-01-31T00:00:00.000Z",
+        });
+      }
+
+      throw buildErrnoError("ENOENT");
+    });
+
+    mockFetch.mockResolvedValue(
+      createJsonResponse(200, {
+        agentAuth: {
+          tokenType: "Bearer",
+          accessToken: "clw_agt_new_access",
+          accessExpiresAt: "2030-01-02T00:15:00.000Z",
+          refreshToken: "clw_rft_new_refresh",
+          refreshExpiresAt: "2030-02-01T00:00:00.000Z",
+        },
+      }),
+    );
+  });
+
+  afterEach(() => {
+    process.exitCode = undefined;
+    vi.unstubAllGlobals();
+  });
+
+  it("refreshes agent auth and rewrites registry-auth.json", async () => {
+    const result = await runAgentCommand(["auth", "refresh", "agent-01"]);
+
+    expect(mockedSignHttpRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "POST",
+        pathWithQuery: "/v1/agents/auth/refresh",
+      }),
+    );
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://api.clawdentity.com/v1/agents/auth/refresh",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          authorization: "Claw ait.jwt.value",
+          "content-type": "application/json",
+        }),
+      }),
+    );
+    const [tempPath, tempContents, tempEncoding] = mockedWriteFile.mock
+      .calls[0] as [string, string, BufferEncoding];
+    expect(tempPath).toContain(
+      "/mock-home/.clawdentity/agents/agent-01/registry-auth.json.tmp-",
+    );
+    expect(tempContents).toContain('"refreshToken": "clw_rft_new_refresh"');
+    expect(tempEncoding).toBe("utf-8");
+    expect(mockedRename).toHaveBeenCalledWith(
+      tempPath,
+      "/mock-home/.clawdentity/agents/agent-01/registry-auth.json",
+    );
+    expect(mockedWriteFile).not.toHaveBeenCalledWith(
+      "/mock-home/.clawdentity/agents/agent-01/registry-auth.json",
+      expect.stringContaining('"refreshToken": "clw_rft_new_refresh"'),
+      "utf-8",
+    );
+    expect(result.stdout).toContain("Agent auth refreshed: agent-01");
+    expect(result.exitCode).toBeUndefined();
+  });
+
+  it("fails when registry-auth.json is missing", async () => {
+    mockedReadFile.mockImplementation(async (path) => {
+      const filePath = String(path);
+      if (filePath.endsWith("/registry-auth.json")) {
+        throw buildErrnoError("ENOENT");
+      }
+      if (filePath.endsWith("/ait.jwt")) {
+        return "ait.jwt.value";
+      }
+      if (filePath.endsWith("/identity.json")) {
+        return JSON.stringify({
+          did: "did:claw:agent:01HF7YAT00W6W7CM7N3W5FDXT4",
+          registryUrl: "https://api.clawdentity.com",
+        });
+      }
+      if (filePath.endsWith("/secret.key")) {
+        return "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+      }
+
+      throw buildErrnoError("ENOENT");
+    });
+
+    const result = await runAgentCommand(["auth", "refresh", "agent-01"]);
+
+    expect(result.stderr).toContain("registry-auth.json");
+    expect(result.exitCode).toBe(1);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("signs refresh proof with the resolved endpoint path for base-path registries", async () => {
+    mockedReadFile.mockImplementation(async (path) => {
+      const filePath = String(path);
+      if (filePath.endsWith("/ait.jwt")) {
+        return "ait.jwt.value";
+      }
+      if (filePath.endsWith("/identity.json")) {
+        return JSON.stringify({
+          did: "did:claw:agent:01HF7YAT00W6W7CM7N3W5FDXT4",
+          registryUrl: "https://api.clawdentity.com/registry",
+        });
+      }
+      if (filePath.endsWith("/secret.key")) {
+        return "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+      }
+      if (filePath.endsWith("/registry-auth.json")) {
+        return JSON.stringify({
+          tokenType: "Bearer",
+          accessToken: "clw_agt_old_access",
+          accessExpiresAt: "2030-01-01T00:15:00.000Z",
+          refreshToken: "clw_rft_old_refresh",
+          refreshExpiresAt: "2030-01-31T00:00:00.000Z",
+        });
+      }
+
+      throw buildErrnoError("ENOENT");
+    });
+
+    await runAgentCommand(["auth", "refresh", "agent-01"]);
+
+    expect(mockedSignHttpRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pathWithQuery: "/registry/v1/agents/auth/refresh",
+      }),
+    );
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://api.clawdentity.com/registry/v1/agents/auth/refresh",
+      expect.any(Object),
+    );
   });
 });
 

--- a/apps/cli/src/commands/agent.ts
+++ b/apps/cli/src/commands/agent.ts
@@ -1,8 +1,19 @@
-import { access, chmod, mkdir, readFile, writeFile } from "node:fs/promises";
+import {
+  access,
+  chmod,
+  mkdir,
+  readFile,
+  rename,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
 import { join } from "node:path";
 import {
+  AGENT_AUTH_REFRESH_PATH,
   AGENT_REGISTRATION_CHALLENGE_PATH,
   canonicalizeAgentRegistrationProof,
+  decodeBase64url,
+  encodeBase64url,
   parseDid,
 } from "@clawdentity/protocol";
 import {
@@ -13,6 +24,7 @@ import {
   encodeEd25519SignatureBase64url,
   generateEd25519Keypair,
   signEd25519,
+  signHttpRequest,
 } from "@clawdentity/sdk";
 import { Command } from "commander";
 import { getConfigDir, resolveConfig } from "../config/manager.js";
@@ -25,6 +37,7 @@ const logger = createLogger({ service: "cli", module: "agent" });
 const AGENTS_DIR_NAME = "agents";
 const AIT_FILE_NAME = "ait.jwt";
 const IDENTITY_FILE_NAME = "identity.json";
+const REGISTRY_AUTH_FILE_NAME = "registry-auth.json";
 const FILE_MODE = 0o600;
 
 type AgentCreateOptions = {
@@ -40,6 +53,7 @@ type AgentRegistrationResponse = {
     expiresAt: string;
   };
   ait: string;
+  agentAuth: AgentAuthBundle;
 };
 
 type AgentRegistrationChallengeResponse = {
@@ -51,6 +65,19 @@ type AgentRegistrationChallengeResponse = {
 
 type LocalAgentIdentity = {
   did: string;
+  registryUrl?: string;
+};
+
+type AgentAuthBundle = {
+  tokenType: "Bearer";
+  accessToken: string;
+  accessExpiresAt: string;
+  refreshToken: string;
+  refreshExpiresAt: string;
+};
+
+type LocalAgentRegistryAuth = {
+  refreshToken: string;
 };
 
 type RegistryErrorEnvelope = {
@@ -63,6 +90,14 @@ const isRecord = (value: unknown): value is Record<string, unknown> => {
   return typeof value === "object" && value !== null;
 };
 
+const parseNonEmptyString = (value: unknown): string => {
+  if (typeof value !== "string") {
+    return "";
+  }
+
+  return value.trim();
+};
+
 const getAgentDirectory = (name: string): string => {
   return join(getConfigDir(), AGENTS_DIR_NAME, name);
 };
@@ -73,6 +108,14 @@ const getAgentAitPath = (name: string): string => {
 
 const getAgentIdentityPath = (name: string): string => {
   return join(getAgentDirectory(name), IDENTITY_FILE_NAME);
+};
+
+const getAgentSecretKeyPath = (name: string): string => {
+  return join(getAgentDirectory(name), "secret.key");
+};
+
+const getAgentRegistryAuthPath = (name: string): string => {
+  return join(getAgentDirectory(name), REGISTRY_AUTH_FILE_NAME);
 };
 
 const readAgentAitToken = async (agentName: string): Promise<string> => {
@@ -137,7 +180,82 @@ const readAgentIdentity = async (
     );
   }
 
-  return { did };
+  const registryUrl = parseNonEmptyString(parsed.registryUrl);
+  return {
+    did,
+    registryUrl: registryUrl.length > 0 ? registryUrl : undefined,
+  };
+};
+
+const readAgentSecretKey = async (agentName: string): Promise<Uint8Array> => {
+  const secretKeyPath = getAgentSecretKeyPath(agentName);
+
+  let rawSecretKey: string;
+  try {
+    rawSecretKey = await readFile(secretKeyPath, "utf-8");
+  } catch (error) {
+    const nodeError = error as NodeJS.ErrnoException;
+    if (nodeError.code === "ENOENT") {
+      throw new Error(`Agent "${agentName}" not found (${secretKeyPath})`);
+    }
+    throw error;
+  }
+
+  const encodedSecretKey = rawSecretKey.trim();
+  if (encodedSecretKey.length === 0) {
+    throw new Error(`Agent "${agentName}" has an empty secret.key`);
+  }
+
+  try {
+    return decodeBase64url(encodedSecretKey);
+  } catch {
+    throw new Error(`Agent "${agentName}" has invalid secret.key format`);
+  }
+};
+
+const readAgentRegistryAuth = async (
+  agentName: string,
+): Promise<LocalAgentRegistryAuth> => {
+  const registryAuthPath = getAgentRegistryAuthPath(agentName);
+
+  let rawRegistryAuth: string;
+  try {
+    rawRegistryAuth = await readFile(registryAuthPath, "utf-8");
+  } catch (error) {
+    const nodeError = error as NodeJS.ErrnoException;
+    if (nodeError.code === "ENOENT") {
+      throw new Error(
+        `Agent "${agentName}" has no ${REGISTRY_AUTH_FILE_NAME}. Recreate agent identity or re-run auth bootstrap.`,
+      );
+    }
+    throw error;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawRegistryAuth);
+  } catch {
+    throw new Error(
+      `Agent "${agentName}" has invalid ${REGISTRY_AUTH_FILE_NAME} (must be valid JSON)`,
+    );
+  }
+
+  if (!isRecord(parsed)) {
+    throw new Error(
+      `Agent "${agentName}" has invalid ${REGISTRY_AUTH_FILE_NAME}`,
+    );
+  }
+
+  const refreshToken = parseNonEmptyString(parsed.refreshToken);
+  if (refreshToken.length === 0) {
+    throw new Error(
+      `Agent "${agentName}" has invalid ${REGISTRY_AUTH_FILE_NAME} (missing refreshToken)`,
+    );
+  }
+
+  return {
+    refreshToken,
+  };
 };
 
 const parseAgentIdFromDid = (agentName: string, did: string): string => {
@@ -235,6 +353,22 @@ const toRegistryAgentChallengeRequestUrl = (registryUrl: string): string => {
   ).toString();
 };
 
+const toRegistryAgentAuthRefreshRequestUrl = (registryUrl: string): string => {
+  const normalizedBaseUrl = registryUrl.endsWith("/")
+    ? registryUrl
+    : `${registryUrl}/`;
+
+  return new URL(
+    AGENT_AUTH_REFRESH_PATH.slice(1),
+    normalizedBaseUrl,
+  ).toString();
+};
+
+const toPathWithQuery = (requestUrl: string): string => {
+  const parsed = new URL(requestUrl);
+  return `${parsed.pathname}${parsed.search}`;
+};
+
 const toHttpErrorMessage = (status: number, responseBody: unknown): string => {
   const registryMessage = extractRegistryErrorMessage(responseBody);
 
@@ -261,6 +395,36 @@ const toHttpErrorMessage = (status: number, responseBody: unknown): string => {
   return `Registry request failed (${status})`;
 };
 
+const parseAgentAuthBundle = (value: unknown): AgentAuthBundle => {
+  if (!isRecord(value)) {
+    throw new Error("Registry returned an invalid response payload");
+  }
+
+  const tokenType = value.tokenType;
+  const accessToken = value.accessToken;
+  const accessExpiresAt = value.accessExpiresAt;
+  const refreshToken = value.refreshToken;
+  const refreshExpiresAt = value.refreshExpiresAt;
+
+  if (
+    tokenType !== "Bearer" ||
+    typeof accessToken !== "string" ||
+    typeof accessExpiresAt !== "string" ||
+    typeof refreshToken !== "string" ||
+    typeof refreshExpiresAt !== "string"
+  ) {
+    throw new Error("Registry returned an invalid response payload");
+  }
+
+  return {
+    tokenType,
+    accessToken,
+    accessExpiresAt,
+    refreshToken,
+    refreshExpiresAt,
+  };
+};
+
 const parseAgentRegistrationResponse = (
   payload: unknown,
 ): AgentRegistrationResponse => {
@@ -270,8 +434,13 @@ const parseAgentRegistrationResponse = (
 
   const agentValue = payload.agent;
   const aitValue = payload.ait;
+  const agentAuthValue = payload.agentAuth;
 
-  if (!isRecord(agentValue) || typeof aitValue !== "string") {
+  if (
+    !isRecord(agentValue) ||
+    typeof aitValue !== "string" ||
+    !isRecord(agentAuthValue)
+  ) {
     throw new Error("Registry returned an invalid response payload");
   }
 
@@ -297,6 +466,7 @@ const parseAgentRegistrationResponse = (
       expiresAt,
     },
     ait: aitValue,
+    agentAuth: parseAgentAuthBundle(agentAuthValue),
   };
 };
 
@@ -354,6 +524,28 @@ const writeSecureFile = async (
   await chmod(path, FILE_MODE);
 };
 
+const writeSecureFileAtomically = async (
+  path: string,
+  content: string,
+): Promise<void> => {
+  const tempPath = `${path}.tmp-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
+  await writeFile(tempPath, content, "utf-8");
+  await chmod(tempPath, FILE_MODE);
+
+  try {
+    await rename(tempPath, path);
+  } catch (error) {
+    try {
+      await unlink(tempPath);
+    } catch {
+      // Best-effort cleanup only.
+    }
+
+    throw error;
+  }
+};
+
 const ensureAgentDirectory = async (
   agentName: string,
   agentDirectory: string,
@@ -384,6 +576,7 @@ const writeAgentIdentity = async (input: {
   publicKey: string;
   secretKey: string;
   ait: string;
+  agentAuth: AgentAuthBundle;
 }): Promise<void> => {
   await ensureAgentDirectory(input.name, input.agentDirectory);
 
@@ -408,6 +601,20 @@ const writeAgentIdentity = async (input: {
     `${JSON.stringify(identityJson, null, 2)}\n`,
   );
   await writeSecureFile(join(input.agentDirectory, "ait.jwt"), input.ait);
+  await writeSecureFile(
+    join(input.agentDirectory, REGISTRY_AUTH_FILE_NAME),
+    `${JSON.stringify(input.agentAuth, null, 2)}\n`,
+  );
+};
+
+const writeAgentRegistryAuth = async (input: {
+  agentName: string;
+  agentAuth: AgentAuthBundle;
+}): Promise<void> => {
+  await writeSecureFileAtomically(
+    getAgentRegistryAuthPath(input.agentName),
+    `${JSON.stringify(input.agentAuth, null, 2)}\n`,
+  );
 };
 
 const requestAgentRegistrationChallenge = async (input: {
@@ -558,6 +765,110 @@ const toRevokeHttpErrorMessage = (
   return `Registry request failed (${status})`;
 };
 
+const toRefreshHttpErrorMessage = (
+  status: number,
+  responseBody: unknown,
+): string => {
+  const registryMessage = extractRegistryErrorMessage(responseBody);
+
+  if (status === 400) {
+    return registryMessage
+      ? `Refresh request is invalid (400): ${registryMessage}`
+      : "Refresh request is invalid (400).";
+  }
+
+  if (status === 401) {
+    return registryMessage
+      ? `Refresh rejected (401): ${registryMessage}`
+      : "Refresh rejected (401). Agent credentials are invalid, revoked, or expired.";
+  }
+
+  if (status === 409) {
+    return registryMessage
+      ? `Refresh conflict (409): ${registryMessage}`
+      : "Refresh conflict (409). Retry the command.";
+  }
+
+  if (status >= 500) {
+    return `Registry server error (${status}). Try again later.`;
+  }
+
+  if (registryMessage) {
+    return `Registry request failed (${status}): ${registryMessage}`;
+  }
+
+  return `Registry request failed (${status})`;
+};
+
+const parseAgentAuthRefreshResponse = (payload: unknown): AgentAuthBundle => {
+  if (!isRecord(payload) || !isRecord(payload.agentAuth)) {
+    throw new Error("Registry returned an invalid response payload");
+  }
+
+  return parseAgentAuthBundle(payload.agentAuth);
+};
+
+const refreshAgentAuth = async (input: {
+  agentName: string;
+}): Promise<{
+  registryUrl: string;
+  agentAuth: AgentAuthBundle;
+}> => {
+  const ait = await readAgentAitToken(input.agentName);
+  const identity = await readAgentIdentity(input.agentName);
+  const secretKey = await readAgentSecretKey(input.agentName);
+  const localAuth = await readAgentRegistryAuth(input.agentName);
+
+  const registryUrl = identity.registryUrl?.trim();
+  if (!registryUrl) {
+    throw new Error(
+      `Agent "${input.agentName}" identity is missing registryUrl in ${IDENTITY_FILE_NAME}`,
+    );
+  }
+
+  const refreshBody = JSON.stringify({
+    refreshToken: localAuth.refreshToken,
+  });
+  const refreshUrl = toRegistryAgentAuthRefreshRequestUrl(registryUrl);
+  const timestamp = String(Math.floor(Date.now() / 1000));
+  const nonce = encodeBase64url(crypto.getRandomValues(new Uint8Array(16)));
+  const signed = await signHttpRequest({
+    method: "POST",
+    pathWithQuery: toPathWithQuery(refreshUrl),
+    timestamp,
+    nonce,
+    body: new TextEncoder().encode(refreshBody),
+    secretKey,
+  });
+
+  let response: Response;
+  try {
+    response = await fetch(refreshUrl, {
+      method: "POST",
+      headers: {
+        authorization: `Claw ${ait}`,
+        "content-type": "application/json",
+        ...signed.headers,
+      },
+      body: refreshBody,
+    });
+  } catch {
+    throw new Error(
+      "Unable to connect to the registry. Check network access and registryUrl.",
+    );
+  }
+
+  const responseBody = await parseJsonResponse(response);
+  if (!response.ok) {
+    throw new Error(toRefreshHttpErrorMessage(response.status, responseBody));
+  }
+
+  return {
+    registryUrl,
+    agentAuth: parseAgentAuthRefreshResponse(responseBody),
+  };
+};
+
 const revokeAgent = async (input: {
   apiKey: string;
   registryUrl: string;
@@ -660,6 +971,7 @@ export const createAgentCommand = (): Command => {
             publicKey: encoded.publicKey,
             secretKey: encoded.secretKey,
             ait: registration.ait,
+            agentAuth: registration.agentAuth,
           });
 
           logger.info("cli.agent_created", {
@@ -684,6 +996,44 @@ export const createAgentCommand = (): Command => {
         await printAgentInspectCommand(name);
       }),
     );
+
+  const authCommand = new Command("auth").description(
+    "Manage local agent registry auth credentials",
+  );
+
+  authCommand
+    .command("refresh <name>")
+    .description("Refresh agent registry auth credentials with Claw proof")
+    .action(
+      withErrorHandling("agent auth refresh", async (name: string) => {
+        const agentName = assertValidAgentName(name);
+        const result = await refreshAgentAuth({
+          agentName,
+        });
+
+        await writeAgentRegistryAuth({
+          agentName,
+          agentAuth: result.agentAuth,
+        });
+
+        logger.info("cli.agent_auth_refreshed", {
+          name: agentName,
+          registryUrl: result.registryUrl,
+          accessExpiresAt: result.agentAuth.accessExpiresAt,
+          refreshExpiresAt: result.agentAuth.refreshExpiresAt,
+        });
+
+        writeStdoutLine(`Agent auth refreshed: ${agentName}`);
+        writeStdoutLine(
+          `Access Expires At: ${result.agentAuth.accessExpiresAt}`,
+        );
+        writeStdoutLine(
+          `Refresh Expires At: ${result.agentAuth.refreshExpiresAt}`,
+        );
+      }),
+    );
+
+  agentCommand.addCommand(authCommand);
 
   agentCommand
     .command("revoke <name>")

--- a/apps/registry/drizzle/0002_agent_auth_refresh.sql
+++ b/apps/registry/drizzle/0002_agent_auth_refresh.sql
@@ -1,0 +1,38 @@
+CREATE TABLE `agent_auth_sessions` (
+	`id` text PRIMARY KEY NOT NULL,
+	`agent_id` text NOT NULL,
+	`refresh_key_hash` text NOT NULL,
+	`refresh_key_prefix` text NOT NULL,
+	`refresh_issued_at` text NOT NULL,
+	`refresh_expires_at` text NOT NULL,
+	`refresh_last_used_at` text,
+	`access_key_hash` text NOT NULL,
+	`access_key_prefix` text NOT NULL,
+	`access_issued_at` text NOT NULL,
+	`access_expires_at` text NOT NULL,
+	`access_last_used_at` text,
+	`status` text DEFAULT 'active' NOT NULL,
+	`revoked_at` text,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL,
+	FOREIGN KEY (`agent_id`) REFERENCES `agents`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `agent_auth_sessions_agent_id_unique` ON `agent_auth_sessions` (`agent_id`);--> statement-breakpoint
+CREATE INDEX `idx_agent_auth_sessions_agent_status` ON `agent_auth_sessions` (`agent_id`,`status`);--> statement-breakpoint
+CREATE INDEX `idx_agent_auth_sessions_refresh_prefix` ON `agent_auth_sessions` (`refresh_key_prefix`);--> statement-breakpoint
+CREATE INDEX `idx_agent_auth_sessions_access_prefix` ON `agent_auth_sessions` (`access_key_prefix`);--> statement-breakpoint
+CREATE TABLE `agent_auth_events` (
+	`id` text PRIMARY KEY NOT NULL,
+	`agent_id` text NOT NULL,
+	`session_id` text NOT NULL,
+	`event_type` text NOT NULL,
+	`reason` text,
+	`metadata_json` text,
+	`created_at` text NOT NULL,
+	FOREIGN KEY (`agent_id`) REFERENCES `agents`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`session_id`) REFERENCES `agent_auth_sessions`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE INDEX `idx_agent_auth_events_agent_created` ON `agent_auth_events` (`agent_id`,`created_at`);--> statement-breakpoint
+CREATE INDEX `idx_agent_auth_events_session_created` ON `agent_auth_events` (`session_id`,`created_at`);

--- a/apps/registry/src/AGENTS.md
+++ b/apps/registry/src/AGENTS.md
@@ -122,7 +122,20 @@
 - Use shared SDK datetime helpers (`nowIso`, `addSeconds`) for issuance/expiry math instead of ad-hoc `Date.now()` arithmetic in route logic.
 - Resolve signing material through a reusable signer helper (`registry-signer.ts`) that derives the public key from `REGISTRY_SIGNING_KEY` and matches it to an `active` `kid` in `REGISTRY_SIGNING_KEYS` before signing.
 - Keep AIT `iss` deterministic from environment mapping (`development`/`test` -> `https://dev.api.clawdentity.com`, `production` -> `https://api.clawdentity.com`) rather than request-origin inference.
-- Response shape remains `{ agent, ait }`; the token must be verifiable with the public keyset returned by `/.well-known/claw-keys.json`.
+- Bootstrap agent auth refresh material in the same mutation unit as agent creation by inserting an active `agent_auth_sessions` row.
+- Response shape is `{ agent, ait, agentAuth }` where `agentAuth` returns short-lived access credentials and rotating refresh credentials.
+
+## POST /v1/agents/auth/refresh Contract
+- Public endpoint (no PAT): auth is agent-scoped via `Authorization: Claw <AIT>` + PoP headers + refresh token payload.
+- Verify AIT against active registry signing keys and enforce deterministic issuer mapping for environment.
+- Verify PoP using canonical request inputs and public key from AIT `cnf`.
+- Enforce timestamp skew checks for replay-window reduction.
+- Require payload `{ refreshToken }` and validate marker format (`clw_rft_`).
+- Enforce single-active-session rotation semantics:
+  - refresh token must match current active session hash/prefix
+  - expired refresh token transitions session to `revoked`
+  - successful refresh rotates both refresh/access credentials with a guarded update
+- Insert audit events in `agent_auth_events` for `refreshed`, `revoked`, and `refresh_rejected`.
 
 ## DELETE /v1/agents/:id Contract
 - Require PAT auth via `createApiKeyAuth`; only the caller-owned agent may be revoked.
@@ -133,8 +146,16 @@
   - return `204` after first successful revoke
 - If an owned active agent has no `current_jti`, fail with `409 AGENT_REVOKE_INVALID_STATE` rather than writing a partial revocation.
 - Perform state changes in one DB transaction:
-  - update `agents.status` to `revoked` and `agents.updated_at` to `nowIso()`
-  - insert `revocations` row using the previous `current_jti`
+- update `agents.status` to `revoked` and `agents.updated_at` to `nowIso()`
+- insert `revocations` row using the previous `current_jti`
+- revoke active `agent_auth_sessions` row for the same agent and write `agent_auth_events` entry with reason `agent_revoked`.
+
+## DELETE /v1/agents/:id/auth/revoke Contract
+- Require PAT auth via `createApiKeyAuth`; only the caller-owned agent may be targeted.
+- Validate `:id` with the same ULID path parser used by revoke/reissue flows.
+- Return `404 AGENT_NOT_FOUND` for unknown/foreign agents.
+- Revoke active `agent_auth_sessions` rows idempotently (`204` if already revoked/missing).
+- Write `agent_auth_events` entry with reason `owner_auth_revoke` on first successful revoke.
 
 ## POST /v1/agents/:id/reissue Contract
 - Require PAT auth via `createApiKeyAuth`; only the caller-owned agent may be reissued.

--- a/apps/registry/src/agent-auth-lifecycle.ts
+++ b/apps/registry/src/agent-auth-lifecycle.ts
@@ -1,0 +1,205 @@
+import { generateUlid } from "@clawdentity/protocol";
+import {
+  AppError,
+  addSeconds,
+  nowIso,
+  type RegistryConfig,
+  shouldExposeVerboseErrors,
+} from "@clawdentity/sdk";
+import {
+  deriveAccessTokenLookupPrefix,
+  deriveRefreshTokenLookupPrefix,
+  generateAccessToken,
+  generateRefreshToken,
+  hashAgentToken,
+  parseRefreshToken,
+} from "./auth/agent-auth-token.js";
+
+export const DEFAULT_AGENT_ACCESS_TOKEN_TTL_SECONDS = 15 * 60;
+export const DEFAULT_AGENT_REFRESH_TOKEN_TTL_SECONDS = 30 * 24 * 60 * 60;
+
+export type AgentAuthIssue = {
+  sessionId: string;
+  accessToken: string;
+  accessTokenHash: string;
+  accessTokenPrefix: string;
+  refreshToken: string;
+  refreshTokenHash: string;
+  refreshTokenPrefix: string;
+  accessIssuedAt: string;
+  accessExpiresAt: string;
+  refreshIssuedAt: string;
+  refreshExpiresAt: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type AgentAuthResponse = {
+  tokenType: "Bearer";
+  accessToken: string;
+  accessExpiresAt: string;
+  refreshToken: string;
+  refreshExpiresAt: string;
+};
+
+function invalidRefreshPayloadError(options: {
+  environment: RegistryConfig["ENVIRONMENT"];
+  details?: {
+    fieldErrors: Record<string, string[]>;
+    formErrors: string[];
+  };
+}): AppError {
+  const exposeDetails = shouldExposeVerboseErrors(options.environment);
+  return new AppError({
+    code: "AGENT_AUTH_REFRESH_INVALID",
+    message: exposeDetails
+      ? "Refresh payload is invalid"
+      : "Request could not be processed",
+    status: 400,
+    expose: true,
+    details: exposeDetails ? options.details : undefined,
+  });
+}
+
+export function parseAgentAuthRefreshPayload(input: {
+  payload: unknown;
+  environment: RegistryConfig["ENVIRONMENT"];
+}): { refreshToken: string } {
+  if (
+    typeof input.payload !== "object" ||
+    input.payload === null ||
+    Array.isArray(input.payload)
+  ) {
+    throw invalidRefreshPayloadError({
+      environment: input.environment,
+      details: {
+        fieldErrors: {
+          body: ["body must be a JSON object"],
+        },
+        formErrors: [],
+      },
+    });
+  }
+
+  const payload = input.payload as Record<string, unknown>;
+  if (typeof payload.refreshToken !== "string") {
+    throw invalidRefreshPayloadError({
+      environment: input.environment,
+      details: {
+        fieldErrors: {
+          refreshToken: ["refreshToken is required"],
+        },
+        formErrors: [],
+      },
+    });
+  }
+
+  let refreshToken: string;
+  try {
+    refreshToken = parseRefreshToken(payload.refreshToken);
+  } catch {
+    throw invalidRefreshPayloadError({
+      environment: input.environment,
+      details: {
+        fieldErrors: {
+          refreshToken: ["refreshToken format is invalid"],
+        },
+        formErrors: [],
+      },
+    });
+  }
+
+  return {
+    refreshToken,
+  };
+}
+
+export async function issueAgentAuth(options?: {
+  nowMs?: number;
+  accessTtlSeconds?: number;
+  refreshTtlSeconds?: number;
+}): Promise<AgentAuthIssue> {
+  const nowMs = options?.nowMs ?? Date.now();
+  const accessTtlSeconds =
+    options?.accessTtlSeconds ?? DEFAULT_AGENT_ACCESS_TOKEN_TTL_SECONDS;
+  const refreshTtlSeconds =
+    options?.refreshTtlSeconds ?? DEFAULT_AGENT_REFRESH_TOKEN_TTL_SECONDS;
+  const accessToken = generateAccessToken();
+  const refreshToken = generateRefreshToken();
+
+  const [accessTokenHash, refreshTokenHash] = await Promise.all([
+    hashAgentToken(accessToken),
+    hashAgentToken(refreshToken),
+  ]);
+
+  const accessIssuedAt = nowIso();
+  const refreshIssuedAt = accessIssuedAt;
+  const accessExpiresAt = addSeconds(new Date(nowMs), accessTtlSeconds);
+  const refreshExpiresAt = addSeconds(new Date(nowMs), refreshTtlSeconds);
+  const createdAt = accessIssuedAt;
+  const updatedAt = accessIssuedAt;
+
+  return {
+    sessionId: generateUlid(nowMs),
+    accessToken,
+    accessTokenHash,
+    accessTokenPrefix: deriveAccessTokenLookupPrefix(accessToken),
+    refreshToken,
+    refreshTokenHash,
+    refreshTokenPrefix: deriveRefreshTokenLookupPrefix(refreshToken),
+    accessIssuedAt,
+    accessExpiresAt,
+    refreshIssuedAt,
+    refreshExpiresAt,
+    createdAt,
+    updatedAt,
+  };
+}
+
+export function toAgentAuthResponse(input: {
+  accessToken: string;
+  accessExpiresAt: string;
+  refreshToken: string;
+  refreshExpiresAt: string;
+}): AgentAuthResponse {
+  return {
+    tokenType: "Bearer",
+    accessToken: input.accessToken,
+    accessExpiresAt: input.accessExpiresAt,
+    refreshToken: input.refreshToken,
+    refreshExpiresAt: input.refreshExpiresAt,
+  };
+}
+
+export function agentAuthRefreshUnauthorizedError(): AppError {
+  return new AppError({
+    code: "AGENT_AUTH_REFRESH_UNAUTHORIZED",
+    message: "Agent auth refresh is unauthorized",
+    status: 401,
+    expose: true,
+  });
+}
+
+export function agentAuthRefreshRejectedError(options: {
+  code:
+    | "AGENT_AUTH_REFRESH_REVOKED"
+    | "AGENT_AUTH_REFRESH_EXPIRED"
+    | "AGENT_AUTH_REFRESH_INVALID";
+  message: string;
+}): AppError {
+  return new AppError({
+    code: options.code,
+    message: options.message,
+    status: 401,
+    expose: true,
+  });
+}
+
+export function agentAuthRefreshConflictError(): AppError {
+  return new AppError({
+    code: "AGENT_AUTH_REFRESH_CONFLICT",
+    message: "Agent auth refresh state changed; retry request",
+    status: 409,
+    expose: true,
+  });
+}

--- a/apps/registry/src/auth/AGENTS.md
+++ b/apps/registry/src/auth/AGENTS.md
@@ -18,3 +18,10 @@
 ## Verification
 - Cover valid, invalid, and missing PAT paths in `server.test.ts`.
 - Verify middleware updates `api_keys.last_used_at` on successful auth.
+
+## Agent Auth Refresh Rules
+- Keep agent refresh token helpers (`clw_rft_`, `clw_agt_`, prefix derivation, hashing, token generation) centralized in `agent-auth-token.ts`.
+- Verify agent-authenticated refresh requests using `Authorization: Claw <AIT>` and PoP headers; never trust refresh payload without AIT + PoP verification.
+- Enforce issuer + keyset-based AIT verification against active registry signing keys only.
+- Validate `X-Claw-Timestamp` skew and fail closed on malformed/expired signatures.
+- Never log or persist plaintext refresh/access tokens server-side; persist only hash/prefix material.

--- a/apps/registry/src/auth/agent-auth-token.ts
+++ b/apps/registry/src/auth/agent-auth-token.ts
@@ -1,0 +1,110 @@
+import { encodeBase64url } from "@clawdentity/protocol";
+import { AppError } from "@clawdentity/sdk";
+
+export const AGENT_ACCESS_TOKEN_MARKER = "clw_agt_";
+export const AGENT_REFRESH_TOKEN_MARKER = "clw_rft_";
+const AGENT_TOKEN_LOOKUP_ENTROPY_LENGTH = 8;
+const AGENT_TOKEN_RANDOM_BYTES_LENGTH = 32;
+
+function parseAgentToken(options: {
+  token: string | undefined;
+  marker: string;
+  field: "accessToken" | "refreshToken";
+}): string {
+  const trimmedToken = options.token?.trim();
+
+  if (!trimmedToken) {
+    throw new AppError({
+      code: "AGENT_AUTH_REFRESH_INVALID",
+      message: "Refresh payload is invalid",
+      status: 400,
+      expose: true,
+      details: {
+        fieldErrors: {
+          [options.field]: [`${options.field} is required`],
+        },
+        formErrors: [],
+      },
+    });
+  }
+
+  if (
+    !trimmedToken.startsWith(options.marker) ||
+    trimmedToken.length <= options.marker.length
+  ) {
+    throw new AppError({
+      code: "AGENT_AUTH_REFRESH_INVALID",
+      message: "Refresh payload is invalid",
+      status: 400,
+      expose: true,
+      details: {
+        fieldErrors: {
+          [options.field]: [`${options.field} format is invalid`],
+        },
+        formErrors: [],
+      },
+    });
+  }
+
+  return trimmedToken;
+}
+
+export function parseAccessToken(token: string | undefined): string {
+  return parseAgentToken({
+    token,
+    marker: AGENT_ACCESS_TOKEN_MARKER,
+    field: "accessToken",
+  });
+}
+
+export function parseRefreshToken(token: string | undefined): string {
+  return parseAgentToken({
+    token,
+    marker: AGENT_REFRESH_TOKEN_MARKER,
+    field: "refreshToken",
+  });
+}
+
+function deriveTokenLookupPrefix(token: string, marker: string): string {
+  const entropyPrefix = token.slice(
+    marker.length,
+    marker.length + AGENT_TOKEN_LOOKUP_ENTROPY_LENGTH,
+  );
+
+  return `${marker}${entropyPrefix}`;
+}
+
+export function deriveAccessTokenLookupPrefix(token: string): string {
+  return deriveTokenLookupPrefix(token, AGENT_ACCESS_TOKEN_MARKER);
+}
+
+export function deriveRefreshTokenLookupPrefix(token: string): string {
+  return deriveTokenLookupPrefix(token, AGENT_REFRESH_TOKEN_MARKER);
+}
+
+export async function hashAgentToken(token: string): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(token),
+  );
+
+  return Array.from(new Uint8Array(digest))
+    .map((value) => value.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function generateToken(marker: string): string {
+  const randomBytes = crypto.getRandomValues(
+    new Uint8Array(AGENT_TOKEN_RANDOM_BYTES_LENGTH),
+  );
+
+  return `${marker}${encodeBase64url(randomBytes)}`;
+}
+
+export function generateAccessToken(): string {
+  return generateToken(AGENT_ACCESS_TOKEN_MARKER);
+}
+
+export function generateRefreshToken(): string {
+  return generateToken(AGENT_REFRESH_TOKEN_MARKER);
+}

--- a/apps/registry/src/auth/agent-claw-auth.ts
+++ b/apps/registry/src/auth/agent-claw-auth.ts
@@ -1,0 +1,147 @@
+import { type AitClaims, decodeBase64url } from "@clawdentity/protocol";
+import {
+  AppError,
+  type RegistryAitVerificationKey,
+  type RegistryConfig,
+  verifyAIT,
+  verifyHttpRequest,
+} from "@clawdentity/sdk";
+import { resolveRegistryIssuer } from "../agent-registration.js";
+
+const DEFAULT_MAX_TIMESTAMP_SKEW_SECONDS = 300;
+
+function unauthorizedError(message: string): AppError {
+  return new AppError({
+    code: "AGENT_AUTH_REFRESH_UNAUTHORIZED",
+    message,
+    status: 401,
+    expose: true,
+  });
+}
+
+function parseClawAuthorizationHeader(authorization?: string): string {
+  if (typeof authorization !== "string" || authorization.trim().length === 0) {
+    throw unauthorizedError("Authorization header is required");
+  }
+
+  const parsed = authorization.trim().match(/^Claw\s+(\S+)$/);
+  if (!parsed || parsed[1].trim().length === 0) {
+    throw unauthorizedError("Authorization must be in the format 'Claw <ait>'");
+  }
+
+  return parsed[1].trim();
+}
+
+function parseUnixTimestamp(headerValue: string): number {
+  if (!/^\d+$/.test(headerValue)) {
+    throw unauthorizedError("X-Claw-Timestamp must be a unix seconds integer");
+  }
+
+  const timestamp = Number.parseInt(headerValue, 10);
+  if (!Number.isInteger(timestamp) || timestamp < 0) {
+    throw unauthorizedError("X-Claw-Timestamp must be a unix seconds integer");
+  }
+
+  return timestamp;
+}
+
+function assertTimestampWithinSkew(options: {
+  nowMs: number;
+  maxSkewSeconds: number;
+  timestampSeconds: number;
+}): void {
+  const nowSeconds = Math.floor(options.nowMs / 1000);
+  const skew = Math.abs(nowSeconds - options.timestampSeconds);
+
+  if (skew > options.maxSkewSeconds) {
+    throw unauthorizedError(
+      "X-Claw-Timestamp is outside the allowed skew window",
+    );
+  }
+}
+
+function toPathWithQuery(url: string): string {
+  const parsed = new URL(url, "http://localhost");
+  return `${parsed.pathname}${parsed.search}`;
+}
+
+function buildRegistryVerificationKeys(
+  keys: RegistryConfig["REGISTRY_SIGNING_KEYS"],
+): RegistryAitVerificationKey[] {
+  return (keys ?? [])
+    .filter((key) => key.status === "active")
+    .map((key) => ({
+      kid: key.kid,
+      jwk: {
+        kty: "OKP",
+        crv: "Ed25519",
+        x: key.x,
+      },
+    }));
+}
+
+export async function verifyAgentClawRequest(input: {
+  config: RegistryConfig;
+  request: Request;
+  bodyBytes: Uint8Array;
+  nowMs?: number;
+  maxTimestampSkewSeconds?: number;
+}): Promise<AitClaims> {
+  const nowMs = input.nowMs ?? Date.now();
+  const maxTimestampSkewSeconds =
+    input.maxTimestampSkewSeconds ?? DEFAULT_MAX_TIMESTAMP_SKEW_SECONDS;
+  const token = parseClawAuthorizationHeader(
+    input.request.headers.get("authorization") ?? undefined,
+  );
+  const expectedIssuer = resolveRegistryIssuer(input.config.ENVIRONMENT);
+  const verificationKeys = buildRegistryVerificationKeys(
+    input.config.REGISTRY_SIGNING_KEYS,
+  );
+
+  if (verificationKeys.length === 0) {
+    throw unauthorizedError("Registry signing keys are unavailable");
+  }
+
+  let claims: AitClaims;
+  try {
+    claims = await verifyAIT({
+      token,
+      registryKeys: verificationKeys,
+      expectedIssuer,
+    });
+  } catch {
+    throw unauthorizedError("AIT verification failed");
+  }
+
+  const timestampHeader = input.request.headers.get("x-claw-timestamp");
+  if (!timestampHeader) {
+    throw unauthorizedError("X-Claw-Timestamp header is required");
+  }
+
+  assertTimestampWithinSkew({
+    nowMs,
+    maxSkewSeconds: maxTimestampSkewSeconds,
+    timestampSeconds: parseUnixTimestamp(timestampHeader),
+  });
+
+  let cnfPublicKey: Uint8Array;
+  try {
+    cnfPublicKey = decodeBase64url(claims.cnf.jwk.x);
+  } catch {
+    throw unauthorizedError("AIT public key is invalid");
+  }
+
+  try {
+    await verifyHttpRequest({
+      method: input.request.method,
+      pathWithQuery: toPathWithQuery(input.request.url),
+      headers: Object.fromEntries(input.request.headers.entries()),
+      body: input.bodyBytes,
+      publicKey: cnfPublicKey,
+    });
+  } catch {
+    throw unauthorizedError("PoP verification failed");
+  }
+
+  return claims;
+}

--- a/apps/registry/src/db/AGENTS.md
+++ b/apps/registry/src/db/AGENTS.md
@@ -9,9 +9,11 @@
 - Treat contract tests (for example `schema.contract.test.ts`) as executable checks for required table/index coverage.
 
 ## Baseline Requirements
-- Required tables: `humans`, `agents`, `revocations`, `api_keys`.
+- Required tables: `humans`, `agents`, `revocations`, `api_keys`, `agent_auth_sessions`, `agent_auth_events`.
 - Required index: `idx_agents_owner_status` on `agents(owner_id, status)`.
 - Revocation `jti` lookup can be unique or non-unique; current baseline uses `revocations_jti_unique`.
+- Agent auth refresh lookups require prefix indexes on `agent_auth_sessions.refresh_key_prefix` and `agent_auth_sessions.access_key_prefix`.
+- One session per agent is enforced by `agent_auth_sessions_agent_id_unique`.
 
 ## Query Rules
 - Prefer Drizzle (`createDb`) for application reads/writes.

--- a/apps/registry/src/db/schema.contract.test.ts
+++ b/apps/registry/src/db/schema.contract.test.ts
@@ -1,13 +1,23 @@
 import { getTableName } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 import migrationSql from "../../drizzle/0000_common_marrow.sql?raw";
-import { agents, api_keys, humans, revocations } from "./schema.js";
+import authMigrationSql from "../../drizzle/0002_agent_auth_refresh.sql?raw";
+import {
+  agent_auth_events,
+  agent_auth_sessions,
+  agents,
+  api_keys,
+  humans,
+  revocations,
+} from "./schema.js";
 
 const t10RequiredTables = [
   "humans",
   "agents",
   "revocations",
   "api_keys",
+  "agent_auth_sessions",
+  "agent_auth_events",
 ] as const;
 describe("T10 schema contract", () => {
   it("defines required table names in schema source", () => {
@@ -15,11 +25,13 @@ describe("T10 schema contract", () => {
     expect(getTableName(agents)).toBe("agents");
     expect(getTableName(revocations)).toBe("revocations");
     expect(getTableName(api_keys)).toBe("api_keys");
+    expect(getTableName(agent_auth_sessions)).toBe("agent_auth_sessions");
+    expect(getTableName(agent_auth_events)).toBe("agent_auth_events");
   });
 
   it("contains required tables in baseline migration SQL", () => {
     for (const tableName of t10RequiredTables) {
-      expect(migrationSql).toMatch(
+      expect(`${migrationSql}\n${authMigrationSql}`).toMatch(
         new RegExp(String.raw`CREATE TABLE \`${tableName}\``),
       );
     }
@@ -34,6 +46,15 @@ describe("T10 schema contract", () => {
   it("creates a revocations jti lookup index (unique or non-unique)", () => {
     expect(migrationSql).toMatch(
       /CREATE (?:UNIQUE )?INDEX `[^`]+` ON `revocations` \(`jti`\);/,
+    );
+  });
+
+  it("creates required agent auth session indexes", () => {
+    expect(authMigrationSql).toMatch(
+      /CREATE UNIQUE INDEX `agent_auth_sessions_agent_id_unique` ON `agent_auth_sessions` \(`agent_id`\);/,
+    );
+    expect(authMigrationSql).toMatch(
+      /CREATE INDEX `idx_agent_auth_sessions_refresh_prefix` ON `agent_auth_sessions` \(`refresh_key_prefix`\);/,
     );
   });
 });

--- a/apps/registry/src/db/schema.ts
+++ b/apps/registry/src/db/schema.ts
@@ -1,4 +1,4 @@
-import { index, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { index, sqliteTable, text, uniqueIndex } from "drizzle-orm/sqlite-core";
 
 export const humans = sqliteTable("humans", {
   id: text("id").primaryKey(),
@@ -95,6 +95,72 @@ export const agent_registration_challenges = sqliteTable(
       table.status,
     ),
     index("idx_agent_registration_challenges_expires_at").on(table.expires_at),
+  ],
+);
+
+export const agent_auth_sessions = sqliteTable(
+  "agent_auth_sessions",
+  {
+    id: text("id").primaryKey(),
+    agent_id: text("agent_id")
+      .notNull()
+      .references(() => agents.id),
+    refresh_key_hash: text("refresh_key_hash").notNull(),
+    refresh_key_prefix: text("refresh_key_prefix").notNull(),
+    refresh_issued_at: text("refresh_issued_at").notNull(),
+    refresh_expires_at: text("refresh_expires_at").notNull(),
+    refresh_last_used_at: text("refresh_last_used_at"),
+    access_key_hash: text("access_key_hash").notNull(),
+    access_key_prefix: text("access_key_prefix").notNull(),
+    access_issued_at: text("access_issued_at").notNull(),
+    access_expires_at: text("access_expires_at").notNull(),
+    access_last_used_at: text("access_last_used_at"),
+    status: text("status", { enum: ["active", "revoked"] })
+      .notNull()
+      .default("active"),
+    revoked_at: text("revoked_at"),
+    created_at: text("created_at").notNull(),
+    updated_at: text("updated_at").notNull(),
+  },
+  (table) => [
+    uniqueIndex("agent_auth_sessions_agent_id_unique").on(table.agent_id),
+    index("idx_agent_auth_sessions_agent_status").on(
+      table.agent_id,
+      table.status,
+    ),
+    index("idx_agent_auth_sessions_refresh_prefix").on(
+      table.refresh_key_prefix,
+    ),
+    index("idx_agent_auth_sessions_access_prefix").on(table.access_key_prefix),
+  ],
+);
+
+export const agent_auth_events = sqliteTable(
+  "agent_auth_events",
+  {
+    id: text("id").primaryKey(),
+    agent_id: text("agent_id")
+      .notNull()
+      .references(() => agents.id),
+    session_id: text("session_id")
+      .notNull()
+      .references(() => agent_auth_sessions.id),
+    event_type: text("event_type", {
+      enum: ["issued", "refreshed", "revoked", "refresh_rejected"],
+    }).notNull(),
+    reason: text("reason"),
+    metadata_json: text("metadata_json"),
+    created_at: text("created_at").notNull(),
+  },
+  (table) => [
+    index("idx_agent_auth_events_agent_created").on(
+      table.agent_id,
+      table.created_at,
+    ),
+    index("idx_agent_auth_events_session_created").on(
+      table.session_id,
+      table.created_at,
+    ),
   ],
 );
 

--- a/apps/registry/src/server.test.ts
+++ b/apps/registry/src/server.test.ts
@@ -1,5 +1,6 @@
 import {
   ADMIN_BOOTSTRAP_PATH,
+  AGENT_AUTH_REFRESH_PATH,
   AGENT_REGISTRATION_CHALLENGE_PATH,
   type AitClaims,
   canonicalizeAgentRegistrationProof,
@@ -17,6 +18,7 @@ import {
   REQUEST_ID_HEADER,
   signAIT,
   signEd25519,
+  signHttpRequest,
   verifyAIT,
   verifyCRL,
 } from "@clawdentity/sdk";
@@ -26,6 +28,10 @@ import {
   DEFAULT_AGENT_FRAMEWORK,
   DEFAULT_AGENT_TTL_DAYS,
 } from "./agent-registration.js";
+import {
+  deriveRefreshTokenLookupPrefix,
+  hashAgentToken,
+} from "./auth/agent-auth-token.js";
 import {
   deriveApiKeyLookupPrefix,
   hashApiKeyToken,
@@ -89,6 +95,29 @@ type FakeApiKeyRow = {
   createdAt: string;
   lastUsedAt: string | null;
 };
+
+type FakeAgentAuthSessionRow = {
+  id: string;
+  agentId: string;
+  refreshKeyHash: string;
+  refreshKeyPrefix: string;
+  refreshIssuedAt: string;
+  refreshExpiresAt: string;
+  refreshLastUsedAt: string | null;
+  accessKeyHash: string;
+  accessKeyPrefix: string;
+  accessIssuedAt: string;
+  accessExpiresAt: string;
+  accessLastUsedAt: string | null;
+  status: "active" | "revoked";
+  revokedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type FakeAgentAuthEventInsertRow = Record<string, unknown>;
+type FakeAgentAuthSessionInsertRow = Record<string, unknown>;
+type FakeAgentAuthSessionUpdateRow = Record<string, unknown>;
 type FakeApiKeySelectRow = {
   id: string;
   human_id: string;
@@ -172,6 +201,7 @@ type FakeDbOptions = {
   inviteRows?: FakeInviteRow[];
   revocationRows?: FakeRevocationRow[];
   registrationChallengeRows?: FakeAgentRegistrationChallengeRow[];
+  agentAuthSessionRows?: FakeAgentAuthSessionRow[];
 };
 
 type FakeCrlSelectRow = {
@@ -584,6 +614,112 @@ function resolveApiKeySelectRows(options: {
   return rows.slice(0, limit);
 }
 
+function getAgentAuthSessionSelectColumnValue(
+  row: FakeAgentAuthSessionRow,
+  column: string,
+): unknown {
+  if (column === "id") {
+    return row.id;
+  }
+  if (column === "agent_id") {
+    return row.agentId;
+  }
+  if (column === "refresh_key_hash") {
+    return row.refreshKeyHash;
+  }
+  if (column === "refresh_key_prefix") {
+    return row.refreshKeyPrefix;
+  }
+  if (column === "refresh_issued_at") {
+    return row.refreshIssuedAt;
+  }
+  if (column === "refresh_expires_at") {
+    return row.refreshExpiresAt;
+  }
+  if (column === "refresh_last_used_at") {
+    return row.refreshLastUsedAt;
+  }
+  if (column === "access_key_hash") {
+    return row.accessKeyHash;
+  }
+  if (column === "access_key_prefix") {
+    return row.accessKeyPrefix;
+  }
+  if (column === "access_issued_at") {
+    return row.accessIssuedAt;
+  }
+  if (column === "access_expires_at") {
+    return row.accessExpiresAt;
+  }
+  if (column === "access_last_used_at") {
+    return row.accessLastUsedAt;
+  }
+  if (column === "status") {
+    return row.status;
+  }
+  if (column === "revoked_at") {
+    return row.revokedAt;
+  }
+  if (column === "created_at") {
+    return row.createdAt;
+  }
+  if (column === "updated_at") {
+    return row.updatedAt;
+  }
+  return undefined;
+}
+
+function resolveAgentAuthSessionSelectRows(options: {
+  query: string;
+  params: unknown[];
+  sessionRows: FakeAgentAuthSessionRow[];
+}): FakeAgentAuthSessionRow[] {
+  const whereClause = extractWhereClause(options.query);
+  const equalityParams = parseWhereEqualityParams({
+    whereClause,
+    params: options.params,
+  });
+  const hasAgentIdFilter = hasFilter(whereClause, "agent_id");
+  const hasIdFilter = hasFilter(whereClause, "id");
+  const hasStatusFilter = hasFilter(whereClause, "status");
+  const hasRefreshPrefixFilter = hasFilter(whereClause, "refresh_key_prefix");
+  const hasLimitClause = options.query.toLowerCase().includes(" limit ");
+
+  const agentId =
+    hasAgentIdFilter && typeof equalityParams.values.agent_id?.[0] === "string"
+      ? String(equalityParams.values.agent_id[0])
+      : undefined;
+  const id =
+    hasIdFilter && typeof equalityParams.values.id?.[0] === "string"
+      ? String(equalityParams.values.id[0])
+      : undefined;
+  const status =
+    hasStatusFilter && typeof equalityParams.values.status?.[0] === "string"
+      ? String(equalityParams.values.status[0])
+      : undefined;
+  const refreshPrefix =
+    hasRefreshPrefixFilter &&
+    typeof equalityParams.values.refresh_key_prefix?.[0] === "string"
+      ? String(equalityParams.values.refresh_key_prefix[0])
+      : undefined;
+
+  const maybeLimit = hasLimitClause
+    ? Number(options.params[options.params.length - 1])
+    : Number.NaN;
+  const limit = Number.isFinite(maybeLimit)
+    ? maybeLimit
+    : options.sessionRows.length;
+
+  return options.sessionRows
+    .filter((row) => (agentId ? row.agentId === agentId : true))
+    .filter((row) => (id ? row.id === id : true))
+    .filter((row) => (status ? row.status === status : true))
+    .filter((row) =>
+      refreshPrefix ? row.refreshKeyPrefix === refreshPrefix : true,
+    )
+    .slice(0, limit);
+}
+
 function resolveAgentSelectRows(options: {
   query: string;
   params: unknown[];
@@ -600,6 +736,7 @@ function resolveAgentSelectRows(options: {
   const hasStatusFilter = hasFilter(whereClause, "status");
   const hasFrameworkFilter = hasFilter(whereClause, "framework");
   const hasIdFilter = hasFilter(whereClause, "id");
+  const hasDidFilter = hasFilter(whereClause, "did");
   const hasCurrentJtiFilter = hasFilter(whereClause, "current_jti");
   const hasCursorFilter = hasFilter(whereClause, "id", "<");
   const hasLimitClause = options.query.toLowerCase().includes(" limit ");
@@ -624,6 +761,10 @@ function resolveAgentSelectRows(options: {
     hasIdFilter && typeof equalityParams.values.id?.[0] === "string"
       ? String(equalityParams.values.id?.[0])
       : undefined;
+  const didFilter =
+    hasDidFilter && typeof equalityParams.values.did?.[0] === "string"
+      ? String(equalityParams.values.did?.[0])
+      : undefined;
   const currentJtiFilter = hasCurrentJtiFilter
     ? (equalityParams.values.current_jti?.[0] as string | null | undefined)
     : undefined;
@@ -645,6 +786,7 @@ function resolveAgentSelectRows(options: {
       frameworkFilter ? row.framework === frameworkFilter : true,
     )
     .filter((row) => (idFilter ? row.id === idFilter : true))
+    .filter((row) => (didFilter ? row.did === didFilter : true))
     .filter((row) =>
       currentJtiFilter !== undefined
         ? (row.currentJti ?? null) === currentJtiFilter
@@ -872,12 +1014,16 @@ function createFakeDb(
     [];
   const agentRegistrationChallengeUpdates: FakeAgentRegistrationChallengeUpdateRow[] =
     [];
+  const agentAuthSessionInserts: FakeAgentAuthSessionInsertRow[] = [];
+  const agentAuthSessionUpdates: FakeAgentAuthSessionUpdateRow[] = [];
+  const agentAuthEventInserts: FakeAgentAuthEventInsertRow[] = [];
   const inviteInserts: FakeInviteInsertRow[] = [];
   const inviteUpdates: FakeInviteUpdateRow[] = [];
   const revocationRows = [...(options.revocationRows ?? [])];
   const registrationChallengeRows = [
     ...(options.registrationChallengeRows ?? []),
   ];
+  const agentAuthSessionRows = [...(options.agentAuthSessionRows ?? [])];
   const inviteRows = [...(options.inviteRows ?? [])];
   const humanRows = rows.reduce<FakeHumanRow[]>((acc, row) => {
     if (acc.some((item) => item.id === row.humanId)) {
@@ -1074,6 +1220,38 @@ function createFakeDb(
             };
           }
           if (
+            (normalizedQuery.includes('from "agent_auth_sessions"') ||
+              normalizedQuery.includes("from agent_auth_sessions")) &&
+            (normalizedQuery.includes("select") ||
+              normalizedQuery.includes("returning"))
+          ) {
+            const resultRows = resolveAgentAuthSessionSelectRows({
+              query,
+              params,
+              sessionRows: agentAuthSessionRows,
+            });
+            const selectedColumns = parseSelectedColumns(query);
+
+            return {
+              results: resultRows.map((row) => {
+                if (selectedColumns.length === 0) {
+                  return row;
+                }
+
+                return selectedColumns.reduce<Record<string, unknown>>(
+                  (acc, column) => {
+                    acc[column] = getAgentAuthSessionSelectColumnValue(
+                      row,
+                      column,
+                    );
+                    return acc;
+                  },
+                  {},
+                );
+              }),
+            };
+          }
+          if (
             (normalizedQuery.includes('from "invites"') ||
               normalizedQuery.includes("from invites")) &&
             (normalizedQuery.includes("select") ||
@@ -1165,6 +1343,22 @@ function createFakeDb(
             return resultRows.map((row) =>
               selectedColumns.map((column) =>
                 getApiKeySelectColumnValue(row, column),
+              ),
+            );
+          }
+          if (
+            normalizedQuery.includes('from "agent_auth_sessions"') ||
+            normalizedQuery.includes("from agent_auth_sessions")
+          ) {
+            const resultRows = resolveAgentAuthSessionSelectRows({
+              query,
+              params,
+              sessionRows: agentAuthSessionRows,
+            });
+            const selectedColumns = parseSelectedColumns(query);
+            return resultRows.map((row) =>
+              selectedColumns.map((column) =>
+                getAgentAuthSessionSelectColumnValue(row, column),
               ),
             );
           }
@@ -1415,6 +1609,235 @@ function createFakeDb(
             }
 
             changes = 1;
+          }
+          if (
+            normalizedQuery.includes('insert into "agent_auth_sessions"') ||
+            normalizedQuery.includes("insert into agent_auth_sessions")
+          ) {
+            const columns = parseInsertColumns(query, "agent_auth_sessions");
+            const row = columns.reduce<FakeAgentAuthSessionInsertRow>(
+              (acc, column, index) => {
+                acc[column] = params[index];
+                return acc;
+              },
+              {},
+            );
+            agentAuthSessionInserts.push(row);
+
+            if (
+              typeof row.id === "string" &&
+              typeof row.agent_id === "string" &&
+              typeof row.refresh_key_hash === "string" &&
+              typeof row.refresh_key_prefix === "string" &&
+              typeof row.refresh_issued_at === "string" &&
+              typeof row.refresh_expires_at === "string" &&
+              typeof row.access_key_hash === "string" &&
+              typeof row.access_key_prefix === "string" &&
+              typeof row.access_issued_at === "string" &&
+              typeof row.access_expires_at === "string" &&
+              (row.status === "active" || row.status === "revoked") &&
+              typeof row.created_at === "string" &&
+              typeof row.updated_at === "string"
+            ) {
+              const existingIndex = agentAuthSessionRows.findIndex(
+                (sessionRow) => sessionRow.agentId === row.agent_id,
+              );
+              const nextSession: FakeAgentAuthSessionRow = {
+                id: row.id,
+                agentId: row.agent_id,
+                refreshKeyHash: row.refresh_key_hash,
+                refreshKeyPrefix: row.refresh_key_prefix,
+                refreshIssuedAt: row.refresh_issued_at,
+                refreshExpiresAt: row.refresh_expires_at,
+                refreshLastUsedAt:
+                  typeof row.refresh_last_used_at === "string"
+                    ? row.refresh_last_used_at
+                    : null,
+                accessKeyHash: row.access_key_hash,
+                accessKeyPrefix: row.access_key_prefix,
+                accessIssuedAt: row.access_issued_at,
+                accessExpiresAt: row.access_expires_at,
+                accessLastUsedAt:
+                  typeof row.access_last_used_at === "string"
+                    ? row.access_last_used_at
+                    : null,
+                status: row.status,
+                revokedAt:
+                  typeof row.revoked_at === "string" ? row.revoked_at : null,
+                createdAt: row.created_at,
+                updatedAt: row.updated_at,
+              };
+              if (existingIndex >= 0) {
+                agentAuthSessionRows.splice(existingIndex, 1, nextSession);
+              } else {
+                agentAuthSessionRows.push(nextSession);
+              }
+            }
+
+            changes = 1;
+          }
+          if (
+            normalizedQuery.includes('insert into "agent_auth_events"') ||
+            normalizedQuery.includes("insert into agent_auth_events")
+          ) {
+            const columns = parseInsertColumns(query, "agent_auth_events");
+            const row = columns.reduce<FakeAgentAuthEventInsertRow>(
+              (acc, column, index) => {
+                acc[column] = params[index];
+                return acc;
+              },
+              {},
+            );
+            agentAuthEventInserts.push(row);
+            changes = 1;
+          }
+          if (
+            normalizedQuery.includes('update "agent_auth_sessions"') ||
+            normalizedQuery.includes("update agent_auth_sessions")
+          ) {
+            const setColumns = parseUpdateSetColumns(
+              query,
+              "agent_auth_sessions",
+            );
+            const nextValues = setColumns.reduce<Record<string, unknown>>(
+              (acc, column, index) => {
+                acc[column] = params[index];
+                return acc;
+              },
+              {},
+            );
+            const whereClause = extractWhereClause(query);
+            const whereParams = params.slice(setColumns.length);
+            const equalityParams = parseWhereEqualityParams({
+              whereClause,
+              params: whereParams,
+            });
+
+            const idFilter =
+              typeof equalityParams.values.id?.[0] === "string"
+                ? String(equalityParams.values.id[0])
+                : undefined;
+            const agentIdFilter =
+              typeof equalityParams.values.agent_id?.[0] === "string"
+                ? String(equalityParams.values.agent_id[0])
+                : undefined;
+            const statusFilter =
+              typeof equalityParams.values.status?.[0] === "string"
+                ? String(equalityParams.values.status[0])
+                : undefined;
+            const refreshHashFilter =
+              typeof equalityParams.values.refresh_key_hash?.[0] === "string"
+                ? String(equalityParams.values.refresh_key_hash[0])
+                : undefined;
+
+            let matchedRows = 0;
+            for (const row of agentAuthSessionRows) {
+              if (idFilter && row.id !== idFilter) {
+                continue;
+              }
+              if (agentIdFilter && row.agentId !== agentIdFilter) {
+                continue;
+              }
+              if (statusFilter && row.status !== statusFilter) {
+                continue;
+              }
+              if (
+                refreshHashFilter &&
+                row.refreshKeyHash !== refreshHashFilter
+              ) {
+                continue;
+              }
+
+              matchedRows += 1;
+              if (typeof nextValues.refresh_key_hash === "string") {
+                row.refreshKeyHash = nextValues.refresh_key_hash;
+              }
+              if (typeof nextValues.refresh_key_prefix === "string") {
+                row.refreshKeyPrefix = nextValues.refresh_key_prefix;
+              }
+              if (typeof nextValues.refresh_issued_at === "string") {
+                row.refreshIssuedAt = nextValues.refresh_issued_at;
+              }
+              if (typeof nextValues.refresh_expires_at === "string") {
+                row.refreshExpiresAt = nextValues.refresh_expires_at;
+              }
+              if (
+                typeof nextValues.refresh_last_used_at === "string" ||
+                nextValues.refresh_last_used_at === null
+              ) {
+                row.refreshLastUsedAt = nextValues.refresh_last_used_at;
+              }
+              if (typeof nextValues.access_key_hash === "string") {
+                row.accessKeyHash = nextValues.access_key_hash;
+              }
+              if (typeof nextValues.access_key_prefix === "string") {
+                row.accessKeyPrefix = nextValues.access_key_prefix;
+              }
+              if (typeof nextValues.access_issued_at === "string") {
+                row.accessIssuedAt = nextValues.access_issued_at;
+              }
+              if (typeof nextValues.access_expires_at === "string") {
+                row.accessExpiresAt = nextValues.access_expires_at;
+              }
+              if (
+                typeof nextValues.access_last_used_at === "string" ||
+                nextValues.access_last_used_at === null
+              ) {
+                row.accessLastUsedAt = nextValues.access_last_used_at;
+              }
+              if (
+                nextValues.status === "active" ||
+                nextValues.status === "revoked"
+              ) {
+                row.status = nextValues.status;
+              }
+              if (
+                typeof nextValues.revoked_at === "string" ||
+                nextValues.revoked_at === null
+              ) {
+                row.revokedAt = nextValues.revoked_at;
+              }
+              if (typeof nextValues.updated_at === "string") {
+                row.updatedAt = nextValues.updated_at;
+              }
+            }
+
+            agentAuthSessionUpdates.push({
+              ...nextValues,
+              id: idFilter,
+              agent_id: agentIdFilter,
+              status_where: statusFilter,
+              refresh_key_hash_where: refreshHashFilter,
+              matched_rows: matchedRows,
+            });
+            changes = matchedRows;
+          }
+          if (
+            normalizedQuery.includes('delete from "agent_auth_sessions"') ||
+            normalizedQuery.includes("delete from agent_auth_sessions")
+          ) {
+            const whereClause = extractWhereClause(query);
+            const equalityParams = parseWhereEqualityParams({
+              whereClause,
+              params,
+            });
+            const idFilter =
+              typeof equalityParams.values.id?.[0] === "string"
+                ? String(equalityParams.values.id[0])
+                : undefined;
+
+            if (idFilter) {
+              for (
+                let index = agentAuthSessionRows.length - 1;
+                index >= 0;
+                index -= 1
+              ) {
+                if (agentAuthSessionRows[index]?.id === idFilter) {
+                  agentAuthSessionRows.splice(index, 1);
+                  changes += 1;
+                }
+              }
+            }
           }
           if (
             normalizedQuery.includes('insert into "invites"') ||
@@ -1824,6 +2247,10 @@ function createFakeDb(
     humanRows,
     humanInserts,
     apiKeyInserts,
+    agentAuthSessionRows,
+    agentAuthSessionInserts,
+    agentAuthSessionUpdates,
+    agentAuthEventInserts,
     agentInserts,
     agentUpdates,
     agentRegistrationChallengeInserts,
@@ -1879,6 +2306,40 @@ async function signRegistrationChallenge(options: {
     options.secretKey,
   );
   return encodeEd25519SignatureBase64url(signature);
+}
+
+async function createSignedAgentRefreshRequest(options: {
+  ait: string;
+  secretKey: Uint8Array;
+  refreshToken: string;
+  timestamp?: string;
+  nonce?: string;
+}): Promise<{
+  body: string;
+  headers: Record<string, string>;
+}> {
+  const timestamp = options.timestamp ?? String(Math.floor(Date.now() / 1000));
+  const nonce = options.nonce ?? "nonce-agent-refresh";
+  const body = JSON.stringify({
+    refreshToken: options.refreshToken,
+  });
+  const signed = await signHttpRequest({
+    method: "POST",
+    pathWithQuery: AGENT_AUTH_REFRESH_PATH,
+    timestamp,
+    nonce,
+    body: new TextEncoder().encode(body),
+    secretKey: options.secretKey,
+  });
+
+  return {
+    body,
+    headers: {
+      authorization: `Claw ${options.ait}`,
+      "content-type": "application/json",
+      ...signed.headers,
+    },
+  };
 }
 
 describe("GET /health", () => {
@@ -5126,7 +5587,12 @@ describe("POST /v1/agents", () => {
 
   it("creates an agent, defaults framework/ttl, and persists current_jti + expires_at", async () => {
     const { token, authRow } = await makeValidPatContext();
-    const { database, agentInserts } = createFakeDb([authRow]);
+    const {
+      database,
+      agentInserts,
+      agentAuthSessionInserts,
+      agentAuthEventInserts,
+    } = createFakeDb([authRow]);
     const signer = await generateEd25519Keypair();
     const agentKeypair = await generateEd25519Keypair();
     const appInstance = createRegistryApp();
@@ -5221,6 +5687,13 @@ describe("POST /v1/agents", () => {
         updatedAt: string;
       };
       ait: string;
+      agentAuth: {
+        tokenType: string;
+        accessToken: string;
+        accessExpiresAt: string;
+        refreshToken: string;
+        refreshExpiresAt: string;
+      };
     };
 
     expect(body.agent.name).toBe("agent-01");
@@ -5229,6 +5702,15 @@ describe("POST /v1/agents", () => {
     expect(body.agent.publicKey).toBe(encodeBase64url(agentKeypair.publicKey));
     expect(body.agent.status).toBe("active");
     expect(body.ait).toEqual(expect.any(String));
+    expect(body.agentAuth.tokenType).toBe("Bearer");
+    expect(body.agentAuth.accessToken.startsWith("clw_agt_")).toBe(true);
+    expect(body.agentAuth.refreshToken.startsWith("clw_rft_")).toBe(true);
+    expect(Date.parse(body.agentAuth.accessExpiresAt)).toBeGreaterThan(
+      Date.now(),
+    );
+    expect(Date.parse(body.agentAuth.refreshExpiresAt)).toBeGreaterThan(
+      Date.now(),
+    );
 
     expect(agentInserts).toHaveLength(1);
     const inserted = agentInserts[0];
@@ -5238,6 +5720,16 @@ describe("POST /v1/agents", () => {
     expect(inserted?.public_key).toBe(encodeBase64url(agentKeypair.publicKey));
     expect(inserted?.current_jti).toBe(body.agent.currentJti);
     expect(inserted?.expires_at).toBe(body.agent.expiresAt);
+    expect(agentAuthSessionInserts).toHaveLength(1);
+    expect(agentAuthSessionInserts[0]).toMatchObject({
+      agent_id: body.agent.id,
+      status: "active",
+    });
+    expect(agentAuthEventInserts).toHaveLength(1);
+    expect(agentAuthEventInserts[0]).toMatchObject({
+      agent_id: body.agent.id,
+      event_type: "issued",
+    });
   });
 
   it("returns verifiable AIT using published keyset", async () => {
@@ -5458,5 +5950,402 @@ describe("POST /v1/agents", () => {
     expect(body.error.details?.fieldErrors).toMatchObject({
       REGISTRY_SIGNING_KEYS: expect.any(Array),
     });
+  });
+});
+
+describe(`POST ${AGENT_AUTH_REFRESH_PATH}`, () => {
+  async function buildRefreshFixture() {
+    const signer = await generateEd25519Keypair();
+    const agentKeypair = await generateEd25519Keypair();
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const agentId = generateUlid(Date.now());
+    const agentDid = makeAgentDid(agentId);
+    const aitJti = generateUlid(Date.now() + 1);
+    const refreshToken =
+      "clw_rft_fixture_refresh_token_value_for_registry_tests";
+    const refreshTokenHash = await hashAgentToken(refreshToken);
+    const ait = await signAIT({
+      claims: {
+        iss: "https://dev.api.clawdentity.com",
+        sub: agentDid,
+        ownerDid: makeHumanDid(generateUlid(Date.now() + 2)),
+        name: "agent-refresh-01",
+        framework: "openclaw",
+        cnf: {
+          jwk: {
+            kty: "OKP",
+            crv: "Ed25519",
+            x: encodeBase64url(agentKeypair.publicKey),
+          },
+        },
+        iat: nowSeconds - 10,
+        nbf: nowSeconds - 10,
+        exp: nowSeconds + 3600,
+        jti: aitJti,
+      },
+      signerKid: "reg-key-1",
+      signerKeypair: signer,
+    });
+
+    return {
+      signer,
+      agentKeypair,
+      agentId,
+      agentDid,
+      aitJti,
+      ait,
+      refreshToken,
+      refreshTokenHash,
+    };
+  }
+
+  it("rotates refresh credentials and returns a new agent auth bundle", async () => {
+    const fixture = await buildRefreshFixture();
+    const nowIso = new Date().toISOString();
+    const refreshExpiresAt = new Date(Date.now() + 60_000).toISOString();
+    const {
+      database,
+      agentAuthSessionRows,
+      agentAuthSessionUpdates,
+      agentAuthEventInserts,
+    } = createFakeDb(
+      [],
+      [
+        {
+          id: fixture.agentId,
+          did: fixture.agentDid,
+          ownerId: "human-1",
+          name: "agent-refresh-01",
+          framework: "openclaw",
+          publicKey: encodeBase64url(fixture.agentKeypair.publicKey),
+          status: "active",
+          expiresAt: null,
+          currentJti: fixture.aitJti,
+        },
+      ],
+      {
+        agentAuthSessionRows: [
+          {
+            id: generateUlid(Date.now() + 3),
+            agentId: fixture.agentId,
+            refreshKeyHash: fixture.refreshTokenHash,
+            refreshKeyPrefix: deriveRefreshTokenLookupPrefix(
+              fixture.refreshToken,
+            ),
+            refreshIssuedAt: nowIso,
+            refreshExpiresAt,
+            refreshLastUsedAt: null,
+            accessKeyHash: "old-access-hash",
+            accessKeyPrefix: "clw_agt_old",
+            accessIssuedAt: nowIso,
+            accessExpiresAt: refreshExpiresAt,
+            accessLastUsedAt: null,
+            status: "active",
+            revokedAt: null,
+            createdAt: nowIso,
+            updatedAt: nowIso,
+          },
+        ],
+      },
+    );
+    const request = await createSignedAgentRefreshRequest({
+      ait: fixture.ait,
+      secretKey: fixture.agentKeypair.secretKey,
+      refreshToken: fixture.refreshToken,
+    });
+
+    const response = await createRegistryApp().request(
+      AGENT_AUTH_REFRESH_PATH,
+      {
+        method: "POST",
+        headers: request.headers,
+        body: request.body,
+      },
+      {
+        DB: database,
+        ENVIRONMENT: "test",
+        REGISTRY_SIGNING_KEY: encodeBase64url(fixture.signer.secretKey),
+        REGISTRY_SIGNING_KEYS: JSON.stringify([
+          {
+            kid: "reg-key-1",
+            alg: "EdDSA",
+            crv: "Ed25519",
+            x: encodeBase64url(fixture.signer.publicKey),
+            status: "active",
+          },
+        ]),
+      },
+    );
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      agentAuth: {
+        tokenType: string;
+        accessToken: string;
+        accessExpiresAt: string;
+        refreshToken: string;
+        refreshExpiresAt: string;
+      };
+    };
+    expect(body.agentAuth.tokenType).toBe("Bearer");
+    expect(body.agentAuth.accessToken.startsWith("clw_agt_")).toBe(true);
+    expect(body.agentAuth.refreshToken.startsWith("clw_rft_")).toBe(true);
+    expect(body.agentAuth.refreshToken).not.toBe(fixture.refreshToken);
+    expect(agentAuthSessionUpdates).toHaveLength(1);
+    expect(agentAuthSessionRows[0]?.refreshKeyPrefix).toBe(
+      deriveRefreshTokenLookupPrefix(body.agentAuth.refreshToken),
+    );
+    expect(agentAuthEventInserts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ event_type: "refreshed" }),
+      ]),
+    );
+  });
+
+  it("rejects refresh when session is revoked", async () => {
+    const fixture = await buildRefreshFixture();
+    const nowIso = new Date().toISOString();
+    const request = await createSignedAgentRefreshRequest({
+      ait: fixture.ait,
+      secretKey: fixture.agentKeypair.secretKey,
+      refreshToken: fixture.refreshToken,
+    });
+    const { database } = createFakeDb(
+      [],
+      [
+        {
+          id: fixture.agentId,
+          did: fixture.agentDid,
+          ownerId: "human-1",
+          name: "agent-refresh-01",
+          framework: "openclaw",
+          publicKey: encodeBase64url(fixture.agentKeypair.publicKey),
+          status: "active",
+          expiresAt: null,
+          currentJti: fixture.aitJti,
+        },
+      ],
+      {
+        agentAuthSessionRows: [
+          {
+            id: generateUlid(Date.now() + 4),
+            agentId: fixture.agentId,
+            refreshKeyHash: fixture.refreshTokenHash,
+            refreshKeyPrefix: deriveRefreshTokenLookupPrefix(
+              fixture.refreshToken,
+            ),
+            refreshIssuedAt: nowIso,
+            refreshExpiresAt: new Date(Date.now() + 60_000).toISOString(),
+            refreshLastUsedAt: null,
+            accessKeyHash: "old-access-hash",
+            accessKeyPrefix: "clw_agt_old",
+            accessIssuedAt: nowIso,
+            accessExpiresAt: new Date(Date.now() + 60_000).toISOString(),
+            accessLastUsedAt: null,
+            status: "revoked",
+            revokedAt: nowIso,
+            createdAt: nowIso,
+            updatedAt: nowIso,
+          },
+        ],
+      },
+    );
+
+    const response = await createRegistryApp().request(
+      AGENT_AUTH_REFRESH_PATH,
+      {
+        method: "POST",
+        headers: request.headers,
+        body: request.body,
+      },
+      {
+        DB: database,
+        ENVIRONMENT: "test",
+        REGISTRY_SIGNING_KEY: encodeBase64url(fixture.signer.secretKey),
+        REGISTRY_SIGNING_KEYS: JSON.stringify([
+          {
+            kid: "reg-key-1",
+            alg: "EdDSA",
+            crv: "Ed25519",
+            x: encodeBase64url(fixture.signer.publicKey),
+            status: "active",
+          },
+        ]),
+      },
+    );
+
+    expect(response.status).toBe(401);
+    const body = (await response.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("AGENT_AUTH_REFRESH_REVOKED");
+  });
+
+  it("marks expired refresh credentials revoked and returns expired error", async () => {
+    const fixture = await buildRefreshFixture();
+    const nowIso = new Date().toISOString();
+    const {
+      database,
+      agentAuthSessionRows,
+      agentAuthEventInserts,
+      agentAuthSessionUpdates,
+    } = createFakeDb(
+      [],
+      [
+        {
+          id: fixture.agentId,
+          did: fixture.agentDid,
+          ownerId: "human-1",
+          name: "agent-refresh-01",
+          framework: "openclaw",
+          publicKey: encodeBase64url(fixture.agentKeypair.publicKey),
+          status: "active",
+          expiresAt: null,
+          currentJti: fixture.aitJti,
+        },
+      ],
+      {
+        agentAuthSessionRows: [
+          {
+            id: generateUlid(Date.now() + 5),
+            agentId: fixture.agentId,
+            refreshKeyHash: fixture.refreshTokenHash,
+            refreshKeyPrefix: deriveRefreshTokenLookupPrefix(
+              fixture.refreshToken,
+            ),
+            refreshIssuedAt: nowIso,
+            refreshExpiresAt: new Date(Date.now() - 60_000).toISOString(),
+            refreshLastUsedAt: null,
+            accessKeyHash: "old-access-hash",
+            accessKeyPrefix: "clw_agt_old",
+            accessIssuedAt: nowIso,
+            accessExpiresAt: new Date(Date.now() - 60_000).toISOString(),
+            accessLastUsedAt: null,
+            status: "active",
+            revokedAt: null,
+            createdAt: nowIso,
+            updatedAt: nowIso,
+          },
+        ],
+      },
+    );
+    const request = await createSignedAgentRefreshRequest({
+      ait: fixture.ait,
+      secretKey: fixture.agentKeypair.secretKey,
+      refreshToken: fixture.refreshToken,
+    });
+
+    const response = await createRegistryApp().request(
+      AGENT_AUTH_REFRESH_PATH,
+      {
+        method: "POST",
+        headers: request.headers,
+        body: request.body,
+      },
+      {
+        DB: database,
+        ENVIRONMENT: "test",
+        REGISTRY_SIGNING_KEY: encodeBase64url(fixture.signer.secretKey),
+        REGISTRY_SIGNING_KEYS: JSON.stringify([
+          {
+            kid: "reg-key-1",
+            alg: "EdDSA",
+            crv: "Ed25519",
+            x: encodeBase64url(fixture.signer.publicKey),
+            status: "active",
+          },
+        ]),
+      },
+    );
+
+    expect(response.status).toBe(401);
+    const body = (await response.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("AGENT_AUTH_REFRESH_EXPIRED");
+    expect(agentAuthSessionRows[0]?.status).toBe("revoked");
+    expect(agentAuthSessionUpdates).toHaveLength(1);
+    expect(agentAuthEventInserts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ event_type: "revoked" }),
+      ]),
+    );
+  });
+});
+
+describe("DELETE /v1/agents/:id/auth/revoke", () => {
+  it("revokes active session for owned agent and is idempotent", async () => {
+    const { token, authRow } = await makeValidPatContext();
+    const agentId = generateUlid(Date.now() + 10);
+    const nowIso = new Date().toISOString();
+    const { database, agentAuthSessionRows, agentAuthEventInserts } =
+      createFakeDb(
+        [authRow],
+        [
+          {
+            id: agentId,
+            did: makeAgentDid(agentId),
+            ownerId: authRow.humanId,
+            name: "agent-auth-revoke",
+            framework: "openclaw",
+            publicKey: encodeBase64url(new Uint8Array(32)),
+            status: "active",
+            expiresAt: null,
+            currentJti: generateUlid(Date.now() + 11),
+          },
+        ],
+        {
+          agentAuthSessionRows: [
+            {
+              id: generateUlid(Date.now() + 12),
+              agentId,
+              refreshKeyHash: "refresh-hash",
+              refreshKeyPrefix: "clw_rft_test",
+              refreshIssuedAt: nowIso,
+              refreshExpiresAt: new Date(Date.now() + 60_000).toISOString(),
+              refreshLastUsedAt: null,
+              accessKeyHash: "access-hash",
+              accessKeyPrefix: "clw_agt_test",
+              accessIssuedAt: nowIso,
+              accessExpiresAt: new Date(Date.now() + 60_000).toISOString(),
+              accessLastUsedAt: null,
+              status: "active",
+              revokedAt: null,
+              createdAt: nowIso,
+              updatedAt: nowIso,
+            },
+          ],
+        },
+      );
+
+    const appInstance = createRegistryApp();
+    const firstResponse = await appInstance.request(
+      `/v1/agents/${agentId}/auth/revoke`,
+      {
+        method: "DELETE",
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      },
+      { DB: database, ENVIRONMENT: "test" },
+    );
+    expect(firstResponse.status).toBe(204);
+    expect(agentAuthSessionRows[0]?.status).toBe("revoked");
+    expect(agentAuthEventInserts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          event_type: "revoked",
+          reason: "owner_auth_revoke",
+        }),
+      ]),
+    );
+
+    const secondResponse = await appInstance.request(
+      `/v1/agents/${agentId}/auth/revoke`,
+      {
+        method: "DELETE",
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      },
+      { DB: database, ENVIRONMENT: "test" },
+    );
+    expect(secondResponse.status).toBe(204);
   });
 });

--- a/apps/registry/src/server.ts
+++ b/apps/registry/src/server.ts
@@ -1,5 +1,6 @@
 import {
   ADMIN_BOOTSTRAP_PATH,
+  AGENT_AUTH_REFRESH_PATH,
   AGENT_REGISTRATION_CHALLENGE_PATH,
   generateUlid,
   INVITES_PATH,
@@ -23,6 +24,13 @@ import {
 import { and, desc, eq, isNull, lt } from "drizzle-orm";
 import { Hono } from "hono";
 import { parseAdminBootstrapPayload } from "./admin-bootstrap.js";
+import {
+  agentAuthRefreshConflictError,
+  agentAuthRefreshRejectedError,
+  issueAgentAuth,
+  parseAgentAuthRefreshPayload,
+  toAgentAuthResponse,
+} from "./agent-auth-lifecycle.js";
 import { mapAgentListRow, parseAgentListQuery } from "./agent-list.js";
 import {
   buildAgentRegistrationChallenge,
@@ -50,6 +58,11 @@ import {
   parseApiKeyRevokePath,
 } from "./api-key-lifecycle.js";
 import {
+  deriveRefreshTokenLookupPrefix,
+  hashAgentToken,
+} from "./auth/agent-auth-token.js";
+import { verifyAgentClawRequest } from "./auth/agent-claw-auth.js";
+import {
   type AuthenticatedHuman,
   createApiKeyAuth,
 } from "./auth/api-key-auth.js";
@@ -61,6 +74,8 @@ import {
 } from "./auth/api-key-token.js";
 import { createDb } from "./db/client.js";
 import {
+  agent_auth_events,
+  agent_auth_sessions,
   agent_registration_challenges,
   agents,
   api_keys,
@@ -124,6 +139,25 @@ type OwnedAgentRegistrationChallenge = {
   status: "pending" | "used";
   expires_at: string;
   used_at: string | null;
+};
+
+type OwnedAgentAuthSession = {
+  id: string;
+  agent_id: string;
+  refresh_key_hash: string;
+  refresh_key_prefix: string;
+  refresh_issued_at: string;
+  refresh_expires_at: string;
+  refresh_last_used_at: string | null;
+  access_key_hash: string;
+  access_key_prefix: string;
+  access_issued_at: string;
+  access_expires_at: string;
+  access_last_used_at: string | null;
+  status: "active" | "revoked";
+  revoked_at: string | null;
+  created_at: string;
+  updated_at: string;
 };
 
 type InviteRow = {
@@ -246,6 +280,58 @@ async function findOwnedAgent(input: {
   return rows[0];
 }
 
+async function findAgentAuthSessionByAgentId(input: {
+  db: ReturnType<typeof createDb>;
+  agentId: string;
+}): Promise<OwnedAgentAuthSession | undefined> {
+  const rows = await input.db
+    .select({
+      id: agent_auth_sessions.id,
+      agent_id: agent_auth_sessions.agent_id,
+      refresh_key_hash: agent_auth_sessions.refresh_key_hash,
+      refresh_key_prefix: agent_auth_sessions.refresh_key_prefix,
+      refresh_issued_at: agent_auth_sessions.refresh_issued_at,
+      refresh_expires_at: agent_auth_sessions.refresh_expires_at,
+      refresh_last_used_at: agent_auth_sessions.refresh_last_used_at,
+      access_key_hash: agent_auth_sessions.access_key_hash,
+      access_key_prefix: agent_auth_sessions.access_key_prefix,
+      access_issued_at: agent_auth_sessions.access_issued_at,
+      access_expires_at: agent_auth_sessions.access_expires_at,
+      access_last_used_at: agent_auth_sessions.access_last_used_at,
+      status: agent_auth_sessions.status,
+      revoked_at: agent_auth_sessions.revoked_at,
+      created_at: agent_auth_sessions.created_at,
+      updated_at: agent_auth_sessions.updated_at,
+    })
+    .from(agent_auth_sessions)
+    .where(eq(agent_auth_sessions.agent_id, input.agentId))
+    .limit(1);
+
+  return rows[0];
+}
+
+async function findOwnedAgentByDid(input: {
+  db: ReturnType<typeof createDb>;
+  did: string;
+}): Promise<OwnedAgent | undefined> {
+  const rows = await input.db
+    .select({
+      id: agents.id,
+      did: agents.did,
+      name: agents.name,
+      framework: agents.framework,
+      public_key: agents.public_key,
+      status: agents.status,
+      expires_at: agents.expires_at,
+      current_jti: agents.current_jti,
+    })
+    .from(agents)
+    .where(eq(agents.did, input.did))
+    .limit(1);
+
+  return rows[0];
+}
+
 async function findOwnedAgentRegistrationChallenge(input: {
   db: ReturnType<typeof createDb>;
   ownerId: string;
@@ -327,6 +413,36 @@ function isInviteExpired(input: {
   }
 
   return expiresAtMillis <= input.nowMillis;
+}
+
+function isIsoExpired(expiresAtIso: string, nowMillis: number): boolean {
+  const parsed = Date.parse(expiresAtIso);
+  if (!Number.isFinite(parsed)) {
+    return true;
+  }
+
+  return parsed <= nowMillis;
+}
+
+async function insertAgentAuthEvent(input: {
+  db: ReturnType<typeof createDb>;
+  agentId: string;
+  sessionId: string;
+  eventType: "issued" | "refreshed" | "revoked" | "refresh_rejected";
+  reason?: string;
+  metadata?: Record<string, unknown>;
+  createdAt?: string;
+}): Promise<void> {
+  await input.db.insert(agent_auth_events).values({
+    id: generateUlid(Date.now()),
+    agent_id: input.agentId,
+    session_id: input.sessionId,
+    event_type: input.eventType,
+    reason: input.reason ?? null,
+    metadata_json:
+      input.metadata === undefined ? null : JSON.stringify(input.metadata),
+    created_at: input.createdAt ?? nowIso(),
+  });
 }
 
 async function resolveInviteRedeemStateError(input: {
@@ -1212,6 +1328,7 @@ function createRegistryApp() {
       signerKeypair: signer.signerKeypair,
     });
 
+    const initialAuth = await issueAgentAuth();
     const challengeUsedAt = nowIso();
     const applyRegistrationMutation = async (
       executor: typeof db,
@@ -1258,8 +1375,62 @@ function createRegistryApp() {
           created_at: registration.agent.createdAt,
           updated_at: registration.agent.updatedAt,
         });
+
+        await executor.insert(agent_auth_sessions).values({
+          id: initialAuth.sessionId,
+          agent_id: registration.agent.id,
+          refresh_key_hash: initialAuth.refreshTokenHash,
+          refresh_key_prefix: initialAuth.refreshTokenPrefix,
+          refresh_issued_at: initialAuth.refreshIssuedAt,
+          refresh_expires_at: initialAuth.refreshExpiresAt,
+          refresh_last_used_at: null,
+          access_key_hash: initialAuth.accessTokenHash,
+          access_key_prefix: initialAuth.accessTokenPrefix,
+          access_issued_at: initialAuth.accessIssuedAt,
+          access_expires_at: initialAuth.accessExpiresAt,
+          access_last_used_at: null,
+          status: "active",
+          revoked_at: null,
+          created_at: initialAuth.createdAt,
+          updated_at: initialAuth.updatedAt,
+        });
+
+        await insertAgentAuthEvent({
+          db: executor,
+          agentId: registration.agent.id,
+          sessionId: initialAuth.sessionId,
+          eventType: "issued",
+          createdAt: initialAuth.createdAt,
+          metadata: {
+            actor: "agent_registration",
+          },
+        });
       } catch (error) {
         if (options.rollbackOnAgentInsertFailure) {
+          try {
+            await executor
+              .delete(agent_auth_sessions)
+              .where(eq(agent_auth_sessions.id, initialAuth.sessionId));
+          } catch (rollbackError) {
+            logger.error("registry.agent_registration_rollback_failed", {
+              rollbackErrorName:
+                rollbackError instanceof Error ? rollbackError.name : "unknown",
+              stage: "auth_session_delete",
+            });
+          }
+
+          try {
+            await executor
+              .delete(agents)
+              .where(eq(agents.id, registration.agent.id));
+          } catch (rollbackError) {
+            logger.error("registry.agent_registration_rollback_failed", {
+              rollbackErrorName:
+                rollbackError instanceof Error ? rollbackError.name : "unknown",
+              stage: "agent_delete",
+            });
+          }
+
           await executor
             .update(agent_registration_challenges)
             .set({
@@ -1296,7 +1467,269 @@ function createRegistryApp() {
       });
     }
 
-    return c.json({ agent: registration.agent, ait }, 201);
+    return c.json(
+      {
+        agent: registration.agent,
+        ait,
+        agentAuth: toAgentAuthResponse({
+          accessToken: initialAuth.accessToken,
+          accessExpiresAt: initialAuth.accessExpiresAt,
+          refreshToken: initialAuth.refreshToken,
+          refreshExpiresAt: initialAuth.refreshExpiresAt,
+        }),
+      },
+      201,
+    );
+  });
+
+  app.post(AGENT_AUTH_REFRESH_PATH, async (c) => {
+    const config = getConfig(c.env);
+    const exposeDetails = shouldExposeVerboseErrors(config.ENVIRONMENT);
+    const bodyBytes = new Uint8Array(await c.req.raw.clone().arrayBuffer());
+
+    let payload: unknown;
+    try {
+      const rawBody = new TextDecoder().decode(bodyBytes);
+      payload = rawBody.trim().length === 0 ? {} : JSON.parse(rawBody);
+    } catch {
+      throw new AppError({
+        code: "AGENT_AUTH_REFRESH_INVALID",
+        message: exposeDetails
+          ? "Request body must be valid JSON"
+          : "Request could not be processed",
+        status: 400,
+        expose: exposeDetails,
+      });
+    }
+
+    const parsedPayload = parseAgentAuthRefreshPayload({
+      payload,
+      environment: config.ENVIRONMENT,
+    });
+    const claims = await verifyAgentClawRequest({
+      config,
+      request: c.req.raw,
+      bodyBytes,
+    });
+    const nowMillis = Date.now();
+    const db = createDb(c.env.DB);
+    const existingAgent = await findOwnedAgentByDid({
+      db,
+      did: claims.sub,
+    });
+
+    if (!existingAgent || existingAgent.status !== "active") {
+      throw agentAuthRefreshRejectedError({
+        code: "AGENT_AUTH_REFRESH_INVALID",
+        message: "Agent auth refresh token is invalid",
+      });
+    }
+
+    if (existingAgent.current_jti !== claims.jti) {
+      throw agentAuthRefreshRejectedError({
+        code: "AGENT_AUTH_REFRESH_INVALID",
+        message: "Agent auth refresh token is invalid",
+      });
+    }
+
+    const existingSession = await findAgentAuthSessionByAgentId({
+      db,
+      agentId: existingAgent.id,
+    });
+
+    if (!existingSession) {
+      throw agentAuthRefreshRejectedError({
+        code: "AGENT_AUTH_REFRESH_INVALID",
+        message: "Agent auth refresh token is invalid",
+      });
+    }
+
+    if (existingSession.status !== "active") {
+      throw agentAuthRefreshRejectedError({
+        code: "AGENT_AUTH_REFRESH_REVOKED",
+        message: "Agent auth refresh token is revoked",
+      });
+    }
+
+    const refreshPrefix = deriveRefreshTokenLookupPrefix(
+      parsedPayload.refreshToken,
+    );
+    const refreshHash = await hashAgentToken(parsedPayload.refreshToken);
+    const refreshTokenMatches =
+      existingSession.refresh_key_prefix === refreshPrefix &&
+      constantTimeEqual(existingSession.refresh_key_hash, refreshHash);
+
+    if (!refreshTokenMatches) {
+      await insertAgentAuthEvent({
+        db,
+        agentId: existingAgent.id,
+        sessionId: existingSession.id,
+        eventType: "refresh_rejected",
+        reason: "invalid_refresh_token",
+      });
+      throw agentAuthRefreshRejectedError({
+        code: "AGENT_AUTH_REFRESH_INVALID",
+        message: "Agent auth refresh token is invalid",
+      });
+    }
+
+    if (isIsoExpired(existingSession.refresh_expires_at, nowMillis)) {
+      const revokedAt = nowIso();
+      await db
+        .update(agent_auth_sessions)
+        .set({
+          status: "revoked",
+          revoked_at: revokedAt,
+          updated_at: revokedAt,
+        })
+        .where(eq(agent_auth_sessions.id, existingSession.id));
+      await insertAgentAuthEvent({
+        db,
+        agentId: existingAgent.id,
+        sessionId: existingSession.id,
+        eventType: "revoked",
+        reason: "refresh_token_expired",
+        createdAt: revokedAt,
+      });
+      throw agentAuthRefreshRejectedError({
+        code: "AGENT_AUTH_REFRESH_EXPIRED",
+        message: "Agent auth refresh token is expired",
+      });
+    }
+
+    const rotatedAuth = await issueAgentAuth({
+      nowMs: nowMillis,
+    });
+    const refreshedAt = nowIso();
+    const applyRefreshMutation = async (executor: typeof db): Promise<void> => {
+      const updateResult = await executor
+        .update(agent_auth_sessions)
+        .set({
+          refresh_key_hash: rotatedAuth.refreshTokenHash,
+          refresh_key_prefix: rotatedAuth.refreshTokenPrefix,
+          refresh_issued_at: rotatedAuth.refreshIssuedAt,
+          refresh_expires_at: rotatedAuth.refreshExpiresAt,
+          refresh_last_used_at: refreshedAt,
+          access_key_hash: rotatedAuth.accessTokenHash,
+          access_key_prefix: rotatedAuth.accessTokenPrefix,
+          access_issued_at: rotatedAuth.accessIssuedAt,
+          access_expires_at: rotatedAuth.accessExpiresAt,
+          access_last_used_at: null,
+          status: "active",
+          revoked_at: null,
+          updated_at: refreshedAt,
+        })
+        .where(
+          and(
+            eq(agent_auth_sessions.id, existingSession.id),
+            eq(agent_auth_sessions.status, "active"),
+            eq(agent_auth_sessions.refresh_key_hash, refreshHash),
+          ),
+        );
+
+      const updatedRows = getMutationRowCount(updateResult);
+      if (updatedRows === 0) {
+        throw agentAuthRefreshConflictError();
+      }
+
+      await insertAgentAuthEvent({
+        db: executor,
+        agentId: existingAgent.id,
+        sessionId: existingSession.id,
+        eventType: "refreshed",
+        createdAt: refreshedAt,
+      });
+    };
+
+    try {
+      await db.transaction(async (tx) => {
+        await applyRefreshMutation(tx as unknown as typeof db);
+      });
+    } catch (error) {
+      if (!isUnsupportedLocalTransactionError(error)) {
+        throw error;
+      }
+
+      await applyRefreshMutation(db);
+    }
+
+    return c.json({
+      agentAuth: toAgentAuthResponse({
+        accessToken: rotatedAuth.accessToken,
+        accessExpiresAt: rotatedAuth.accessExpiresAt,
+        refreshToken: rotatedAuth.refreshToken,
+        refreshExpiresAt: rotatedAuth.refreshExpiresAt,
+      }),
+    });
+  });
+
+  app.delete("/v1/agents/:id/auth/revoke", createApiKeyAuth(), async (c) => {
+    const config = getConfig(c.env);
+    const agentId = parseAgentRevokePath({
+      id: c.req.param("id"),
+      environment: config.ENVIRONMENT,
+    });
+    const human = c.get("human");
+    const db = createDb(c.env.DB);
+    const existingAgent = await findOwnedAgent({
+      db,
+      ownerId: human.id,
+      agentId,
+    });
+
+    if (!existingAgent) {
+      throw agentNotFoundError();
+    }
+
+    const existingSession = await findAgentAuthSessionByAgentId({
+      db,
+      agentId: existingAgent.id,
+    });
+    if (!existingSession || existingSession.status === "revoked") {
+      return c.body(null, 204);
+    }
+
+    const revokedAt = nowIso();
+    const applyAuthRevokeMutation = async (
+      executor: typeof db,
+    ): Promise<void> => {
+      await executor
+        .update(agent_auth_sessions)
+        .set({
+          status: "revoked",
+          revoked_at: revokedAt,
+          updated_at: revokedAt,
+        })
+        .where(
+          and(
+            eq(agent_auth_sessions.id, existingSession.id),
+            eq(agent_auth_sessions.status, "active"),
+          ),
+        );
+
+      await insertAgentAuthEvent({
+        db: executor,
+        agentId: existingAgent.id,
+        sessionId: existingSession.id,
+        eventType: "revoked",
+        reason: "owner_auth_revoke",
+        createdAt: revokedAt,
+      });
+    };
+
+    try {
+      await db.transaction(async (tx) => {
+        await applyAuthRevokeMutation(tx as unknown as typeof db);
+      });
+    } catch (error) {
+      if (!isUnsupportedLocalTransactionError(error)) {
+        throw error;
+      }
+
+      await applyAuthRevokeMutation(db);
+    }
+
+    return c.body(null, 204);
   });
 
   app.delete("/v1/agents/:id", createApiKeyAuth(), async (c) => {
@@ -1331,6 +1764,10 @@ function createRegistryApp() {
         }),
     });
 
+    const existingSession = await findAgentAuthSessionByAgentId({
+      db,
+      agentId: existingAgent.id,
+    });
     const revokedAt = nowIso();
     const applyRevokeMutation = async (executor: typeof db): Promise<void> => {
       await executor
@@ -1353,6 +1790,31 @@ function createRegistryApp() {
         .onConflictDoNothing({
           target: revocations.jti,
         });
+
+      if (existingSession && existingSession.status === "active") {
+        await executor
+          .update(agent_auth_sessions)
+          .set({
+            status: "revoked",
+            revoked_at: revokedAt,
+            updated_at: revokedAt,
+          })
+          .where(
+            and(
+              eq(agent_auth_sessions.id, existingSession.id),
+              eq(agent_auth_sessions.status, "active"),
+            ),
+          );
+
+        await insertAgentAuthEvent({
+          db: executor,
+          agentId: existingAgent.id,
+          sessionId: existingSession.id,
+          eventType: "revoked",
+          reason: "agent_revoked",
+          createdAt: revokedAt,
+        });
+      }
     };
 
     try {

--- a/packages/protocol/AGENTS.md
+++ b/packages/protocol/AGENTS.md
@@ -18,7 +18,7 @@
 - Share header names/values via protocol exports so SDK/Proxy layers import a single source of truth (e.g., `X-Claw-Timestamp`, `X-Claw-Nonce`, `X-Claw-Body-SHA256`, and `X-Claw-Proof`).
 - Keep T02 canonicalization minimal and deterministic; replay/skew/nonce policy enforcement is handled in later tickets (`T07`, `T08`, `T09`).
 - Define shared API route fragments in protocol exports (for example `ADMIN_BOOTSTRAP_PATH`) so CLI/SDK/apps avoid hardcoded duplicate endpoint literals.
-- Keep lifecycle route constants together in `endpoints.ts` (e.g., `ADMIN_BOOTSTRAP_PATH`, `AGENT_REGISTRATION_CHALLENGE_PATH`, `ME_API_KEYS_PATH`) so registry and CLI stay contract-synchronized.
+- Keep lifecycle route constants together in `endpoints.ts` (e.g., `ADMIN_BOOTSTRAP_PATH`, `AGENT_REGISTRATION_CHALLENGE_PATH`, `AGENT_AUTH_REFRESH_PATH`, `ME_API_KEYS_PATH`) so registry and CLI stay contract-synchronized.
 - Keep registration-proof canonicalization in protocol exports (`canonicalizeAgentRegistrationProof`) so CLI signing and registry verification use an identical message format.
 - Keep optional proof fields deterministic in canonical strings (empty-string placeholders) to avoid default-value mismatches between clients and server.
 

--- a/packages/protocol/src/endpoints.ts
+++ b/packages/protocol/src/endpoints.ts
@@ -1,5 +1,6 @@
 export const ADMIN_BOOTSTRAP_PATH = "/v1/admin/bootstrap";
 export const AGENT_REGISTRATION_CHALLENGE_PATH = "/v1/agents/challenge";
+export const AGENT_AUTH_REFRESH_PATH = "/v1/agents/auth/refresh";
 export const INVITES_PATH = "/v1/invites";
 export const INVITES_REDEEM_PATH = "/v1/invites/redeem";
 export const ME_API_KEYS_PATH = "/v1/me/api-keys";

--- a/packages/protocol/src/index.test.ts
+++ b/packages/protocol/src/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   ADMIN_BOOTSTRAP_PATH,
+  AGENT_AUTH_REFRESH_PATH,
   AGENT_NAME_REGEX,
   AGENT_REGISTRATION_CHALLENGE_PATH,
   AGENT_REGISTRATION_PROOF_MESSAGE_TEMPLATE,
@@ -37,6 +38,7 @@ describe("protocol", () => {
   it("exports shared endpoint constants", () => {
     expect(ADMIN_BOOTSTRAP_PATH).toBe("/v1/admin/bootstrap");
     expect(AGENT_REGISTRATION_CHALLENGE_PATH).toBe("/v1/agents/challenge");
+    expect(AGENT_AUTH_REFRESH_PATH).toBe("/v1/agents/auth/refresh");
     expect(INVITES_PATH).toBe("/v1/invites");
     expect(INVITES_REDEEM_PATH).toBe("/v1/invites/redeem");
     expect(ME_API_KEYS_PATH).toBe("/v1/me/api-keys");

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -22,6 +22,7 @@ export type { ClawDidKind } from "./did.js";
 export { makeAgentDid, makeHumanDid, parseDid } from "./did.js";
 export {
   ADMIN_BOOTSTRAP_PATH,
+  AGENT_AUTH_REFRESH_PATH,
   AGENT_REGISTRATION_CHALLENGE_PATH,
   INVITES_PATH,
   INVITES_REDEEM_PATH,


### PR DESCRIPTION
## Summary
- add agent-auth session and event persistence to registry with new migration (`agent_auth_sessions`, `agent_auth_events`)
- add `POST /v1/agents/auth/refresh` authenticated via `Authorization: Claw <AIT>` + PoP proof verification
- rotate access + refresh credentials with guarded update semantics, audit event writes, and explicit invalid/revoked/expired/conflict errors
- add `DELETE /v1/agents/:id/auth/revoke` for owner-initiated auth-session revocation and wire auth-session revoke into existing `DELETE /v1/agents/:id`
- return `agentAuth` bootstrap credentials from `POST /v1/agents`
- add CLI support for persisted `registry-auth.json` on `agent create` and new `agent auth refresh <name>` flow
- fix refresh PoP signing to use resolved request path (supports registry base-path deployments)
- make refresh credential persistence atomic via temp-file + rename to avoid destructive partial writes
- update AGENTS guidance and protocol endpoint exports/tests

## Validation
- `pnpm lint`
- `pnpm -r typecheck`
- `pnpm -r test`
- `pnpm -r build`

## Issue
Closes #80
