### PR TITLE
[T09] Add openclaw doctor + relay test commands for self-serve troubleshooting

### DIFF
--- a/apps/cli/src/commands/AGENTS.md
+++ b/apps/cli/src/commands/AGENTS.md
@@ -9,6 +9,7 @@
 - Use `withErrorHandling` for command actions unless a command has a documented reason not to.
 - Route all user-facing messages through `writeStdoutLine`/`writeStderrLine`.
 - For new command-domain errors, use SDK `AppError` with stable `code` values.
+- Normalize Commander option keys at the command boundary when helper/runtime option names differ (for example `--peer` -> `peerAlias`) so flags are never silently ignored.
 
 ## Verification Command Rules
 - `verify` must preserve the `✅`/`❌` output contract with explicit reasons.

--- a/apps/cli/src/commands/openclaw.test.ts
+++ b/apps/cli/src/commands/openclaw.test.ts
@@ -6,9 +6,10 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
+  createOpenclawCommand,
   createOpenclawInviteCode,
   decodeOpenclawInviteCode,
   runOpenclawDoctor,
@@ -474,6 +475,68 @@ describe("openclaw command helpers", () => {
         ),
       ).toBe(true);
     } finally {
+      sandbox.cleanup();
+    }
+  });
+
+  it("applies --peer filter for doctor command", async () => {
+    const sandbox = createSandbox();
+    seedLocalAgentCredentials(sandbox.homeDir, "alpha");
+    const originalHome = process.env.HOME;
+    const originalExitCode = process.exitCode;
+
+    try {
+      const invite = createOpenclawInviteCode({
+        did: "did:claw:agent:01HF7YAT31JZHSMW1CG6Q6MHB7",
+        proxyUrl: "https://beta.example.com/hooks/agent",
+        peerAlias: "beta",
+      });
+
+      await setupOpenclawRelayFromInvite("alpha", {
+        inviteCode: invite.code,
+        homeDir: sandbox.homeDir,
+        openclawDir: sandbox.openclawDir,
+        transformSource: sandbox.transformSourcePath,
+      });
+
+      const configPath = join(sandbox.homeDir, ".clawdentity", "config.json");
+      mkdirSync(dirname(configPath), { recursive: true });
+      writeFileSync(
+        configPath,
+        JSON.stringify(
+          {
+            registryUrl: "https://api.example.com",
+            apiKey: "test-api-key",
+          },
+          null,
+          2,
+        ),
+        "utf8",
+      );
+
+      const baseline = await runOpenclawDoctor({
+        homeDir: sandbox.homeDir,
+        openclawDir: sandbox.openclawDir,
+        resolveConfigImpl: async () => ({
+          registryUrl: "https://api.example.com",
+          apiKey: "test-api-key",
+        }),
+      });
+      expect(baseline.status).toBe("healthy");
+
+      process.env.HOME = sandbox.homeDir;
+      process.exitCode = undefined;
+
+      const command = createOpenclawCommand();
+      await command.parseAsync(
+        ["doctor", "--peer", "gamma", "--openclaw-dir", sandbox.openclawDir],
+        { from: "user" },
+      );
+
+      expect(process.exitCode).toBe(1);
+    } finally {
+      process.env.HOME = originalHome;
+      process.exitCode = originalExitCode;
       sandbox.cleanup();
     }
   });

--- a/apps/cli/src/commands/openclaw.ts
+++ b/apps/cli/src/commands/openclaw.ts
@@ -69,6 +69,12 @@ type OpenclawDoctorOptions = {
   json?: boolean;
 };
 
+type OpenclawDoctorCommandOptions = {
+  peer?: string;
+  openclawDir?: string;
+  json?: boolean;
+};
+
 type OpenclawRelayTestOptions = {
   peer: string;
   homeDir?: string;
@@ -1570,8 +1576,12 @@ export const createOpenclawCommand = (): Command => {
     .action(
       withErrorHandling(
         "openclaw doctor",
-        async (options: OpenclawDoctorOptions) => {
-          const result = await runOpenclawDoctor(options);
+        async (options: OpenclawDoctorCommandOptions) => {
+          const result = await runOpenclawDoctor({
+            openclawDir: options.openclawDir,
+            peerAlias: options.peer,
+            json: options.json,
+          });
           if (options.json) {
             writeStdoutLine(JSON.stringify(result, null, 2));
           } else {


### PR DESCRIPTION
## Summary
- add `clawdentity openclaw doctor` with deterministic local-state checks and remediation hints
- add `clawdentity openclaw relay test --peer <alias>` probe flow with preflight checks and clear failure mapping
- add `--json` machine-readable output for doctor and relay test
- extend OpenClaw command tests with doctor/relay pass-fail coverage
- update command AGENTS guidance for new diagnostics behavior

## Validation
- pnpm lint
- pnpm -r typecheck
- pnpm -r test
- pnpm -r build

Closes #77
