### PR TITLE
feat(issue-76): harden hook session default and enable identity injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,9 +459,9 @@ clawdentity/
 - Enforces caller allowlist policy by DID.
 - Applies per-agent rate limiting.
 - Keeps `hooks.token` private and only injects it internally during forward.
-- Optional: set `INJECT_IDENTITY_INTO_MESSAGE=true` to prepend a sanitized identity block
+- By default, `INJECT_IDENTITY_INTO_MESSAGE=true` to prepend a sanitized identity block
   (`agentDid`, `ownerDid`, `issuer`, `aitJti`) into `/hooks/agent` payload `message`.
-  Default is `false`, which keeps payloads unchanged.
+  Set `INJECT_IDENTITY_INTO_MESSAGE=false` to keep payloads unchanged.
 
 ### Proxy Worker local runs
 

--- a/apps/cli/src/commands/AGENTS.md
+++ b/apps/cli/src/commands/AGENTS.md
@@ -21,6 +21,7 @@
 - `openclaw setup` must be idempotent for relay mapping updates and peer map writes.
 - `openclaw setup` must persist/update `~/.clawdentity/openclaw-relay.json` with the resolved `openclawBaseUrl` so downstream proxy runtime can boot without manual env edits.
 - `openclaw setup --openclaw-base-url` should only be needed when OpenClaw is not reachable on the default `http://127.0.0.1:18789`.
+- `openclaw setup` must set `hooks.allowRequestSessionKey=false` by default and retain `hooks.allowedSessionKeyPrefixes` enforcement for safer `/hooks/agent` session routing.
 - Keep error messages static (no interpolated runtime values); include variable context only in error details/log fields.
 
 ## Connector Command Rules

--- a/apps/cli/src/commands/openclaw.test.ts
+++ b/apps/cli/src/commands/openclaw.test.ts
@@ -125,7 +125,7 @@ describe("openclaw command helpers", () => {
       };
 
       expect(openclawConfig.hooks.enabled).toBe(true);
-      expect(openclawConfig.hooks.allowRequestSessionKey).toBe(true);
+      expect(openclawConfig.hooks.allowRequestSessionKey).toBe(false);
       expect(openclawConfig.hooks.allowedSessionKeyPrefixes).toContain("hook:");
       expect(
         openclawConfig.hooks.mappings?.some(

--- a/apps/cli/src/commands/openclaw.ts
+++ b/apps/cli/src/commands/openclaw.ts
@@ -689,7 +689,7 @@ async function patchOpenclawConfig(openclawConfigPath: string): Promise<void> {
   const hooks = isRecord(config.hooks) ? { ...config.hooks } : {};
 
   hooks.enabled = true;
-  hooks.allowRequestSessionKey = true;
+  hooks.allowRequestSessionKey = false;
   hooks.allowedSessionKeyPrefixes = normalizeStringArrayWithValue(
     hooks.allowedSessionKeyPrefixes,
     "hook:",

--- a/apps/proxy/.env.example
+++ b/apps/proxy/.env.example
@@ -8,7 +8,7 @@
 # Runtime vars
 ENVIRONMENT=local
 REGISTRY_URL=https://dev.api.clawdentity.com
-INJECT_IDENTITY_INTO_MESSAGE=false
+INJECT_IDENTITY_INTO_MESSAGE=true
 
 # Optional policy/runtime overrides
 # ALLOW_LIST={"owners":[],"agents":[]}

--- a/apps/proxy/AGENTS.md
+++ b/apps/proxy/AGENTS.md
@@ -12,7 +12,7 @@
 - Keep agent DID limiter defaults explicit in `src/config.ts` (`AGENT_RATE_LIMIT_REQUESTS_PER_MINUTE=60`, `AGENT_RATE_LIMIT_WINDOW_MS=60000`) unless explicitly overridden.
 - Keep runtime `ENVIRONMENT` explicit and validated to supported values: `local`, `development`, `production`, `test` (default `development`).
 - Keep deployment intent explicit: `local` is for local Wrangler dev runs only; `development` and `production` are remote cloud environments.
-- Keep `INJECT_IDENTITY_INTO_MESSAGE` explicit and default-off (`false`); only enable when operators need webhook `message` augmentation with verified identity context.
+- Keep `INJECT_IDENTITY_INTO_MESSAGE` explicit and default-on (`true`); disable only when operators need unchanged webhook `message` forwarding.
 - Keep OpenClaw env inputs (`OPENCLAW_BASE_URL`, `OPENCLAW_HOOK_TOKEN` / `OPENCLAW_HOOKS_TOKEN`) backward-compatible but optional for relay-mode startup.
 - Keep `.dev.vars` and `.env.example` synchronized when adding/changing proxy config fields (registry URL, optional OpenClaw compatibility vars, and policy/rate-limit vars).
 - Load env files with OpenClaw precedence and no overrides:

--- a/apps/proxy/src/AGENTS.md
+++ b/apps/proxy/src/AGENTS.md
@@ -40,6 +40,6 @@
 - Keep `/hooks/agent` input contract strict: require `Content-Type: application/json` and reject malformed JSON with explicit client errors.
 - Keep agent-access validation centralized in `auth-middleware.ts` and call registry `POST /v1/agents/auth/validate`; treat non-`204` non-`401` responses as dependency failures (`503`).
 - Keep relay delivery failure mapping explicit for `/hooks/agent`: DO delivery/RPC failures -> `502`, unavailable DO namespace -> `503`.
-- Keep identity message injection optional and default-off (`INJECT_IDENTITY_INTO_MESSAGE=false`) so forwarding behavior is unchanged unless explicitly enabled.
+- Keep identity message injection explicit and default-on (`INJECT_IDENTITY_INTO_MESSAGE=true`); operators can disable it when unchanged forwarding is required.
 - Keep identity augmentation logic in small pure helpers (`sanitizeIdentityField`, `buildIdentityBlock`, payload mutation helper) inside `agent-hook-route.ts`; avoid spreading identity-format logic into `server.ts`.
 - When identity injection is enabled, sanitize identity fields (strip control chars, normalize whitespace, enforce max lengths) and mutate only string `message` fields.

--- a/apps/proxy/src/config.test.ts
+++ b/apps/proxy/src/config.test.ts
@@ -65,6 +65,14 @@ describe("proxy config", () => {
     expect(config.injectIdentityIntoMessage).toBe(true);
   });
 
+  it("allows disabling identity injection via env override", () => {
+    const config = parseProxyConfig({
+      INJECT_IDENTITY_INTO_MESSAGE: "false",
+    });
+
+    expect(config.injectIdentityIntoMessage).toBe(false);
+  });
+
   it("parses allow list object and override env lists", () => {
     const config = parseProxyConfig({
       OPENCLAW_HOOK_TOKEN: "token",

--- a/apps/proxy/src/config.ts
+++ b/apps/proxy/src/config.ts
@@ -28,7 +28,7 @@ export const DEFAULT_CRL_MAX_AGE_MS = 15 * 60 * 1000;
 export const DEFAULT_CRL_STALE_BEHAVIOR: ProxyCrlStaleBehavior = "fail-open";
 export const DEFAULT_AGENT_RATE_LIMIT_REQUESTS_PER_MINUTE = 60;
 export const DEFAULT_AGENT_RATE_LIMIT_WINDOW_MS = 60 * 1000;
-export const DEFAULT_INJECT_IDENTITY_INTO_MESSAGE = false;
+export const DEFAULT_INJECT_IDENTITY_INTO_MESSAGE = true;
 
 export class ProxyConfigError extends Error {
   readonly code = "CONFIG_VALIDATION_FAILED";

--- a/apps/proxy/wrangler.jsonc
+++ b/apps/proxy/wrangler.jsonc
@@ -39,7 +39,7 @@
         "ENVIRONMENT": "local",
         "REGISTRY_URL": "https://dev.api.clawdentity.com",
         "OPENCLAW_BASE_URL": "http://127.0.0.1:18789",
-        "INJECT_IDENTITY_INTO_MESSAGE": "false"
+        "INJECT_IDENTITY_INTO_MESSAGE": "true"
       }
     },
     "development": {
@@ -61,7 +61,7 @@
       "vars": {
         "ENVIRONMENT": "development",
         "REGISTRY_URL": "https://dev.api.clawdentity.com",
-        "INJECT_IDENTITY_INTO_MESSAGE": "false"
+        "INJECT_IDENTITY_INTO_MESSAGE": "true"
       }
     },
     "production": {
@@ -83,7 +83,7 @@
       "vars": {
         "ENVIRONMENT": "production",
         "REGISTRY_URL": "https://api.clawdentity.com",
-        "INJECT_IDENTITY_INTO_MESSAGE": "false"
+        "INJECT_IDENTITY_INTO_MESSAGE": "true"
       }
     }
   }


### PR DESCRIPTION
## Summary
- default openclaw setup hook policy to hooks.allowRequestSessionKey=false for safer session routing
- default proxy identity injection to INJECT_IDENTITY_INTO_MESSAGE=true (runtime config, wrangler envs, and .env.example)
- update tests and AGENTS/README docs to match the new defaults

## Files
- apps/cli/src/commands/openclaw.ts
- apps/cli/src/commands/openclaw.test.ts
- apps/proxy/src/config.ts
- apps/proxy/src/config.test.ts
- apps/proxy/wrangler.jsonc
- apps/proxy/.env.example
- README.md
- apps/cli/src/commands/AGENTS.md
- apps/proxy/AGENTS.md
- apps/proxy/src/AGENTS.md

## Validation
- pnpm lint
- pnpm -r typecheck
- pnpm -r test
- pnpm -r build

Refs: #76
