### PR TITLE
Harden public API routes against abuse on free plan

### DIFF
--- a/apps/proxy/AGENTS.md
+++ b/apps/proxy/AGENTS.md
@@ -52,6 +52,7 @@
 - When CRL verification fails with unknown `kid`, refresh registry keyset once and retry verification before returning dependency failure.
 - Return `401` for invalid/expired/replayed/revoked/invalid-proof requests.
 - Return `403` when requests are verified but agent DID is not allowlisted.
+- Return `429` with `PROXY_PUBLIC_RATE_LIMIT_EXCEEDED` when repeated unauthenticated probes exceed public-route IP budget.
 - Return `429` with `PROXY_RATE_LIMIT_EXCEEDED` when an allowlisted verified agent DID exceeds its request budget within the configured window.
 - Return `503` when registry keyset dependency is unavailable, and when CRL dependency is unavailable under `fail-closed` stale policy.
 - Keep `/hooks/agent` runtime auth contract strict: require `x-claw-agent-access` and map missing/invalid access credentials to `401`.
@@ -71,7 +72,7 @@
 - Keep `src/server.ts` as the HTTP app/runtime entry.
 - Keep `src/worker.ts` as the Cloudflare Worker fetch entry and `src/node-server.ts` as the Node compatibility entry.
 - Keep `AgentRelaySession` exported from `src/worker.ts` and bound/migrated in `wrangler.jsonc`.
-- Keep middleware order stable: request context -> request logging -> auth verification -> agent DID rate limit -> error handler.
+- Keep middleware order stable: request context -> request logging -> public-route IP rate limit -> auth verification -> agent DID rate limit -> error handler.
 - Keep `/health` response contract stable: `{ status, version, environment }` with HTTP 200.
 - Log startup and request completion with structured JSON logs; never log secrets or tokens.
 - If identity injection is enabled, mutate only `payload.message` when it is a string; preserve all other payload fields unchanged.

--- a/apps/proxy/src/AGENTS.md
+++ b/apps/proxy/src/AGENTS.md
@@ -9,6 +9,7 @@
 - Keep Node runtime startup in `node-server.ts`; use `bin.ts` as Node process entrypoint.
 - Keep inbound auth verification in `auth-middleware.ts` with focused helpers for token parsing, registry material loading, CRL checks, and replay protection.
 - Keep per-agent DID throttling in `agent-rate-limit-middleware.ts`; do not blend rate-limit state or counters into `auth-middleware.ts`.
+- Keep pre-auth public-route IP throttling in `public-rate-limit-middleware.ts`; do not blend unauthenticated probe controls into `auth-middleware.ts`.
 - Keep `.env` fallback loading and OpenClaw config (`hooks.token`) fallback logic inside `config.ts` so runtime behavior is deterministic.
 - Keep OpenClaw base URL fallback logic in `config.ts`: `OPENCLAW_BASE_URL` env -> `~/.clawdentity/openclaw-relay.json` -> default.
 - Keep OpenClaw compatibility vars optional for relay-mode runtime; never require `OPENCLAW_BASE_URL` or hook token for cloud relay startup.
@@ -33,7 +34,9 @@
 - Keep `/hooks/agent` runtime auth contract strict: require `x-claw-agent-access` and map missing/invalid access credentials to `401`.
 - Keep `/hooks/agent` recipient routing explicit: require `x-claw-recipient-agent-did` and resolve DO IDs from that recipient DID, never from owner DID env.
 - Keep `/v1/relay/connect` keyed by authenticated connector DID from auth middleware, and reject non-websocket requests with clear client errors.
+- Keep pre-auth IP throttling enabled for `/hooks/agent` and `/v1/relay/connect` so repeated unauthenticated probes fail with `429` before auth/registry work.
 - Keep rate-limit failure semantics stable: verified requests over budget map to `429` with code `PROXY_RATE_LIMIT_EXCEEDED` and structured warn log event `proxy.rate_limit.exceeded`.
+- Keep pre-auth rate-limit failure semantics stable: repeated public-route probes map to `429` with code `PROXY_PUBLIC_RATE_LIMIT_EXCEEDED` and structured warn log event `proxy.public_rate_limit.exceeded`.
 - Keep `X-Claw-Timestamp` parsing strict: accept digit-only unix-seconds strings and reject mixed/decimal formats.
 - Keep AIT verification resilient to routine key rotation: retry once with a forced keyset refresh on `UNKNOWN_AIT_KID` before rejecting.
 - Keep CRL verification resilient to routine key rotation: retry once with a forced keyset refresh on `UNKNOWN_CRL_KID` before dependency-failure mapping.

--- a/apps/proxy/src/public-rate-limit-middleware.ts
+++ b/apps/proxy/src/public-rate-limit-middleware.ts
@@ -1,0 +1,81 @@
+import { AppError, type Logger } from "@clawdentity/sdk";
+import { createMiddleware } from "hono/factory";
+
+type InMemoryBucket = {
+  windowStartedAtMs: number;
+  count: number;
+};
+
+export const DEFAULT_PRE_AUTH_IP_RATE_LIMIT_REQUESTS_PER_MINUTE = 120;
+export const DEFAULT_PRE_AUTH_IP_RATE_LIMIT_WINDOW_MS = 60 * 1000;
+
+export type PublicRateLimitMiddlewareOptions = {
+  logger: Logger;
+  paths: string[];
+  maxRequests: number;
+  windowMs: number;
+  nowMs?: () => number;
+};
+
+function resolveClientIp(request: Request): string {
+  const cfIp = request.headers.get("cf-connecting-ip");
+  if (typeof cfIp === "string" && cfIp.trim().length > 0) {
+    return cfIp.trim();
+  }
+
+  return "unknown";
+}
+
+export function createPublicRateLimitMiddleware(
+  options: PublicRateLimitMiddlewareOptions,
+) {
+  const nowMs = options.nowMs ?? Date.now;
+  const buckets = new Map<string, InMemoryBucket>();
+
+  return createMiddleware(async (c, next) => {
+    const matchedPath = options.paths.find((path) => path === c.req.path);
+    if (!matchedPath) {
+      await next();
+      return;
+    }
+
+    const now = nowMs();
+    for (const [key, bucket] of buckets.entries()) {
+      if (now - bucket.windowStartedAtMs >= options.windowMs) {
+        buckets.delete(key);
+      }
+    }
+
+    const clientIp = resolveClientIp(c.req.raw);
+    const key = `${matchedPath}:${clientIp}`;
+    const existing = buckets.get(key);
+
+    if (!existing || now - existing.windowStartedAtMs >= options.windowMs) {
+      buckets.set(key, {
+        windowStartedAtMs: now,
+        count: 1,
+      });
+      await next();
+      return;
+    }
+
+    if (existing.count >= options.maxRequests) {
+      options.logger.warn("proxy.public_rate_limit.exceeded", {
+        path: matchedPath,
+        clientIp,
+        windowMs: options.windowMs,
+        maxRequests: options.maxRequests,
+      });
+      throw new AppError({
+        code: "PROXY_PUBLIC_RATE_LIMIT_EXCEEDED",
+        message: "Too many requests",
+        status: 429,
+        expose: true,
+      });
+    }
+
+    existing.count += 1;
+    buckets.set(key, existing);
+    await next();
+  });
+}

--- a/apps/proxy/src/server.test.ts
+++ b/apps/proxy/src/server.test.ts
@@ -1,3 +1,4 @@
+import { RELAY_CONNECT_PATH } from "@clawdentity/protocol";
 import { describe, expect, it, vi } from "vitest";
 import {
   DEFAULT_PROXY_ENVIRONMENT,
@@ -80,5 +81,73 @@ describe("proxy server", () => {
         },
       }),
     ).toThrow(ProxyConfigError);
+  });
+
+  it("returns 429 for repeated unauthenticated probes on /hooks/agent from same IP", async () => {
+    const app = createProxyApp({
+      config: parseProxyConfig({
+        OPENCLAW_HOOK_TOKEN: "token",
+      }),
+      rateLimit: {
+        publicIpMaxRequests: 2,
+        publicIpWindowMs: 60_000,
+      },
+    });
+
+    for (let index = 0; index < 2; index += 1) {
+      const response = await app.request("/hooks/agent", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "CF-Connecting-IP": "198.51.100.41",
+        },
+        body: JSON.stringify({}),
+      });
+      expect(response.status).toBe(401);
+    }
+
+    const rateLimited = await app.request("/hooks/agent", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "CF-Connecting-IP": "198.51.100.41",
+      },
+      body: JSON.stringify({}),
+    });
+
+    expect(rateLimited.status).toBe(429);
+    const body = (await rateLimited.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("PROXY_PUBLIC_RATE_LIMIT_EXCEEDED");
+  });
+
+  it("returns 429 for repeated unauthenticated probes on relay connect from same IP", async () => {
+    const app = createProxyApp({
+      config: parseProxyConfig({
+        OPENCLAW_HOOK_TOKEN: "token",
+      }),
+      rateLimit: {
+        publicIpMaxRequests: 2,
+        publicIpWindowMs: 60_000,
+      },
+    });
+
+    for (let index = 0; index < 2; index += 1) {
+      const response = await app.request(RELAY_CONNECT_PATH, {
+        headers: {
+          "CF-Connecting-IP": "198.51.100.42",
+        },
+      });
+      expect(response.status).toBe(401);
+    }
+
+    const rateLimited = await app.request(RELAY_CONNECT_PATH, {
+      headers: {
+        "CF-Connecting-IP": "198.51.100.42",
+      },
+    });
+
+    expect(rateLimited.status).toBe(429);
+    const body = (await rateLimited.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("PROXY_PUBLIC_RATE_LIMIT_EXCEEDED");
   });
 });

--- a/apps/proxy/src/server.ts
+++ b/apps/proxy/src/server.ts
@@ -22,6 +22,11 @@ import {
 import type { ProxyConfig } from "./config.js";
 import { PROXY_VERSION } from "./index.js";
 import {
+  createPublicRateLimitMiddleware,
+  DEFAULT_PRE_AUTH_IP_RATE_LIMIT_REQUESTS_PER_MINUTE,
+  DEFAULT_PRE_AUTH_IP_RATE_LIMIT_WINDOW_MS,
+} from "./public-rate-limit-middleware.js";
+import {
   createRelayConnectHandler,
   type RelayConnectRuntimeOptions,
 } from "./relay-connect-route.js";
@@ -35,6 +40,8 @@ type ProxyAuthRuntimeOptions = {
 
 type ProxyRateLimitRuntimeOptions = {
   nowMs?: () => number;
+  publicIpMaxRequests?: number;
+  publicIpWindowMs?: number;
 };
 
 type CreateProxyAppOptions = {
@@ -69,6 +76,20 @@ export function createProxyApp(options: CreateProxyAppOptions): ProxyApp {
 
   app.use("*", createRequestContextMiddleware());
   app.use("*", createRequestLoggingMiddleware(logger));
+  app.use(
+    "*",
+    createPublicRateLimitMiddleware({
+      logger,
+      paths: ["/hooks/agent", RELAY_CONNECT_PATH],
+      maxRequests:
+        options.rateLimit?.publicIpMaxRequests ??
+        DEFAULT_PRE_AUTH_IP_RATE_LIMIT_REQUESTS_PER_MINUTE,
+      windowMs:
+        options.rateLimit?.publicIpWindowMs ??
+        DEFAULT_PRE_AUTH_IP_RATE_LIMIT_WINDOW_MS,
+      nowMs: options.rateLimit?.nowMs,
+    }),
+  );
   app.use(
     "*",
     createProxyAuthMiddleware({

--- a/apps/registry/src/AGENTS.md
+++ b/apps/registry/src/AGENTS.md
@@ -28,6 +28,7 @@
 
 ## CRL Snapshot Contract
 - `GET /v1/crl` is a public endpoint and must remain unauthenticated so SDK/proxy clients can refresh revocation state without PAT bootstrap dependencies.
+- Apply per-client-IP throttling on `GET /v1/crl` and return `429 RATE_LIMIT_EXCEEDED` when over budget.
 - Success response shape must remain `{ crl: <jwt> }` where `crl` is an EdDSA-signed token with `typ=CRL`.
 - Build CRL claims from the full `revocations` table (MVP full snapshot), joining each row to `agents.did` for `revocations[].agentDid`.
 - Keep CRL cache headers explicit and short-lived (`max-age=300` + `stale-while-revalidate`) for predictable revocation propagation.
@@ -47,6 +48,7 @@
 ## Validation
 - Run `pnpm -F @clawdentity/registry run test` after changing routes or config loading.
 - Run `pnpm -F @clawdentity/registry run typecheck` before commit.
+- For route-limit tests, prefer `createRegistryApp({ rateLimit: ... })` overrides to keep tests deterministic without weakening production defaults.
 - When using fake D1 adapters in route tests, make select responses honor bound parameters, selected-column projection, and join semantics so query-shape regressions are caught.
 - Fake D1 join emulation should drop rows when `innerJoin` targets are missing so tests catch missing/incorrect joins instead of masking them with stubbed values.
 
@@ -127,6 +129,7 @@
 
 ## POST /v1/agents/auth/refresh Contract
 - Public endpoint (no PAT): auth is agent-scoped via `Authorization: Claw <AIT>` + PoP headers + refresh token payload.
+- Apply per-client-IP throttling and return `429 RATE_LIMIT_EXCEEDED` before auth parsing when over budget.
 - Verify AIT against active registry signing keys and enforce deterministic issuer mapping for environment.
 - Verify PoP using canonical request inputs and public key from AIT `cnf`.
 - Enforce timestamp skew checks for replay-window reduction.
@@ -139,6 +142,7 @@
 
 ## POST /v1/agents/auth/validate Contract
 - Public endpoint used by proxy runtime auth enforcement; request must include `x-claw-agent-access` and JSON payload `{ agentDid, aitJti }`.
+- Apply per-client-IP throttling and return `429 RATE_LIMIT_EXCEEDED` before payload/auth validation when over budget.
 - Validate `agentDid` + `aitJti` against active agent state (`agents.status=active`, `agents.current_jti` match).
 - Validate access token against active session hash/prefix material with constant-time comparison.
 - Expired access credentials must return `401 AGENT_AUTH_VALIDATE_EXPIRED` without rotating refresh credentials.

--- a/apps/registry/src/rate-limit.ts
+++ b/apps/registry/src/rate-limit.ts
@@ -4,6 +4,12 @@ import type { MiddlewareHandler } from "hono";
 export const RESOLVE_RATE_LIMIT_WINDOW_MS = 60_000;
 export const RESOLVE_RATE_LIMIT_MAX_REQUESTS = 10;
 export const RESOLVE_RATE_LIMIT_MAX_BUCKETS = 10_000;
+export const CRL_RATE_LIMIT_WINDOW_MS = 60_000;
+export const CRL_RATE_LIMIT_MAX_REQUESTS = 30;
+export const AGENT_AUTH_REFRESH_RATE_LIMIT_WINDOW_MS = 60_000;
+export const AGENT_AUTH_REFRESH_RATE_LIMIT_MAX_REQUESTS = 20;
+export const AGENT_AUTH_VALIDATE_RATE_LIMIT_WINDOW_MS = 60_000;
+export const AGENT_AUTH_VALIDATE_RATE_LIMIT_MAX_REQUESTS = 120;
 
 type InMemoryBucket = {
   windowStartedAtMs: number;

--- a/apps/registry/src/server.test.ts
+++ b/apps/registry/src/server.test.ts
@@ -3091,6 +3091,44 @@ describe("GET /v1/crl", () => {
     expect(body.error.message).toBe("CRL snapshot is not available");
   });
 
+  it("returns 429 when rate limit is exceeded for the same client", async () => {
+    const { database } = createFakeDb([]);
+    const appInstance = createRegistryApp({
+      rateLimit: {
+        crlMaxRequests: 2,
+        crlWindowMs: 60_000,
+      },
+    });
+
+    for (let index = 0; index < 2; index += 1) {
+      const response = await appInstance.request(
+        "/v1/crl",
+        {
+          headers: {
+            "CF-Connecting-IP": "203.0.113.77",
+          },
+        },
+        { DB: database, ENVIRONMENT: "test" },
+      );
+
+      expect(response.status).toBe(404);
+    }
+
+    const rateLimited = await appInstance.request(
+      "/v1/crl",
+      {
+        headers: {
+          "CF-Connecting-IP": "203.0.113.77",
+        },
+      },
+      { DB: database, ENVIRONMENT: "test" },
+    );
+
+    expect(rateLimited.status).toBe(429);
+    const body = (await rateLimited.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("RATE_LIMIT_EXCEEDED");
+  });
+
   it("returns 500 when CRL signing configuration is missing", async () => {
     const agentId = generateUlid(1700400000600);
     const { database } = createFakeDb(
@@ -6289,6 +6327,49 @@ describe(`POST ${AGENT_AUTH_REFRESH_PATH}`, () => {
       ]),
     );
   });
+
+  it("returns 429 when refresh rate limit is exceeded for the same client", async () => {
+    const appInstance = createRegistryApp({
+      rateLimit: {
+        agentAuthRefreshMaxRequests: 2,
+        agentAuthRefreshWindowMs: 60_000,
+      },
+    });
+
+    for (let index = 0; index < 2; index += 1) {
+      const response = await appInstance.request(
+        AGENT_AUTH_REFRESH_PATH,
+        {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "CF-Connecting-IP": "203.0.113.88",
+          },
+          body: JSON.stringify({}),
+        },
+        { DB: {} as D1Database, ENVIRONMENT: "test" },
+      );
+
+      expect(response.status).toBe(400);
+    }
+
+    const rateLimited = await appInstance.request(
+      AGENT_AUTH_REFRESH_PATH,
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "CF-Connecting-IP": "203.0.113.88",
+        },
+        body: JSON.stringify({}),
+      },
+      { DB: {} as D1Database, ENVIRONMENT: "test" },
+    );
+
+    expect(rateLimited.status).toBe(429);
+    const body = (await rateLimited.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("RATE_LIMIT_EXCEEDED");
+  });
 });
 
 describe(`POST ${AGENT_AUTH_VALIDATE_PATH}`, () => {
@@ -6535,6 +6616,49 @@ describe(`POST ${AGENT_AUTH_VALIDATE_PATH}`, () => {
     expect(agentAuthSessionUpdates).toEqual(
       expect.arrayContaining([expect.objectContaining({ matched_rows: 0 })]),
     );
+  });
+
+  it("returns 429 when validate rate limit is exceeded for the same client", async () => {
+    const appInstance = createRegistryApp({
+      rateLimit: {
+        agentAuthValidateMaxRequests: 2,
+        agentAuthValidateWindowMs: 60_000,
+      },
+    });
+
+    for (let index = 0; index < 2; index += 1) {
+      const response = await appInstance.request(
+        AGENT_AUTH_VALIDATE_PATH,
+        {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "CF-Connecting-IP": "203.0.113.99",
+          },
+          body: JSON.stringify({}),
+        },
+        { DB: {} as D1Database, ENVIRONMENT: "test" },
+      );
+
+      expect(response.status).toBe(400);
+    }
+
+    const rateLimited = await appInstance.request(
+      AGENT_AUTH_VALIDATE_PATH,
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "CF-Connecting-IP": "203.0.113.99",
+        },
+        body: JSON.stringify({}),
+      },
+      { DB: {} as D1Database, ENVIRONMENT: "test" },
+    );
+
+    expect(rateLimited.status).toBe(429);
+    const body = (await rateLimited.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("RATE_LIMIT_EXCEEDED");
   });
 });
 

--- a/apps/registry/src/server.ts
+++ b/apps/registry/src/server.ts
@@ -96,6 +96,12 @@ import {
   parseInviteRedeemPayload,
 } from "./invite-lifecycle.js";
 import {
+  AGENT_AUTH_REFRESH_RATE_LIMIT_MAX_REQUESTS,
+  AGENT_AUTH_REFRESH_RATE_LIMIT_WINDOW_MS,
+  AGENT_AUTH_VALIDATE_RATE_LIMIT_MAX_REQUESTS,
+  AGENT_AUTH_VALIDATE_RATE_LIMIT_WINDOW_MS,
+  CRL_RATE_LIMIT_MAX_REQUESTS,
+  CRL_RATE_LIMIT_WINDOW_MS,
   createInMemoryRateLimit,
   RESOLVE_RATE_LIMIT_MAX_REQUESTS,
   RESOLVE_RATE_LIMIT_WINDOW_MS,
@@ -178,6 +184,22 @@ type CrlSnapshotRow = {
   reason: string | null;
   revoked_at: string;
   agent_did: string;
+};
+
+type RegistryRateLimitRuntimeOptions = {
+  nowMs?: () => number;
+  resolveMaxRequests?: number;
+  resolveWindowMs?: number;
+  crlMaxRequests?: number;
+  crlWindowMs?: number;
+  agentAuthRefreshMaxRequests?: number;
+  agentAuthRefreshWindowMs?: number;
+  agentAuthValidateMaxRequests?: number;
+  agentAuthValidateWindowMs?: number;
+};
+
+type CreateRegistryAppOptions = {
+  rateLimit?: RegistryRateLimitRuntimeOptions;
 };
 
 function crlBuildError(options: {
@@ -614,7 +636,7 @@ function adminBootstrapAlreadyCompletedError(): AppError {
   });
 }
 
-function createRegistryApp() {
+function createRegistryApp(options: CreateRegistryAppOptions = {}) {
   let cachedConfig: RegistryConfig | undefined;
 
   function getConfig(bindings: Bindings): RegistryConfig {
@@ -630,10 +652,40 @@ function createRegistryApp() {
     Bindings: Bindings;
     Variables: { requestId: string; human: AuthenticatedHuman };
   }>();
+  const rateLimitOptions = options.rateLimit;
   const resolveRateLimit = createInMemoryRateLimit({
     bucketKey: "resolve",
-    maxRequests: RESOLVE_RATE_LIMIT_MAX_REQUESTS,
-    windowMs: RESOLVE_RATE_LIMIT_WINDOW_MS,
+    maxRequests:
+      rateLimitOptions?.resolveMaxRequests ?? RESOLVE_RATE_LIMIT_MAX_REQUESTS,
+    windowMs: rateLimitOptions?.resolveWindowMs ?? RESOLVE_RATE_LIMIT_WINDOW_MS,
+    nowMs: rateLimitOptions?.nowMs,
+  });
+  const crlRateLimit = createInMemoryRateLimit({
+    bucketKey: "crl",
+    maxRequests:
+      rateLimitOptions?.crlMaxRequests ?? CRL_RATE_LIMIT_MAX_REQUESTS,
+    windowMs: rateLimitOptions?.crlWindowMs ?? CRL_RATE_LIMIT_WINDOW_MS,
+    nowMs: rateLimitOptions?.nowMs,
+  });
+  const agentAuthRefreshRateLimit = createInMemoryRateLimit({
+    bucketKey: "agent_auth_refresh",
+    maxRequests:
+      rateLimitOptions?.agentAuthRefreshMaxRequests ??
+      AGENT_AUTH_REFRESH_RATE_LIMIT_MAX_REQUESTS,
+    windowMs:
+      rateLimitOptions?.agentAuthRefreshWindowMs ??
+      AGENT_AUTH_REFRESH_RATE_LIMIT_WINDOW_MS,
+    nowMs: rateLimitOptions?.nowMs,
+  });
+  const agentAuthValidateRateLimit = createInMemoryRateLimit({
+    bucketKey: "agent_auth_validate",
+    maxRequests:
+      rateLimitOptions?.agentAuthValidateMaxRequests ??
+      AGENT_AUTH_VALIDATE_RATE_LIMIT_MAX_REQUESTS,
+    windowMs:
+      rateLimitOptions?.agentAuthValidateWindowMs ??
+      AGENT_AUTH_VALIDATE_RATE_LIMIT_WINDOW_MS,
+    nowMs: rateLimitOptions?.nowMs,
   });
 
   app.use("*", createRequestContextMiddleware());
@@ -796,7 +848,7 @@ function createRegistryApp() {
     );
   });
 
-  app.get("/v1/crl", async (c) => {
+  app.get("/v1/crl", crlRateLimit, async (c) => {
     const config = getConfig(c.env);
     const db = createDb(c.env.DB);
 
@@ -1531,7 +1583,7 @@ function createRegistryApp() {
     );
   });
 
-  app.post(AGENT_AUTH_REFRESH_PATH, async (c) => {
+  app.post(AGENT_AUTH_REFRESH_PATH, agentAuthRefreshRateLimit, async (c) => {
     const config = getConfig(c.env);
     const exposeDetails = shouldExposeVerboseErrors(config.ENVIRONMENT);
     const bodyBytes = new Uint8Array(await c.req.raw.clone().arrayBuffer());
@@ -1712,7 +1764,7 @@ function createRegistryApp() {
     });
   });
 
-  app.post(AGENT_AUTH_VALIDATE_PATH, async (c) => {
+  app.post(AGENT_AUTH_VALIDATE_PATH, agentAuthValidateRateLimit, async (c) => {
     let payload: unknown;
     try {
       payload = await c.req.json();


### PR DESCRIPTION
## Summary
- add route-level IP throttling in registry for GET /v1/crl, POST /v1/agents/auth/refresh, and POST /v1/agents/auth/validate
- add pre-auth IP throttling middleware in proxy for /hooks/agent and /v1/relay/connect
- add focused regression tests for the new 429 behavior on registry and proxy public routes
- update AGENTS docs under touched registry/proxy folders to document the new rate-limit contracts and middleware order

## Validation
- pnpm lint
- pnpm -r typecheck
- pnpm -r test
- pnpm -r build
- pre-push hook: nx affected -t lint,format,typecheck,test --base=origin/main --head=HEAD
