### PR TITLE
feat(proxy): add pairing-based trust store and update OpenClaw skill docs

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -77,14 +77,14 @@ Because OpenClaw requires `hooks.token` and expects Bearer/token auth for `/hook
 
 - **Proxy**
   - Verify inbound Clawdentity headers
-  - Enforce allowlist rules (agent DID only in current phase; owner DID support deferred)
+  - Enforce durable trust-pair rules for sender/recipient agent DIDs
   - Rate-limit per verified agent DID
   - Forward to OpenClaw `/hooks/agent` with `x-openclaw-token`
 
 - **Discovery**
   - Share-by-contact-card (verify link + endpoint)
   - Resolve `gateway_hint` from registry (optional)
-  - Pairing code (optional, “approve first contact”)
+  - Pairing code (`/pair/start` + `/pair/confirm`) for trust bootstrap
 
 - **Onboarding / access control**
   - Invite-gated user registration (`register --invite`)
@@ -192,7 +192,7 @@ Verifier must enforce:
 
 - Valid caller → proxy forwards → OpenClaw returns 202
 - Invalid/expired/revoked token → proxy returns 401
-- Valid but not allowlisted → proxy returns 403
+- Valid but not trusted for recipient pair → proxy returns 403
 - Replay within time window is rejected (nonce reuse)
 - Revocation causes rejection within next CRL refresh
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ What Clawdentity adds:
 
 - Verifiable per-agent identity (AIT + PoP)
 - Fast revocation propagation (signed CRL + cache refresh)
-- Proxy-side policy enforcement (allowlist + rate limits + replay protection)
+- Proxy-side policy enforcement (trust pairs + rate limits + replay protection)
 
 ---
 
@@ -50,7 +50,7 @@ Caller Agent
   |
   |  Authorization: Claw <AIT>  +  X-Claw-Proof/Nonce/Timestamp
   v
-Clawdentity Proxy   (verifies identity + allowlist + rate limits)
+Clawdentity Proxy   (verifies identity + trust policy + rate limits)
   |
   |  x-openclaw-token: <hooks.token>   (internal only)
   v
@@ -89,7 +89,7 @@ OpenClaw Gateway  (normal /hooks/agent handling)
 - Proxy checks AIT expiry and CRL revocation status.
 - Proxy verifies PoP signature against the key in the token.
 - Proxy rejects replay via timestamp skew + nonce cache.
-- Proxy enforces allowlist and rate limits.
+- Proxy enforces trust-pair policy and rate limits.
 
 ### 4) Forward to OpenClaw
 
@@ -139,7 +139,7 @@ This section walks through **every step** from zero to two OpenClaw agents excha
     │                       │          │                      │
     │  Verifies identity    │          └──────────────────────┘
     │  Checks revocation    │
-    │  Enforces allowlist   │
+    │  Enforces trust pairs │
     │  Rejects replays      │
     │  Rate limits per agent│
     └───────────┬───────────┘
@@ -266,7 +266,7 @@ Alice's Operator                        Bob's Operator
   │                                        │  Configures OpenClaw hooks
 ```
 
-**Security:** The invite contains only public information (DID + proxy URL). No keys, tokens, or secrets are exchanged. Alice's operator must also add Bob's DID to the proxy allowlist before Bob can actually send messages.
+**Security:** The invite contains only public information (DID + proxy URL). No keys, tokens, or secrets are exchanged. Alice and Bob must complete proxy pairing (`/pair/start` + `/pair/confirm`) before either side can send messages.
 
 ### Step 4: First Message (Bob → Alice)
 
@@ -317,8 +317,8 @@ Bob's OpenClaw        relay-to-peer.ts       Alice's Proxy           Alice's Ope
      │                      │                 (per-agent nonce cache)      │
      │                      │               ⑤ Check CRL revocation         │
      │                      │                 (signed list from registry)  │
-     │                      │               ⑥ Enforce allowlist            │
-     │                      │                 (is Bob's DID permitted?)    │
+     │                      │               ⑥ Enforce trust pair           │
+     │                      │                 (is Bob trusted for Alice?)  │
      │                      │               ⑦ Validate agent access token  │
      │                      │                 (POST to registry)           │
      │                      │                      │                       │
@@ -344,7 +344,7 @@ Bob's OpenClaw        relay-to-peer.ts       Alice's Proxy           Alice's Ope
 | **Revocation** | Rotate shared token = break all integrations | Revoke one agent instantly via CRL, others unaffected |
 | **Replay protection** | None | Timestamp + nonce + signature on every request |
 | **Tamper detection** | None | Body hash + PoP signature = any modification is detectable |
-| **Per-caller policy** | Not possible | Allowlist by agent DID, rate limit per agent |
+| **Per-caller policy** | Not possible | Trust pairs by sender/recipient DID, rate limit per agent |
 | **Key exposure** | Token must be shared with every caller | Private key never leaves the agent's machine |
 
 ### What Gets Verified (and When It Fails)
@@ -356,7 +356,7 @@ Bob's OpenClaw        relay-to-peer.ts       Alice's Proxy           Alice's Ope
 | PoP signature | `PROXY_AUTH_INVALID_PROOF` | 401 | Sender doesn't hold the private key |
 | Nonce replay | `PROXY_AUTH_REPLAY` | 401 | Same request was sent twice |
 | CRL revocation | `PROXY_AUTH_REVOKED` | 401 | Agent identity has been revoked |
-| Allowlist | `PROXY_AUTH_FORBIDDEN` | 403 | Agent is valid but not authorized here |
+| Trust policy | `PROXY_AUTH_FORBIDDEN` | 403 | Agent is valid but not trusted for this recipient |
 | Agent access token | `PROXY_AGENT_ACCESS_INVALID` | 401 | Session token expired or revoked |
 | Rate limit | `PROXY_RATE_LIMIT_EXCEEDED` | 429 | Too many requests from this agent |
 
@@ -373,7 +373,7 @@ Bob's OpenClaw        relay-to-peer.ts       Alice's Proxy           Alice's Ope
 
 ### Receiver side operator (callee gateway owner)
 
-- Action: remove/deny caller in local allowlist (or keep `approvalRequired` for first contact)
+- Action: remove/deny trusted caller pair in local proxy trust state (or keep approval-required first contact)
 - Scope: **local only** (that specific gateway/proxy)
 - Effect: caller is blocked on this gateway immediately, but remains valid elsewhere unless globally revoked.
 - Use when: policy mismatch, abuse from a specific caller, temporary trust removal.
@@ -390,7 +390,7 @@ Bob's OpenClaw        relay-to-peer.ts       Alice's Proxy           Alice's Ope
 2. Sender owner/admin performs registry revoke for ecosystem-wide invalidation.
 3. Proxies return:
    - `401` for invalid/expired/revoked identity
-   - `403` for valid identity that is not allowlisted locally
+   - `403` for valid identity that is not trusted locally for the target recipient
 
 ---
 
@@ -456,7 +456,7 @@ clawdentity/
 
 - Handled by: `apps/proxy`
 - Proxy Worker verifies AIT + CRL + PoP before forwarding to OpenClaw.
-- Enforces caller allowlist policy by DID.
+- Enforces durable trust pairs for sender/recipient DID.
 - Applies per-agent rate limiting.
 - Keeps `hooks.token` private and only injects it internally during forward.
 - By default, `INJECT_IDENTITY_INTO_MESSAGE=true` to prepend a sanitized identity block
@@ -510,7 +510,7 @@ clawdentity/
 - Handled by: `apps/registry`, `apps/proxy`, `apps/cli`
 - Out-of-band contact card sharing.
 - Registry `gateway_hint` resolution.
-- Optional pairing-code flow for first-contact allowlist approval.
+- Pairing-code flow for first-contact trust approval (PAT-verified owner start + one-time confirm).
 
 ---
 
@@ -559,7 +559,7 @@ MVP supports three ways to “find” another agent:
 
 1. **Out-of-band share**: human shares a contact card (verify link + endpoint URL)
 2. **Registry `gateway_hint`**: callee publishes an endpoint, callers resolve it via registry
-3. **Pairing code** (proxy): “Approve first contact” to auto-add caller to allowlist
+3. **Pairing code** (proxy): “Approve first contact” to establish a mutual trusted agent pair
 
 No one shares keys/files between agents. Identity is presented per request.
 
@@ -582,7 +582,7 @@ No one shares keys/files between agents. Identity is presented per request.
   - method, path, timestamp, nonce, body hash
   - and reject nonce replays
 - Reject tampering: any change to method/path/body/timestamp/nonce invalidates proof.
-- Reject unauthorized callers: AIT verification + allowlist enforcement.
+- Reject unauthorized callers: AIT verification + trust-pair enforcement.
 - Reject compromised identities quickly: CRL-based revocation checks.
 - Contain abuse: per-agent rate limits at proxy boundary.
 
@@ -600,7 +600,7 @@ No one shares keys/files between agents. Identity is presented per request.
 
 - Treat any identity fields (agent name/description) as untrusted input; never allow prompt injection via identity metadata.
 - Keep OpenClaw behind trusted network boundaries; expose only proxy entry points.
-- Rotate PATs and audit allowlist entries regularly.
+- Rotate PATs and audit trusted pair entries regularly.
 - Store PATs in secure local config only; create responses return token once and it cannot be retrieved later from the registry.
 - Rotation baseline: keep one primary key + one standby key, rotate at least every 90 days, and revoke stale keys immediately after rollout.
 

--- a/apps/cli/skill-bundle/openclaw-skill/skill/SKILL.md
+++ b/apps/cli/skill-bundle/openclaw-skill/skill/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: clawdentity_openclaw_relay
-description: This skill should be used when the user asks to "install clawdentity relay skill", "set up agent-to-agent relay from invite code", "connect OpenClaw agents with invite code", or needs OpenClaw peer communication with Clawdentity PoP verification.
+description: This skill should be used when the user asks to "install clawdentity relay skill", "set up agent-to-agent relay from invite code", "connect OpenClaw agents with invite code", or needs OpenClaw peer communication through the local Clawdentity connector runtime.
 version: 0.1.0
 ---
 
 # Clawdentity OpenClaw Relay Skill
 
-This skill configures an OpenClaw agent to relay selected webhook payloads to a peer through Clawdentity identity (`Authorization: Claw <AIT>` + PoP headers) using a single invite code.
+This skill configures an OpenClaw agent to relay selected webhook payloads to a peer through the local Clawdentity connector runtime using a single invite code.
 
 ## Trigger Conditions
 
@@ -36,14 +36,10 @@ Use this skill when any of the following are requested:
 - Local selected agent marker: `~/.clawdentity/openclaw-agent-name`
 - Relay runtime config: `~/.clawdentity/openclaw-relay.json`
 
-## Operator Split
+## Invite Input Assumption
 
-### Admin/operator side (only action required)
-Create invite code:
-
-`clawdentity openclaw invite --did <peer-agent-did> --proxy-url <peer-proxy-hooks-agent-url> --peer-alias <alias>`
-
-Share the invite code string with the human who owns the target agent.
+Provide a valid invite code string before running this skill.
+Invite creation is outside this skill scope; this skill focuses on setup, pairing, and relay validation.
 
 ## Human + Agent Flow (strict user-style)
 
@@ -56,6 +52,41 @@ This skill is operational. The agent must execute side effects via tools.
 - Do not ask the human to run shell commands that the agent can run itself.
 - Ask the human only for missing secrets/inputs (for example API key or invite code).
 - Report final status with concrete outputs (local DID, peer alias, written paths).
+
+## CLI Command Utilization (required)
+
+Use these commands as the default execution path for skill utilization:
+
+- Initialize local CLI config:
+  - `clawdentity config init`
+- Configure registry URL and API key when missing:
+  - `clawdentity config set registryUrl <registry-url>`
+  - `clawdentity config set apiKey <api-key>`
+- Create and inspect local OpenClaw agent identity:
+  - `clawdentity agent create <agent-name> --framework openclaw`
+  - `clawdentity agent inspect <agent-name>`
+- Apply OpenClaw invite setup:
+  - `clawdentity openclaw setup <agent-name> --invite-code <invite-code>`
+- Start connector runtime for relay handoff:
+  - `clawdentity connector start <agent-name>`
+- Optional persistent connector autostart:
+  - `clawdentity connector service install <agent-name>`
+- Validate health and delivery:
+  - `clawdentity openclaw doctor`
+  - `clawdentity openclaw relay test --peer <alias>`
+
+Pairing bootstrap for trust policy is API-based in the current release (no dedicated pairing CLI command yet):
+
+- Owner/initiator starts pairing on initiator proxy:
+  - `POST /pair/start`
+  - Requires `Authorization: Claw <AIT>` and `x-claw-owner-pat`
+  - Body: `{"agentDid":"<responder-agent-did>"}`
+- Responder confirms on responder proxy:
+  - `POST /pair/confirm`
+  - Requires `Authorization: Claw <AIT>`
+  - Body: `{"pairingCode":"<code-from-start>"}`
+
+Successful confirm establishes mutual trust for the two agent DIDs. After confirm, both directions are allowed for trusted delivery.
 
 1. Confirm prerequisites with the human.
 - Confirm `clawdentity` CLI is installed and runnable.
@@ -94,11 +125,21 @@ This skill is operational. The agent must execute side effects via tools.
   - relay runtime config path
 - Confirm `~/.clawdentity/openclaw-agent-name` is set to the local agent name.
 
-7. Validate with user-style relay test.
-- Human asks Alpha to send a request with `peer: "beta"`.
-- Agent relays with Claw + PoP headers.
-- Peer proxy verifies and forwards to peer OpenClaw.
-- Verify success logs on both sides.
+7. Start connector runtime for local relay handoff.
+- Run `clawdentity connector start <agent-name>`.
+- Optional: run `clawdentity connector service install <agent-name>` for persistent autostart.
+
+8. Complete trust pairing bootstrap.
+- Run pairing start (`POST /pair/start`) from the owner/initiator side.
+- Share returned one-time `pairingCode` with responder side.
+- Run pairing confirm (`POST /pair/confirm`) from responder side.
+- Confirm pairing success before relay test.
+
+9. Validate with user-style relay test.
+- Run `clawdentity openclaw doctor` to verify setup health and remediation hints.
+- Run `clawdentity openclaw relay test --peer <alias>` to execute a probe.
+- Confirm probe success and connector-mediated delivery logs.
+- Human asks Alpha to send a real request with `peer: "beta"` and verifies peer delivery.
 
 ## Required question policy
 
@@ -107,20 +148,23 @@ Ask the human only when required inputs are missing:
 - Unclear OpenClaw state directory.
 - Non-default OpenClaw base URL.
 - Missing invite code.
-- Local registry/proxy network location is unknown or unreachable from agent runtime.
+- Local connector runtime or peer network route is unknown or unreachable from agent runtime.
 
 ## Failure Handling
 
 If setup or relay fails:
 - Report precise missing file/path/value.
 - Fix only the failing config/input.
-- Re-run the same user-style flow from step 5 onward.
+- Ensure connector runtime is active (`clawdentity connector start <agent-name>`).
+- Re-run `clawdentity openclaw doctor`.
+- Re-run `clawdentity openclaw relay test --peer <alias>`.
+- Re-run the same user-style flow from step 5 onward only after health checks pass.
 
 ## Bundled Resources
 
 ### References
 | File | Purpose |
 |------|---------|
-| `references/clawdentity-protocol.md` | Header format, peer map schema, and relay verification details |
+| `references/clawdentity-protocol.md` | Invite format, peer map schema, connector handoff envelope, and runtime failure mapping |
 
-Directive: read the reference file before troubleshooting protocol or signature failures.
+Directive: read the reference file before troubleshooting relay contract or connector handoff failures.

--- a/apps/cli/skill-bundle/openclaw-skill/skill/references/clawdentity-protocol.md
+++ b/apps/cli/skill-bundle/openclaw-skill/skill/references/clawdentity-protocol.md
@@ -63,6 +63,42 @@ Rules:
 - `proxyUrl` required and must be a valid absolute URL
 - `name` optional
 
+## Proxy Pairing Prerequisite
+
+Relay delivery policy is trust-pair based on proxy side. Pairing must be completed before first cross-agent delivery.
+
+Current pairing contract is API-based (no dedicated CLI pairing command):
+
+1. Initiator owner starts pairing:
+   - `POST /pair/start`
+   - headers:
+     - `Authorization: Claw <AIT>`
+     - `x-claw-owner-pat: <owner-pat>`
+   - body:
+
+```json
+{
+  "agentDid": "did:claw:agent:01RESPONDER..."
+}
+```
+
+2. Responder confirms pairing:
+   - `POST /pair/confirm`
+   - headers:
+     - `Authorization: Claw <AIT>`
+   - body:
+
+```json
+{
+  "pairingCode": "01PAIRCODE..."
+}
+```
+
+Rules:
+- `pairingCode` is one-time and expires.
+- Confirm establishes mutual trust for the initiator/responder pair.
+- Same-agent sender/recipient is allowed by policy without explicit pair entry.
+
 ## Relay Input Contract
 
 The OpenClaw transform reads `ctx.payload`.
@@ -73,7 +109,7 @@ The OpenClaw transform reads `ctx.payload`.
 - If `payload.peer` exists:
   - resolve peer from `peers.json`
   - remove `peer` from forwarded body
-  - send JSON POST to `peer.proxyUrl`
+  - send JSON POST to local connector outbound endpoint
   - return `null` to skip local handling
 
 ## Relay Agent Selection Contract
@@ -100,31 +136,40 @@ Rules:
 - `updatedAt` is ISO-8601 UTC timestamp.
 - Proxy runtime precedence is: `OPENCLAW_BASE_URL` env first, then `openclaw-relay.json`, then built-in default.
 
-## Outbound Auth Contract
+## Connector Handoff Contract
 
-Headers sent to peer proxy:
-- `Authorization: Claw <AIT>`
-- `Content-Type: application/json`
-- `X-Claw-Timestamp`
-- `X-Claw-Nonce`
-- `X-Claw-Body-SHA256`
-- `X-Claw-Proof`
+The transform does not send directly to the peer proxy. It posts to the local connector runtime:
+- Default endpoint: `http://127.0.0.1:19400/v1/outbound`
+- Optional overrides:
+  - `CLAWDENTITY_CONNECTOR_BASE_URL`
+  - `CLAWDENTITY_CONNECTOR_OUTBOUND_PATH`
 
-Signing inputs:
-- HTTP method: `POST`
-- path+query from peer URL
-- unix seconds timestamp
-- random nonce
-- outbound JSON body bytes
-- agent secret key from `secret.key`
+Outbound JSON body sent by transform:
+
+```json
+{
+  "peer": "beta",
+  "peerDid": "did:claw:agent:01H...",
+  "peerProxyUrl": "https://beta-proxy.example.com/hooks/agent",
+  "payload": {
+    "event": "agent.message"
+  }
+}
+```
+
+Rules:
+- `payload.peer` is removed before creating the `payload` object above.
+- Transform sends `Content-Type: application/json` only.
+- Connector runtime is responsible for Clawdentity auth headers and request signing when calling peer proxy.
 
 ## Error Conditions
 
 Relay fails when:
 - no selected local agent can be resolved
 - peer alias missing from config
-- `secret.key` or `ait.jwt` missing/empty/invalid
-- peer returns non-2xx
-- peer network request fails
+- local connector outbound endpoint is unavailable (`404`)
+- local connector reports unknown peer alias (`409`)
+- local connector rejects payload (`400` or `422`)
+- local connector outbound request fails (network/other non-2xx)
 
 Error messages should include file/path context but never print secret content.

--- a/apps/openclaw-skill/AGENTS.md
+++ b/apps/openclaw-skill/AGENTS.md
@@ -27,6 +27,13 @@
 - Keep filesystem path logic centralized; avoid hardcoding `~/.clawdentity` paths across multiple files.
 - Keep relay behavior pure except for explicit dependencies (`fetch`, filesystem) so tests stay deterministic.
 - Prefer schema-first runtime validation over ad-hoc guards.
+- Keep skill docs aligned with connector architecture: do not document direct transform-to-peer-proxy signing.
+- Keep `skill/SKILL.md` command utilization section explicit and executable with current CLI commands used by this skill (`config`, `agent`, `openclaw setup/doctor/relay test`, `connector start`, optional `connector service install`).
+- Keep pairing prerequisite documented as API-based (`/pair/start`, `/pair/confirm`) until a dedicated CLI pairing command exists.
+- When `src/transforms/relay-to-peer.ts` relay envelope, endpoint defaults, or failure mapping changes, update:
+  - `skill/SKILL.md`
+  - `skill/references/clawdentity-protocol.md`
+  - bundled copies in `apps/cli/skill-bundle/openclaw-skill/skill/*`
 
 ## Validation Commands
 - `pnpm -F @clawdentity/openclaw-skill typecheck`

--- a/apps/openclaw-skill/skill/SKILL.md
+++ b/apps/openclaw-skill/skill/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: clawdentity_openclaw_relay
-description: This skill should be used when the user asks to "install clawdentity relay skill", "set up agent-to-agent relay from invite code", "connect OpenClaw agents with invite code", or needs OpenClaw peer communication with Clawdentity PoP verification.
+description: This skill should be used when the user asks to "install clawdentity relay skill", "set up agent-to-agent relay from invite code", "connect OpenClaw agents with invite code", or needs OpenClaw peer communication through the local Clawdentity connector runtime.
 version: 0.1.0
 ---
 
 # Clawdentity OpenClaw Relay Skill
 
-This skill configures an OpenClaw agent to relay selected webhook payloads to a peer through Clawdentity identity (`Authorization: Claw <AIT>` + PoP headers) using a single invite code.
+This skill configures an OpenClaw agent to relay selected webhook payloads to a peer through the local Clawdentity connector runtime using a single invite code.
 
 ## Trigger Conditions
 
@@ -36,14 +36,10 @@ Use this skill when any of the following are requested:
 - Local selected agent marker: `~/.clawdentity/openclaw-agent-name`
 - Relay runtime config: `~/.clawdentity/openclaw-relay.json`
 
-## Operator Split
+## Invite Input Assumption
 
-### Admin/operator side (only action required)
-Create invite code:
-
-`clawdentity openclaw invite --did <peer-agent-did> --proxy-url <peer-proxy-hooks-agent-url> --peer-alias <alias>`
-
-Share the invite code string with the human who owns the target agent.
+Provide a valid invite code string before running this skill.
+Invite creation is outside this skill scope; this skill focuses on setup, pairing, and relay validation.
 
 ## Human + Agent Flow (strict user-style)
 
@@ -56,6 +52,41 @@ This skill is operational. The agent must execute side effects via tools.
 - Do not ask the human to run shell commands that the agent can run itself.
 - Ask the human only for missing secrets/inputs (for example API key or invite code).
 - Report final status with concrete outputs (local DID, peer alias, written paths).
+
+## CLI Command Utilization (required)
+
+Use these commands as the default execution path for skill utilization:
+
+- Initialize local CLI config:
+  - `clawdentity config init`
+- Configure registry URL and API key when missing:
+  - `clawdentity config set registryUrl <registry-url>`
+  - `clawdentity config set apiKey <api-key>`
+- Create and inspect local OpenClaw agent identity:
+  - `clawdentity agent create <agent-name> --framework openclaw`
+  - `clawdentity agent inspect <agent-name>`
+- Apply OpenClaw invite setup:
+  - `clawdentity openclaw setup <agent-name> --invite-code <invite-code>`
+- Start connector runtime for relay handoff:
+  - `clawdentity connector start <agent-name>`
+- Optional persistent connector autostart:
+  - `clawdentity connector service install <agent-name>`
+- Validate health and delivery:
+  - `clawdentity openclaw doctor`
+  - `clawdentity openclaw relay test --peer <alias>`
+
+Pairing bootstrap for trust policy is API-based in the current release (no dedicated pairing CLI command yet):
+
+- Owner/initiator starts pairing on initiator proxy:
+  - `POST /pair/start`
+  - Requires `Authorization: Claw <AIT>` and `x-claw-owner-pat`
+  - Body: `{"agentDid":"<responder-agent-did>"}`
+- Responder confirms on responder proxy:
+  - `POST /pair/confirm`
+  - Requires `Authorization: Claw <AIT>`
+  - Body: `{"pairingCode":"<code-from-start>"}`
+
+Successful confirm establishes mutual trust for the two agent DIDs. After confirm, both directions are allowed for trusted delivery.
 
 1. Confirm prerequisites with the human.
 - Confirm `clawdentity` CLI is installed and runnable.
@@ -94,11 +125,21 @@ This skill is operational. The agent must execute side effects via tools.
   - relay runtime config path
 - Confirm `~/.clawdentity/openclaw-agent-name` is set to the local agent name.
 
-7. Validate with user-style relay test.
-- Human asks Alpha to send a request with `peer: "beta"`.
-- Agent relays with Claw + PoP headers.
-- Peer proxy verifies and forwards to peer OpenClaw.
-- Verify success logs on both sides.
+7. Start connector runtime for local relay handoff.
+- Run `clawdentity connector start <agent-name>`.
+- Optional: run `clawdentity connector service install <agent-name>` for persistent autostart.
+
+8. Complete trust pairing bootstrap.
+- Run pairing start (`POST /pair/start`) from the owner/initiator side.
+- Share returned one-time `pairingCode` with responder side.
+- Run pairing confirm (`POST /pair/confirm`) from responder side.
+- Confirm pairing success before relay test.
+
+9. Validate with user-style relay test.
+- Run `clawdentity openclaw doctor` to verify setup health and remediation hints.
+- Run `clawdentity openclaw relay test --peer <alias>` to execute a probe.
+- Confirm probe success and connector-mediated delivery logs.
+- Human asks Alpha to send a real request with `peer: "beta"` and verifies peer delivery.
 
 ## Required question policy
 
@@ -107,20 +148,23 @@ Ask the human only when required inputs are missing:
 - Unclear OpenClaw state directory.
 - Non-default OpenClaw base URL.
 - Missing invite code.
-- Local registry/proxy network location is unknown or unreachable from agent runtime.
+- Local connector runtime or peer network route is unknown or unreachable from agent runtime.
 
 ## Failure Handling
 
 If setup or relay fails:
 - Report precise missing file/path/value.
 - Fix only the failing config/input.
-- Re-run the same user-style flow from step 5 onward.
+- Ensure connector runtime is active (`clawdentity connector start <agent-name>`).
+- Re-run `clawdentity openclaw doctor`.
+- Re-run `clawdentity openclaw relay test --peer <alias>`.
+- Re-run the same user-style flow from step 5 onward only after health checks pass.
 
 ## Bundled Resources
 
 ### References
 | File | Purpose |
 |------|---------|
-| `references/clawdentity-protocol.md` | Header format, peer map schema, and relay verification details |
+| `references/clawdentity-protocol.md` | Invite format, peer map schema, connector handoff envelope, and runtime failure mapping |
 
-Directive: read the reference file before troubleshooting protocol or signature failures.
+Directive: read the reference file before troubleshooting relay contract or connector handoff failures.

--- a/apps/openclaw-skill/skill/references/clawdentity-protocol.md
+++ b/apps/openclaw-skill/skill/references/clawdentity-protocol.md
@@ -63,6 +63,42 @@ Rules:
 - `proxyUrl` required and must be a valid absolute URL
 - `name` optional
 
+## Proxy Pairing Prerequisite
+
+Relay delivery policy is trust-pair based on proxy side. Pairing must be completed before first cross-agent delivery.
+
+Current pairing contract is API-based (no dedicated CLI pairing command):
+
+1. Initiator owner starts pairing:
+   - `POST /pair/start`
+   - headers:
+     - `Authorization: Claw <AIT>`
+     - `x-claw-owner-pat: <owner-pat>`
+   - body:
+
+```json
+{
+  "agentDid": "did:claw:agent:01RESPONDER..."
+}
+```
+
+2. Responder confirms pairing:
+   - `POST /pair/confirm`
+   - headers:
+     - `Authorization: Claw <AIT>`
+   - body:
+
+```json
+{
+  "pairingCode": "01PAIRCODE..."
+}
+```
+
+Rules:
+- `pairingCode` is one-time and expires.
+- Confirm establishes mutual trust for the initiator/responder pair.
+- Same-agent sender/recipient is allowed by policy without explicit pair entry.
+
 ## Relay Input Contract
 
 The OpenClaw transform reads `ctx.payload`.
@@ -73,7 +109,7 @@ The OpenClaw transform reads `ctx.payload`.
 - If `payload.peer` exists:
   - resolve peer from `peers.json`
   - remove `peer` from forwarded body
-  - send JSON POST to `peer.proxyUrl`
+  - send JSON POST to local connector outbound endpoint
   - return `null` to skip local handling
 
 ## Relay Agent Selection Contract
@@ -100,31 +136,40 @@ Rules:
 - `updatedAt` is ISO-8601 UTC timestamp.
 - Proxy runtime precedence is: `OPENCLAW_BASE_URL` env first, then `openclaw-relay.json`, then built-in default.
 
-## Outbound Auth Contract
+## Connector Handoff Contract
 
-Headers sent to peer proxy:
-- `Authorization: Claw <AIT>`
-- `Content-Type: application/json`
-- `X-Claw-Timestamp`
-- `X-Claw-Nonce`
-- `X-Claw-Body-SHA256`
-- `X-Claw-Proof`
+The transform does not send directly to the peer proxy. It posts to the local connector runtime:
+- Default endpoint: `http://127.0.0.1:19400/v1/outbound`
+- Optional overrides:
+  - `CLAWDENTITY_CONNECTOR_BASE_URL`
+  - `CLAWDENTITY_CONNECTOR_OUTBOUND_PATH`
 
-Signing inputs:
-- HTTP method: `POST`
-- path+query from peer URL
-- unix seconds timestamp
-- random nonce
-- outbound JSON body bytes
-- agent secret key from `secret.key`
+Outbound JSON body sent by transform:
+
+```json
+{
+  "peer": "beta",
+  "peerDid": "did:claw:agent:01H...",
+  "peerProxyUrl": "https://beta-proxy.example.com/hooks/agent",
+  "payload": {
+    "event": "agent.message"
+  }
+}
+```
+
+Rules:
+- `payload.peer` is removed before creating the `payload` object above.
+- Transform sends `Content-Type: application/json` only.
+- Connector runtime is responsible for Clawdentity auth headers and request signing when calling peer proxy.
 
 ## Error Conditions
 
 Relay fails when:
 - no selected local agent can be resolved
 - peer alias missing from config
-- `secret.key` or `ait.jwt` missing/empty/invalid
-- peer returns non-2xx
-- peer network request fails
+- local connector outbound endpoint is unavailable (`404`)
+- local connector reports unknown peer alias (`409`)
+- local connector rejects payload (`400` or `422`)
+- local connector outbound request fails (network/other non-2xx)
 
 Error messages should include file/path context but never print secret content.

--- a/apps/proxy/.env.example
+++ b/apps/proxy/.env.example
@@ -1,7 +1,6 @@
 # Proxy local/development template
 # For local Wrangler development, copy values into .dev.vars.
 # OpenClaw vars are optional for relay-mode proxy operation.
-# Keep them only for backwards compatibility with older local setups.
 # OPENCLAW_HOOK_TOKEN=optional-openclaw-hook-token
 # OPENCLAW_BASE_URL=http://127.0.0.1:18789
 
@@ -10,10 +9,11 @@ ENVIRONMENT=local
 REGISTRY_URL=https://dev.api.clawdentity.com
 INJECT_IDENTITY_INTO_MESSAGE=true
 
-# Optional policy/runtime overrides
-# ALLOW_LIST={"owners":[],"agents":[]}
-# ALLOWLIST_OWNERS=did:claw:human:example
-# ALLOWLIST_AGENTS=did:claw:agent:example
+# Pairing/trust state is managed dynamically via /pair/start + /pair/confirm.
+# No static allowlist environment variables are supported.
+# /pair/start requires request header: x-claw-owner-pat: clw_pat_...
+
+# Optional runtime overrides
 # CRL_REFRESH_INTERVAL_MS=300000
 # CRL_MAX_AGE_MS=900000
 # CRL_STALE_BEHAVIOR=fail-open

--- a/apps/proxy/AGENTS.md
+++ b/apps/proxy/AGENTS.md
@@ -7,6 +7,7 @@
 ## Runtime Configuration
 - Keep runtime config centralized in `src/config.ts`.
 - Keep Cloudflare Worker deployment config in `wrangler.jsonc` with explicit `local`, `development`, and `production` environments.
+- Duplicate Durable Object `bindings` and `migrations` inside each Wrangler env block; env sections do not inherit top-level DO config.
 - Keep deploy traceability explicit by passing `APP_VERSION` (or fallback `PROXY_VERSION`) via Worker bindings; `/health` must surface the resolved version.
 - Parse config with a schema and fail fast with `CONFIG_VALIDATION_FAILED` before startup proceeds.
 - Keep defaults explicit for non-secret settings (`listenPort`, `openclawBaseUrl`, `registryUrl`, CRL timings, stale behavior).
@@ -14,8 +15,8 @@
 - Keep runtime `ENVIRONMENT` explicit and validated to supported values: `local`, `development`, `production`, `test` (default `development`).
 - Keep deployment intent explicit: `local` is for local Wrangler dev runs only; `development` and `production` are remote cloud environments.
 - Keep `INJECT_IDENTITY_INTO_MESSAGE` explicit and default-on (`true`); disable only when operators need unchanged webhook `message` forwarding.
-- Keep OpenClaw env inputs (`OPENCLAW_BASE_URL`, `OPENCLAW_HOOK_TOKEN` / `OPENCLAW_HOOKS_TOKEN`) backward-compatible but optional for relay-mode startup.
-- Keep `.dev.vars` and `.env.example` synchronized when adding/changing proxy config fields (registry URL, optional OpenClaw compatibility vars, and policy/rate-limit vars).
+- Keep OpenClaw env inputs (`OPENCLAW_BASE_URL`, `OPENCLAW_HOOK_TOKEN`) optional for relay-mode startup.
+- Keep `.dev.vars` and `.env.example` synchronized when adding/changing proxy config fields (registry URL, optional OpenClaw vars, and policy/rate-limit vars).
 - Load env files with OpenClaw precedence and no overrides:
   - first `./.env` from the proxy working directory
   - then `$OPENCLAW_STATE_DIR/.env` (or default state dir: `~/.openclaw`, with legacy fallback to existing `~/.clawdbot` / `~/.moldbot` / `~/.moltbot`)
@@ -24,21 +25,26 @@
 - Treat blank env values as unset for fallback resolution:
   - empty/whitespace values (and null-like values) in inherited env must not block `.env` or config-file fallbacks
   - dotenv merge semantics must match parser semantics (non-empty value wins).
-- If hook token env vars are missing, resolve fallback token from `hooks.token` in `openclaw.json` (`OPENCLAW_CONFIG_PATH`/`CLAWDBOT_CONFIG_PATH`, default `$OPENCLAW_STATE_DIR/openclaw.json`).
+- If hook token env vars are missing, resolve fallback token from `hooks.token` in `openclaw.json` (`OPENCLAW_CONFIG_PATH`, default `$OPENCLAW_STATE_DIR/openclaw.json`).
 - Route relay sessions via Durable Objects:
   - `GET /v1/relay/connect` keys connector sessions by authenticated caller agent DID.
   - `POST /hooks/agent` keys recipient delivery by `x-claw-recipient-agent-did`.
   - Do not route sessions via `OWNER_AGENT_DID`.
-- Keep env alias support stable for operator UX:
+- Keep env input contract explicit for operator UX:
   - `LISTEN_PORT` or `PORT`
-  - `OPENCLAW_HOOK_TOKEN` or `OPENCLAW_HOOKS_TOKEN`
+  - `OPENCLAW_HOOK_TOKEN`
   - `REGISTRY_URL` or `CLAWDENTITY_REGISTRY_URL`
-  - state/config path aliases: `OPENCLAW_STATE_DIR`/`CLAWDBOT_STATE_DIR`, `OPENCLAW_CONFIG_PATH`/`CLAWDBOT_CONFIG_PATH`
+  - `OPENCLAW_STATE_DIR`, `OPENCLAW_CONFIG_PATH`
 
-## Allowlist and Access
-- Keep allowlist shape as `{ owners: string[], agents: string[] }`.
-- Allow bootstrap from `ALLOW_LIST` JSON with optional explicit overrides (`ALLOWLIST_OWNERS`, `ALLOWLIST_AGENTS`).
-- Keep allowlist parsing deterministic and reject malformed input with structured config errors.
+## Trust and Pairing
+- Keep trust state in Durable Objects (`ProxyTrustState`), not in static environment variables.
+- Do not add support for `ALLOW_LIST`, `ALLOWLIST_OWNERS`, or `ALLOWLIST_AGENTS`; trust is API-managed only.
+- Pairing is managed by API:
+  - `POST /pair/start` (verified Claw auth + `x-claw-owner-pat` ownership check against registry `GET /v1/agents/:id/ownership`)
+  - `POST /pair/confirm` (verified Claw auth + one-time pairing code consume)
+- Keep `/pair/confirm` as a single trust-store operation that establishes trust and consumes the code in one step (`confirmPairingCode`), never two separate calls.
+- Confirming a valid pairing code must establish mutual trust for the initiator/responder agent pair.
+- Keep pairing codes one-time and expiring; reject missing/expired/mismatched codes with explicit client errors.
 - Reject deprecated `ALLOW_ALL_VERIFIED` at startup; never provide a global allow-all bypass for verified callers.
 
 ## Auth Verification
@@ -48,15 +54,16 @@
 - Reject malformed authorization values that contain extra segments beyond `Claw <AIT>`.
 - Reject malformed `X-Claw-Timestamp` values; accept only plain unix-seconds integer strings.
 - Verify request pipeline order as: AIT -> timestamp skew -> PoP signature -> nonce replay -> CRL revocation.
-- Enforce proxy access by explicit agent DID allowlist after auth verification; owner DID-only entries do not grant access.
+- Enforce known-agent access from durable trust state after auth verification (except pairing bootstrap paths).
 - When AIT verification fails with unknown `kid`, refresh registry keyset once and retry verification before returning `401`.
 - When CRL verification fails with unknown `kid`, refresh registry keyset once and retry verification before returning dependency failure.
 - Return `401` for invalid/expired/replayed/revoked/invalid-proof requests.
-- Return `403` when requests are verified but agent DID is not allowlisted.
+- Return `403` when requests are verified but caller is not trusted.
 - Return `429` with `PROXY_PUBLIC_RATE_LIMIT_EXCEEDED` when repeated unauthenticated probes exceed public-route IP budget.
-- Return `429` with `PROXY_RATE_LIMIT_EXCEEDED` when an allowlisted verified agent DID exceeds its request budget within the configured window.
+- Return `429` with `PROXY_RATE_LIMIT_EXCEEDED` when a trusted verified agent DID exceeds its request budget within the configured window.
 - Return `503` when registry keyset dependency is unavailable, and when CRL dependency is unavailable under `fail-closed` stale policy.
 - Keep `/hooks/agent` runtime auth contract strict: require `x-claw-agent-access` and map missing/invalid access credentials to `401`.
+- Keep `/hooks/agent` authorization strict: after auth succeeds, require trusted initiator/responder pair before relay delivery.
 - Keep `/v1/relay/connect` auth strict with verified Claw auth + PoP headers, but do not require `x-claw-agent-access`.
 
 ## CRL Policy

--- a/apps/proxy/src/AGENTS.md
+++ b/apps/proxy/src/AGENTS.md
@@ -16,6 +16,8 @@
 - Keep OpenClaw compatibility vars optional for relay-mode runtime; never require `OPENCLAW_BASE_URL` or hook token for cloud relay startup.
 - Keep fallback semantics consistent across merge + parse stages: empty/whitespace env values are treated as missing, so non-empty `.env`/file values can be used.
 - Do not derive runtime environment from `NODE_ENV`; use validated `ENVIRONMENT` from proxy config.
+- Keep static allowlist env vars removed (`ALLOW_LIST`, `ALLOWLIST_OWNERS`, `ALLOWLIST_AGENTS`); trust must come from pairing state, not env.
+- Keep `/pair/confirm` write path atomic at the trust-store API level: trust persistence and pairing-code consumption must happen in one operation (`confirmPairingCode`).
 
 ## Config Error Handling
 - Convert parse failures to `ProxyConfigError` with code `CONFIG_VALIDATION_FAILED`.
@@ -24,7 +26,8 @@
 ## Maintainability
 - Prefer schema-driven parsing with small pure helpers for coercion/overrides.
 - Keep CRL defaults centralized as exported constants in `config.ts`; do not duplicate timing literals across modules.
-- Keep allowlist schema strict and agent-first: reject unknown allowlist keys and require explicit `allowList.agents` membership after verification.
+- Keep trust/pairing state centralized in `proxy-trust-store.ts` and `proxy-trust-state.ts` (Durable Object backed).
+- Keep pairing route logic isolated in `pairing-route.ts`; `server.ts` should compose it, not implement policy details.
 - Keep `ALLOW_ALL_VERIFIED` removed; fail fast when deprecated bypass flags are provided.
 - Keep server middleware composable and single-responsibility to reduce churn in later T27-T31 auth/forwarding work.
 - Keep `/hooks/agent` forwarding logic isolated in `agent-hook-route.ts`; `server.ts` should only compose middleware/routes.
@@ -32,9 +35,12 @@
 - Keep DO runtime behavior in `agent-relay-session.ts` (websocket accept, heartbeat alarm, connector delivery RPC).
 - Do not import Node-only startup helpers into `worker.ts`; Worker runtime must stay free of process/port startup concerns.
 - Keep worker runtime cache keys sensitive to deploy-time version bindings so `/health` reflects fresh `APP_VERSION` after deploy.
-- Keep auth failure semantics stable: auth-invalid requests map to `401`; verified-but-not-allowlisted requests map to `403`; registry keyset outages map to `503`; CRL outages map to `503` when stale behavior is `fail-closed`.
+- Keep auth failure semantics stable: auth-invalid requests map to `401`; verified-but-not-trusted requests map to `403`; registry keyset outages map to `503`; CRL outages map to `503` when stale behavior is `fail-closed`.
+- Keep pairing bootstrap explicit: `/pair/start` and `/pair/confirm` must bypass known-agent gate in auth middleware.
+- Keep `/pair/start` ownership validation against registry `GET /v1/agents/:id/ownership` using `x-claw-owner-pat`, and map dependency failures to `503`.
 - Keep `/hooks/agent` runtime auth contract strict: require `x-claw-agent-access` and map missing/invalid access credentials to `401`.
 - Keep `/hooks/agent` recipient routing explicit: require `x-claw-recipient-agent-did` and resolve DO IDs from that recipient DID, never from owner DID env.
+- Keep `/hooks/agent` trust check explicit: sender/recipient pair must be authorized by trust state before relay delivery.
 - Keep `/v1/relay/connect` keyed by authenticated connector DID from auth middleware, and reject non-websocket requests with clear client errors.
 - Keep pre-auth IP throttling enabled for `/hooks/agent` and `/v1/relay/connect` so repeated unauthenticated probes fail with `429` before auth/registry work.
 - Keep rate-limit failure semantics stable: verified requests over budget map to `429` with code `PROXY_RATE_LIMIT_EXCEEDED` and structured warn log event `proxy.rate_limit.exceeded`.
@@ -46,5 +52,6 @@
 - Keep agent-access validation centralized in `auth-middleware.ts` and call registry `POST /v1/agents/auth/validate`; treat non-`204` non-`401` responses as dependency failures (`503`).
 - Keep relay delivery failure mapping explicit for `/hooks/agent`: DO delivery/RPC failures -> `502`, unavailable DO namespace -> `503`.
 - Keep identity message injection explicit and default-on (`INJECT_IDENTITY_INTO_MESSAGE=true`); operators can disable it when unchanged forwarding is required.
+- Keep Durable Object trust routes explicit in `proxy-trust-store.ts`/`proxy-trust-state.ts` and use route constants from one source (`TRUST_STORE_ROUTES`) to avoid drift.
 - Keep identity augmentation logic in small pure helpers (`sanitizeIdentityField`, `buildIdentityBlock`, payload mutation helper) inside `agent-hook-route.ts`; avoid spreading identity-format logic into `server.ts`.
 - When identity injection is enabled, sanitize identity fields (strip control chars, normalize whitespace, enforce max lengths) and mutate only string `message` fields.

--- a/apps/proxy/src/agent-hook-route.test.ts
+++ b/apps/proxy/src/agent-hook-route.test.ts
@@ -36,6 +36,7 @@ import type {
   RelayDeliveryResult,
 } from "./agent-relay-session.js";
 import { parseProxyConfig } from "./config.js";
+import type { ProxyTrustStore } from "./proxy-trust-store.js";
 import { createProxyApp } from "./server.js";
 
 function hasDisallowedControlCharacter(value: string): boolean {
@@ -105,10 +106,23 @@ function createHookRouteApp(input: {
   injectIdentityIntoMessage?: boolean;
   now?: () => Date;
 }) {
+  const trustStore: ProxyTrustStore = {
+    createPairingCode: vi.fn(),
+    consumePairingCode: vi.fn(),
+    confirmPairingCode: vi.fn(),
+    isAgentKnown: vi.fn(async () => true),
+    isPairAllowed: vi.fn(
+      async (pair) =>
+        pair.responderAgentDid === "did:claw:agent:01HF7YAT31JZHSMW1CG6Q6MHB7",
+    ),
+    upsertPair: vi.fn(async () => {}),
+  };
+
   return createProxyApp({
     config: parseProxyConfig({
       INJECT_IDENTITY_INTO_MESSAGE: input.injectIdentityIntoMessage,
     }),
+    trustStore,
     hooks: {
       now: input.now,
       resolveSessionNamespace: () => input.relayNamespace,
@@ -182,6 +196,28 @@ describe("POST /hooks/agent", () => {
 
     expect(response.status).toBe(202);
     expect(relayHarness.fetchRpc).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 403 when sender/recipient pair is not trusted", async () => {
+    const relayHarness = createRelayHarness();
+    const app = createHookRouteApp({
+      relayNamespace: relayHarness.namespace,
+    });
+
+    const response = await app.request("/hooks/agent", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        [RELAY_RECIPIENT_AGENT_DID_HEADER]:
+          "did:claw:agent:01HF7YAT31JZHSMW1CG6Q6MHB8",
+      },
+      body: JSON.stringify({ event: "agent.started" }),
+    });
+
+    expect(response.status).toBe(403);
+    const body = (await response.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("PROXY_AUTH_FORBIDDEN");
+    expect(relayHarness.fetchRpc).not.toHaveBeenCalled();
   });
 
   it("prepends sanitized identity block when message injection is enabled", async () => {

--- a/apps/proxy/src/agent-hook-route.ts
+++ b/apps/proxy/src/agent-hook-route.ts
@@ -10,6 +10,8 @@ import {
   type RelayDeliveryInput,
 } from "./agent-relay-session.js";
 import type { ProxyRequestVariables } from "./auth-middleware.js";
+import type { ProxyTrustStore } from "./proxy-trust-store.js";
+import { assertTrustedPair } from "./trust-policy.js";
 
 const MAX_AGENT_DID_LENGTH = 160;
 const MAX_OWNER_DID_LENGTH = 160;
@@ -28,6 +30,7 @@ export type AgentHookRuntimeOptions = {
 
 type CreateAgentHookHandlerOptions = AgentHookRuntimeOptions & {
   logger: Logger;
+  trustStore: ProxyTrustStore;
 };
 
 type ProxyContext = Context<{
@@ -193,6 +196,12 @@ export function createAgentHookHandler(
     }
 
     const recipientAgentDid = parseRecipientAgentDid(c);
+    await assertTrustedPair({
+      trustStore: options.trustStore,
+      initiatorAgentDid: auth.agentDid,
+      responderAgentDid: recipientAgentDid,
+    });
+
     const sessionNamespace = resolveSessionNamespace(c);
     if (sessionNamespace === undefined) {
       throw new AppError({

--- a/apps/proxy/src/auth-middleware.test.ts
+++ b/apps/proxy/src/auth-middleware.test.ts
@@ -1,9 +1,4 @@
-import {
-  AGENT_AUTH_VALIDATE_PATH,
-  generateUlid,
-  makeAgentDid,
-  makeHumanDid,
-} from "@clawdentity/protocol";
+import { AGENT_AUTH_VALIDATE_PATH, generateUlid } from "@clawdentity/protocol";
 import {
   encodeEd25519KeypairBase64url,
   generateEd25519Keypair,
@@ -11,10 +6,13 @@ import {
   signCRL,
   signHttpRequest,
 } from "@clawdentity/sdk";
+import { buildTestAitClaims } from "@clawdentity/sdk/testing";
 import { describe, expect, it, vi } from "vitest";
 import { RELAY_RECIPIENT_AGENT_DID_HEADER } from "./agent-hook-route.js";
 import type { AgentRelaySessionNamespace } from "./agent-relay-session.js";
 import { parseProxyConfig } from "./config.js";
+import { PAIR_CONFIRM_PATH } from "./pairing-constants.js";
+import { createInMemoryProxyTrustStore } from "./proxy-trust-store.js";
 import { RELAY_CONNECT_PATH } from "./relay-connect-route.js";
 import { createProxyApp } from "./server.js";
 
@@ -23,6 +21,7 @@ const NOW_MS = Date.now();
 const NOW_SECONDS = Math.floor(NOW_MS / 1000);
 const ISSUER = "https://api.clawdentity.com";
 const BODY_JSON = JSON.stringify({ message: "hello" });
+const KNOWN_PEER_DID = "did:claw:agent:known-peer";
 
 type AuthHarnessOptions = {
   expired?: boolean;
@@ -30,14 +29,13 @@ type AuthHarnessOptions = {
   fetchCrlFails?: boolean;
   fetchKeysFails?: boolean;
   allowCurrentAgent?: boolean;
-  allowCurrentOwner?: boolean;
   revoked?: boolean;
   validateStatus?: number;
 };
 
 type AuthHarness = {
   app: ReturnType<typeof createProxyApp>;
-  claims: Awaited<ReturnType<typeof buildAitClaims>>;
+  claims: ReturnType<typeof buildTestAitClaims>;
   createSignedHeaders: (input?: {
     body?: string;
     method?: "GET" | "POST";
@@ -47,46 +45,6 @@ type AuthHarness = {
     timestampSeconds?: number;
   }) => Promise<Record<string, string>>;
 };
-
-async function buildAitClaims(input: { agentPublicKeyX: string }): Promise<{
-  iss: string;
-  sub: string;
-  ownerDid: string;
-  name: string;
-  framework: string;
-  description: string;
-  cnf: {
-    jwk: {
-      kty: "OKP";
-      crv: "Ed25519";
-      x: string;
-    };
-  };
-  iat: number;
-  nbf: number;
-  exp: number;
-  jti: string;
-}> {
-  return {
-    iss: ISSUER,
-    sub: makeAgentDid(generateUlid(NOW_MS + 10)),
-    ownerDid: makeHumanDid(generateUlid(NOW_MS + 20)),
-    name: "Proxy Agent",
-    framework: "openclaw",
-    description: "test agent",
-    cnf: {
-      jwk: {
-        kty: "OKP",
-        crv: "Ed25519",
-        x: input.agentPublicKeyX,
-      },
-    },
-    iat: NOW_SECONDS - 10,
-    nbf: NOW_SECONDS - 10,
-    exp: NOW_SECONDS + 600,
-    jti: generateUlid(NOW_MS + 30),
-  };
-}
 
 function resolveRequestUrl(requestInput: unknown): string {
   if (typeof requestInput === "string") {
@@ -167,8 +125,13 @@ async function createAuthHarness(
   const agentKeypair = await generateEd25519Keypair();
   const encodedRegistry = encodeEd25519KeypairBase64url(registryKeypair);
   const encodedAgent = encodeEd25519KeypairBase64url(agentKeypair);
-  const claims = await buildAitClaims({
-    agentPublicKeyX: encodedAgent.publicKey,
+  const claims = buildTestAitClaims({
+    publicKeyX: encodedAgent.publicKey,
+    issuer: ISSUER,
+    nowSeconds: NOW_SECONDS - 10,
+    ttlSeconds: 610,
+    nbfSkewSeconds: 0,
+    seedMs: NOW_MS,
   });
   if (options.expired) {
     claims.exp = NOW_SECONDS - 1;
@@ -210,9 +173,14 @@ async function createAuthHarness(
     validateStatus: options.validateStatus,
   });
 
-  const allowListAgents =
-    options.allowCurrentAgent === false ? [] : [claims.sub];
-  const allowListOwners = options.allowCurrentOwner ? [claims.ownerDid] : [];
+  const trustStore = createInMemoryProxyTrustStore();
+  if (options.allowCurrentAgent !== false) {
+    await trustStore.upsertPair({
+      initiatorAgentDid: claims.sub,
+      responderAgentDid: KNOWN_PEER_DID,
+    });
+  }
+
   const relaySession = {
     fetch: vi.fn(async (request: Request) => {
       if (request.method === "POST") {
@@ -235,16 +203,11 @@ async function createAuthHarness(
 
   const app = createProxyApp({
     config: parseProxyConfig({
-      ...(allowListAgents.length > 0
-        ? { ALLOWLIST_AGENTS: allowListAgents.join(",") }
-        : {}),
-      ...(allowListOwners.length > 0
-        ? { ALLOWLIST_OWNERS: allowListOwners.join(",") }
-        : {}),
       ...(options.crlStaleBehavior
         ? { CRL_STALE_BEHAVIOR: options.crlStaleBehavior }
         : {}),
     }),
+    trustStore,
     auth: {
       fetchImpl: fetchMock as typeof fetch,
       clock: () => NOW_MS,
@@ -328,12 +291,12 @@ describe("proxy auth middleware", () => {
     expect(body.auth.aitJti).toBe(harness.claims.jti);
   });
 
-  it("returns 403 when a verified caller is not allowlisted by agent DID", async () => {
+  it("returns 403 when a verified caller is not trusted by agent DID", async () => {
     const harness = await createAuthHarness({
       allowCurrentAgent: false,
     });
     const headers = await harness.createSignedHeaders({
-      nonce: "nonce-not-allowlisted",
+      nonce: "nonce-not-trusted",
     });
     const response = await harness.app.request("/protected", {
       method: "POST",
@@ -346,23 +309,26 @@ describe("proxy auth middleware", () => {
     expect(body.error.code).toBe("PROXY_AUTH_FORBIDDEN");
   });
 
-  it("returns 403 when only owner DID is allowlisted", async () => {
+  it("allows unknown agents to reach /pair/confirm for pairing bootstrap", async () => {
     const harness = await createAuthHarness({
       allowCurrentAgent: false,
-      allowCurrentOwner: true,
     });
+    const requestBody = JSON.stringify({ pairingCode: "missing-code" });
     const headers = await harness.createSignedHeaders({
-      nonce: "nonce-owner-only-allowlisted",
-    });
-    const response = await harness.app.request("/protected", {
-      method: "POST",
-      headers,
-      body: BODY_JSON,
+      body: requestBody,
+      nonce: "nonce-pair-confirm-bootstrap",
+      pathWithQuery: PAIR_CONFIRM_PATH,
     });
 
-    expect(response.status).toBe(403);
+    const response = await harness.app.request(PAIR_CONFIRM_PATH, {
+      method: "POST",
+      headers,
+      body: requestBody,
+    });
+
+    expect(response.status).toBe(404);
     const body = (await response.json()) as { error: { code: string } };
-    expect(body.error.code).toBe("PROXY_AUTH_FORBIDDEN");
+    expect(body.error.code).toBe("PROXY_PAIR_CODE_NOT_FOUND");
   });
 
   it("refreshes keyset and accepts valid AIT after registry key rotation", async () => {
@@ -377,8 +343,13 @@ describe("proxy auth middleware", () => {
       encodeEd25519KeypairBase64url(newRegistryKeypair);
     const encodedAgent = encodeEd25519KeypairBase64url(agentKeypair);
 
-    const claims = await buildAitClaims({
-      agentPublicKeyX: encodedAgent.publicKey,
+    const claims = buildTestAitClaims({
+      publicKeyX: encodedAgent.publicKey,
+      issuer: ISSUER,
+      nowSeconds: NOW_SECONDS - 10,
+      ttlSeconds: 610,
+      nbfSkewSeconds: 0,
+      seedMs: NOW_MS,
     });
     const ait = await signAIT({
       claims,
@@ -447,11 +418,17 @@ describe("proxy auth middleware", () => {
       },
     );
 
+    const trustStore = createInMemoryProxyTrustStore();
+    await trustStore.upsertPair({
+      initiatorAgentDid: claims.sub,
+      responderAgentDid: KNOWN_PEER_DID,
+    });
+
     const app = createProxyApp({
       config: parseProxyConfig({
         OPENCLAW_HOOK_TOKEN: "openclaw-hook-token",
-        ALLOWLIST_AGENTS: claims.sub,
       }),
+      trustStore,
       auth: {
         fetchImpl: fetchMock as typeof fetch,
         clock: () => NOW_MS,
@@ -495,8 +472,13 @@ describe("proxy auth middleware", () => {
       encodeEd25519KeypairBase64url(newRegistryKeypair);
     const encodedAgent = encodeEd25519KeypairBase64url(agentKeypair);
 
-    const claims = await buildAitClaims({
-      agentPublicKeyX: encodedAgent.publicKey,
+    const claims = buildTestAitClaims({
+      publicKeyX: encodedAgent.publicKey,
+      issuer: ISSUER,
+      nowSeconds: NOW_SECONDS - 10,
+      ttlSeconds: 610,
+      nbfSkewSeconds: 0,
+      seedMs: NOW_MS,
     });
     const ait = await signAIT({
       claims,
@@ -565,11 +547,17 @@ describe("proxy auth middleware", () => {
       },
     );
 
+    const trustStore = createInMemoryProxyTrustStore();
+    await trustStore.upsertPair({
+      initiatorAgentDid: claims.sub,
+      responderAgentDid: KNOWN_PEER_DID,
+    });
+
     const app = createProxyApp({
       config: parseProxyConfig({
         OPENCLAW_HOOK_TOKEN: "openclaw-hook-token",
-        ALLOWLIST_AGENTS: claims.sub,
       }),
+      trustStore,
       auth: {
         fetchImpl: fetchMock as typeof fetch,
         clock: () => NOW_MS,

--- a/apps/proxy/src/auth-middleware.ts
+++ b/apps/proxy/src/auth-middleware.ts
@@ -21,6 +21,9 @@ import {
 } from "@clawdentity/sdk";
 import { createMiddleware } from "hono/factory";
 import type { ProxyConfig } from "./config.js";
+import { PAIR_CONFIRM_PATH, PAIR_START_PATH } from "./pairing-constants.js";
+import type { ProxyTrustStore } from "./proxy-trust-store.js";
+import { assertKnownTrustedAgent } from "./trust-policy.js";
 
 export const DEFAULT_REGISTRY_KEYS_CACHE_TTL_MS = 60 * 60 * 1000;
 export const DEFAULT_MAX_TIMESTAMP_SKEW_SECONDS = 300;
@@ -53,6 +56,7 @@ export type ProxyRequestVariables = RequestContextVariables & {
 export type ProxyAuthMiddlewareOptions = {
   config: ProxyConfig;
   logger: Logger;
+  trustStore: ProxyTrustStore;
   fetchImpl?: typeof fetch;
   clock?: () => number;
   nonceCache?: NonceCache;
@@ -137,22 +141,8 @@ function dependencyUnavailableError(options: {
   });
 }
 
-function forbiddenError(options: {
-  code: string;
-  message: string;
-  details?: Record<string, unknown>;
-}): AppError {
-  return new AppError({
-    code: options.code,
-    message: options.message,
-    status: 403,
-    details: options.details,
-    expose: true,
-  });
-}
-
-function isAgentDidAllowed(config: ProxyConfig, agentDid: string): boolean {
-  return config.allowList.agents.includes(agentDid);
+function shouldSkipKnownAgentCheck(path: string): boolean {
+  return path === PAIR_START_PATH || path === PAIR_CONFIRM_PATH;
 }
 
 export function parseClawAuthorizationHeader(authorization?: string): string {
@@ -596,13 +586,10 @@ export function createProxyAuthMiddleware(options: ProxyAuthMiddlewareOptions) {
         });
       }
 
-      if (!isAgentDidAllowed(options.config, claims.sub)) {
-        throw forbiddenError({
-          code: "PROXY_AUTH_FORBIDDEN",
-          message: "Verified caller is not allowlisted",
-          details: {
-            agentDid: claims.sub,
-          },
+      if (!shouldSkipKnownAgentCheck(c.req.path)) {
+        await assertKnownTrustedAgent({
+          trustStore: options.trustStore,
+          agentDid: claims.sub,
         });
       }
 

--- a/apps/proxy/src/config.test.ts
+++ b/apps/proxy/src/config.test.ts
@@ -29,10 +29,6 @@ describe("proxy config", () => {
       openclawHookToken: undefined,
       registryUrl: DEFAULT_REGISTRY_URL,
       environment: DEFAULT_PROXY_ENVIRONMENT,
-      allowList: {
-        owners: [],
-        agents: [],
-      },
       crlRefreshIntervalMs: DEFAULT_CRL_REFRESH_INTERVAL_MS,
       crlMaxAgeMs: DEFAULT_CRL_MAX_AGE_MS,
       crlStaleBehavior: "fail-open",
@@ -43,10 +39,10 @@ describe("proxy config", () => {
     });
   });
 
-  it("supports OpenClaw-compatible env aliases", () => {
+  it("supports canonical proxy env inputs", () => {
     const config = parseProxyConfig({
       PORT: "4100",
-      OPENCLAW_HOOKS_TOKEN: "hooks-token",
+      OPENCLAW_HOOK_TOKEN: "hooks-token",
       CLAWDENTITY_REGISTRY_URL: "https://registry.example.com",
       ENVIRONMENT: "local",
       CRL_STALE_BEHAVIOR: "fail-closed",
@@ -73,50 +69,14 @@ describe("proxy config", () => {
     expect(config.injectIdentityIntoMessage).toBe(false);
   });
 
-  it("parses allow list object and override env lists", () => {
-    const config = parseProxyConfig({
-      OPENCLAW_HOOK_TOKEN: "token",
-      ALLOW_LIST: JSON.stringify({
-        owners: ["did:claw:owner:1"],
-        agents: ["did:claw:agent:1"],
-      }),
-      ALLOWLIST_OWNERS: "did:claw:owner:2,did:claw:owner:3",
-    });
-
-    expect(config.allowList).toEqual({
-      owners: ["did:claw:owner:2", "did:claw:owner:3"],
-      agents: ["did:claw:agent:1"],
-    });
-  });
-
   it("accepts missing hook token for relay-only startup", () => {
     expect(() => parseProxyConfig({})).not.toThrow();
-  });
-
-  it("throws on malformed allow list JSON", () => {
-    expect(() =>
-      parseProxyConfig({
-        ALLOW_LIST: "{not-json",
-      }),
-    ).toThrow(ProxyConfigError);
   });
 
   it("throws when deprecated ALLOW_ALL_VERIFIED is set", () => {
     expect(() =>
       parseProxyConfig({
         ALLOW_ALL_VERIFIED: "true",
-      }),
-    ).toThrow(ProxyConfigError);
-  });
-
-  it("throws when ALLOW_LIST includes unknown keys", () => {
-    expect(() =>
-      parseProxyConfig({
-        ALLOW_LIST: JSON.stringify({
-          owners: [],
-          agents: [],
-          allowAllVerified: true,
-        }),
       }),
     ).toThrow(ProxyConfigError);
   });

--- a/apps/proxy/src/config.ts
+++ b/apps/proxy/src/config.ts
@@ -86,9 +86,6 @@ const proxyRuntimeEnvSchema = z.object({
   ENVIRONMENT: z
     .enum(proxyEnvironmentValues)
     .default(DEFAULT_PROXY_ENVIRONMENT),
-  ALLOW_LIST: z.string().optional(),
-  ALLOWLIST_OWNERS: z.string().optional(),
-  ALLOWLIST_AGENTS: z.string().optional(),
   CRL_REFRESH_INTERVAL_MS: z.coerce
     .number()
     .int()
@@ -117,20 +114,12 @@ const proxyRuntimeEnvSchema = z.object({
   ),
 });
 
-const proxyAllowListSchema = z
-  .object({
-    owners: z.array(z.string().trim().min(1)).default([]),
-    agents: z.array(z.string().trim().min(1)).default([]),
-  })
-  .strict();
-
 export const proxyConfigSchema = z.object({
   listenPort: z.number().int().min(1).max(65535),
   openclawBaseUrl: z.string().url(),
   openclawHookToken: z.string().min(1).optional(),
   registryUrl: z.string().url(),
   environment: z.enum(proxyEnvironmentValues),
-  allowList: proxyAllowListSchema,
   crlRefreshIntervalMs: z.number().int().positive(),
   crlMaxAgeMs: z.number().int().positive(),
   crlStaleBehavior: z.enum(["fail-open", "fail-closed"]),
@@ -140,20 +129,15 @@ export const proxyConfigSchema = z.object({
 });
 
 export type ProxyConfig = z.infer<typeof proxyConfigSchema>;
-export type ProxyAllowList = z.infer<typeof proxyAllowListSchema>;
 
 type RuntimeEnvInput = {
   LISTEN_PORT?: unknown;
   PORT?: unknown;
   OPENCLAW_BASE_URL?: unknown;
   OPENCLAW_HOOK_TOKEN?: unknown;
-  OPENCLAW_HOOKS_TOKEN?: unknown;
   REGISTRY_URL?: unknown;
   CLAWDENTITY_REGISTRY_URL?: unknown;
   ENVIRONMENT?: unknown;
-  ALLOW_LIST?: unknown;
-  ALLOWLIST_OWNERS?: unknown;
-  ALLOWLIST_AGENTS?: unknown;
   ALLOW_ALL_VERIFIED?: unknown;
   CRL_REFRESH_INTERVAL_MS?: unknown;
   CRL_MAX_AGE_MS?: unknown;
@@ -162,9 +146,7 @@ type RuntimeEnvInput = {
   AGENT_RATE_LIMIT_WINDOW_MS?: unknown;
   INJECT_IDENTITY_INTO_MESSAGE?: unknown;
   OPENCLAW_STATE_DIR?: unknown;
-  CLAWDBOT_STATE_DIR?: unknown;
   OPENCLAW_CONFIG_PATH?: unknown;
-  CLAWDBOT_CONFIG_PATH?: unknown;
   HOME?: unknown;
   USERPROFILE?: unknown;
 };
@@ -272,10 +254,7 @@ function resolveStateDir(
 ): string {
   const cwd = options.cwd ?? resolveDefaultCwd();
   const home = resolveHomeDir(env, options.homeDir);
-  const stateDirOverride = firstNonEmptyString(env, [
-    "OPENCLAW_STATE_DIR",
-    "CLAWDBOT_STATE_DIR",
-  ]);
+  const stateDirOverride = firstNonEmptyString(env, ["OPENCLAW_STATE_DIR"]);
 
   if (stateDirOverride !== undefined) {
     return resolvePathWithHome(stateDirOverride, cwd, home);
@@ -303,10 +282,7 @@ function resolveOpenClawConfigPath(
   const cwd = options.cwd ?? resolveDefaultCwd();
   const home = resolveHomeDir(env, options.homeDir);
   const stateDir = resolveStateDir(env, options);
-  const configPathOverride = firstNonEmptyString(env, [
-    "OPENCLAW_CONFIG_PATH",
-    "CLAWDBOT_CONFIG_PATH",
-  ]);
+  const configPathOverride = firstNonEmptyString(env, ["OPENCLAW_CONFIG_PATH"]);
 
   if (configPathOverride !== undefined) {
     return resolvePathWithHome(configPathOverride, cwd, home);
@@ -520,18 +496,12 @@ function normalizeRuntimeEnv(input: unknown): Record<string, unknown> {
   return {
     LISTEN_PORT: firstNonEmpty(env, ["LISTEN_PORT", "PORT"]),
     OPENCLAW_BASE_URL: firstNonEmpty(env, ["OPENCLAW_BASE_URL"]),
-    OPENCLAW_HOOK_TOKEN: firstNonEmpty(env, [
-      "OPENCLAW_HOOK_TOKEN",
-      "OPENCLAW_HOOKS_TOKEN",
-    ]),
+    OPENCLAW_HOOK_TOKEN: firstNonEmpty(env, ["OPENCLAW_HOOK_TOKEN"]),
     REGISTRY_URL: firstNonEmpty(env, [
       "REGISTRY_URL",
       "CLAWDENTITY_REGISTRY_URL",
     ]),
     ENVIRONMENT: firstNonEmpty(env, ["ENVIRONMENT"]),
-    ALLOW_LIST: firstNonEmpty(env, ["ALLOW_LIST"]),
-    ALLOWLIST_OWNERS: firstNonEmpty(env, ["ALLOWLIST_OWNERS"]),
-    ALLOWLIST_AGENTS: firstNonEmpty(env, ["ALLOWLIST_AGENTS"]),
     CRL_REFRESH_INTERVAL_MS: firstNonEmpty(env, ["CRL_REFRESH_INTERVAL_MS"]),
     CRL_MAX_AGE_MS: firstNonEmpty(env, ["CRL_MAX_AGE_MS"]),
     CRL_STALE_BEHAVIOR: firstNonEmpty(env, ["CRL_STALE_BEHAVIOR"]),
@@ -547,62 +517,6 @@ function normalizeRuntimeEnv(input: unknown): Record<string, unknown> {
   };
 }
 
-function dedupe(values: readonly string[]): string[] {
-  return [...new Set(values)];
-}
-
-function parseDidList(input: string): string[] {
-  return dedupe(
-    input
-      .split(",")
-      .map((value) => value.trim())
-      .filter((value) => value.length > 0),
-  );
-}
-
-function parseAllowList(
-  env: z.infer<typeof proxyRuntimeEnvSchema>,
-): ProxyAllowList {
-  let allowList: ProxyAllowList = {
-    owners: [],
-    agents: [],
-  };
-
-  if (env.ALLOW_LIST !== undefined) {
-    let parsedAllowList: unknown;
-    try {
-      parsedAllowList = JSON.parse(env.ALLOW_LIST);
-    } catch {
-      throw toConfigValidationError({
-        fieldErrors: {
-          ALLOW_LIST: ["Expected valid JSON object"],
-        },
-        formErrors: [],
-      });
-    }
-
-    const parsed = proxyAllowListSchema.safeParse(parsedAllowList);
-    if (!parsed.success) {
-      throw toConfigValidationError({
-        fieldErrors: parsed.error.flatten().fieldErrors,
-        formErrors: parsed.error.flatten().formErrors,
-      });
-    }
-
-    allowList = parsed.data;
-  }
-
-  if (env.ALLOWLIST_OWNERS !== undefined) {
-    allowList = { ...allowList, owners: parseDidList(env.ALLOWLIST_OWNERS) };
-  }
-
-  if (env.ALLOWLIST_AGENTS !== undefined) {
-    allowList = { ...allowList, agents: parseDidList(env.ALLOWLIST_AGENTS) };
-  }
-
-  return allowList;
-}
-
 function assertNoDeprecatedAllowAllVerified(env: RuntimeEnvInput): void {
   const value = env.ALLOW_ALL_VERIFIED;
   if (
@@ -615,9 +529,7 @@ function assertNoDeprecatedAllowAllVerified(env: RuntimeEnvInput): void {
 
   throw toConfigValidationError({
     fieldErrors: {
-      ALLOW_ALL_VERIFIED: [
-        "ALLOW_ALL_VERIFIED is no longer supported. Use ALLOWLIST_AGENTS.",
-      ],
+      ALLOW_ALL_VERIFIED: ["ALLOW_ALL_VERIFIED is no longer supported."],
     },
     formErrors: [],
   });
@@ -628,10 +540,7 @@ function loadHookTokenFromFallback(
   options: ProxyConfigLoadOptions,
 ): void {
   if (
-    firstNonEmpty(env as RuntimeEnvInput, [
-      "OPENCLAW_HOOK_TOKEN",
-      "OPENCLAW_HOOKS_TOKEN",
-    ]) !== undefined
+    firstNonEmpty(env as RuntimeEnvInput, ["OPENCLAW_HOOK_TOKEN"]) !== undefined
   ) {
     return;
   }
@@ -684,7 +593,6 @@ export function parseProxyConfig(env: unknown): ProxyConfig {
     openclawHookToken: parsedRuntimeEnv.data.OPENCLAW_HOOK_TOKEN,
     registryUrl: parsedRuntimeEnv.data.REGISTRY_URL,
     environment: parsedRuntimeEnv.data.ENVIRONMENT,
-    allowList: parseAllowList(parsedRuntimeEnv.data),
     crlRefreshIntervalMs: parsedRuntimeEnv.data.CRL_REFRESH_INTERVAL_MS,
     crlMaxAgeMs: parsedRuntimeEnv.data.CRL_MAX_AGE_MS,
     crlStaleBehavior: parsedRuntimeEnv.data.CRL_STALE_BEHAVIOR,

--- a/apps/proxy/src/pairing-constants.ts
+++ b/apps/proxy/src/pairing-constants.ts
@@ -1,0 +1,8 @@
+export const PAIR_START_PATH = "/pair/start";
+export const PAIR_CONFIRM_PATH = "/pair/confirm";
+export const OWNER_PAT_HEADER = "x-claw-owner-pat";
+
+export const DEFAULT_PAIRING_CODE_TTL_SECONDS = 300;
+export const MAX_PAIRING_CODE_TTL_SECONDS = 900;
+
+export const PROXY_TRUST_DO_NAME = "global-trust";

--- a/apps/proxy/src/pairing-route.test.ts
+++ b/apps/proxy/src/pairing-route.test.ts
@@ -1,0 +1,236 @@
+import { generateUlid, makeAgentDid } from "@clawdentity/protocol";
+import { describe, expect, it, vi } from "vitest";
+
+const INITIATOR_AGENT_DID = makeAgentDid(generateUlid(1_700_000_000_000));
+const RESPONDER_AGENT_DID = makeAgentDid(generateUlid(1_700_000_000_100));
+const INTRUDER_AGENT_DID = makeAgentDid(generateUlid(1_700_000_000_300));
+
+vi.mock("./auth-middleware.js", async () => {
+  const { createMiddleware } = await import("hono/factory");
+
+  return {
+    createProxyAuthMiddleware: () =>
+      createMiddleware(async (c, next) => {
+        c.set("auth", {
+          agentDid: c.req.header("x-test-agent-did") ?? INITIATOR_AGENT_DID,
+          ownerDid: c.req.header("x-test-owner-did") ?? "did:claw:human:owner",
+          issuer: "https://api.clawdentity.com",
+          aitJti: "test-ait-jti",
+          cnfPublicKey: "test-key",
+        });
+        await next();
+      }),
+  };
+});
+
+import { parseProxyConfig } from "./config.js";
+import {
+  OWNER_PAT_HEADER,
+  PAIR_CONFIRM_PATH,
+  PAIR_START_PATH,
+} from "./pairing-constants.js";
+import { createInMemoryProxyTrustStore } from "./proxy-trust-store.js";
+import { createProxyApp } from "./server.js";
+
+function createPairingApp(input?: {
+  fetchImpl?: typeof fetch;
+  nowMs?: () => number;
+}) {
+  const trustStore = createInMemoryProxyTrustStore();
+  const app = createProxyApp({
+    config: parseProxyConfig({
+      REGISTRY_URL: "https://registry.example.com",
+    }),
+    pairing: {
+      start: {
+        fetchImpl: input?.fetchImpl,
+        nowMs: input?.nowMs,
+      },
+      confirm: {
+        nowMs: input?.nowMs,
+      },
+    },
+    trustStore,
+  });
+
+  return {
+    app,
+    trustStore,
+  };
+}
+
+describe(`POST ${PAIR_START_PATH}`, () => {
+  it("creates a pairing code when owner PAT controls caller agent DID", async () => {
+    const fetchMock = vi.fn(async (_requestInput: unknown) =>
+      Response.json(
+        {
+          ownsAgent: true,
+        },
+        { status: 200 },
+      ),
+    );
+    const fetchImpl = fetchMock as unknown as typeof fetch;
+
+    const { app } = createPairingApp({
+      fetchImpl,
+      nowMs: () => 1_700_000_000_000,
+    });
+
+    const response = await app.request(PAIR_START_PATH, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        [OWNER_PAT_HEADER]: "clw_pat_owner_token",
+      },
+      body: JSON.stringify({
+        agentDid: RESPONDER_AGENT_DID,
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      expiresAt: string;
+      initiatorAgentDid: string;
+      pairingCode: string;
+      responderAgentDid: string;
+    };
+
+    expect(body.pairingCode.length).toBeGreaterThan(0);
+    expect(body.initiatorAgentDid).toBe(INITIATOR_AGENT_DID);
+    expect(body.responderAgentDid).toBe(RESPONDER_AGENT_DID);
+    expect(body.expiresAt).toBe("2023-11-14T22:18:20.000Z");
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const fetchCallUrl = String(fetchMock.mock.calls[0]?.[0] ?? "");
+    expect(fetchCallUrl).toContain("/v1/agents/");
+    expect(fetchCallUrl).toContain("/ownership");
+  });
+
+  it("returns 401 when owner PAT is invalid", async () => {
+    const fetchImpl = vi.fn(
+      async (_requestInput: unknown) => new Response(null, { status: 401 }),
+    ) as unknown as typeof fetch;
+    const { app } = createPairingApp({ fetchImpl });
+
+    const response = await app.request(PAIR_START_PATH, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        [OWNER_PAT_HEADER]: "clw_pat_invalid",
+      },
+      body: JSON.stringify({
+        agentDid: RESPONDER_AGENT_DID,
+      }),
+    });
+
+    expect(response.status).toBe(401);
+    const body = (await response.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("PROXY_PAIR_OWNER_PAT_INVALID");
+  });
+
+  it("returns 403 when owner PAT does not control caller DID", async () => {
+    const fetchImpl = vi.fn(async (_requestInput: unknown) =>
+      Response.json(
+        {
+          ownsAgent: false,
+        },
+        { status: 200 },
+      ),
+    ) as unknown as typeof fetch;
+    const { app } = createPairingApp({ fetchImpl });
+
+    const response = await app.request(PAIR_START_PATH, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        [OWNER_PAT_HEADER]: "clw_pat_owner",
+      },
+      body: JSON.stringify({
+        agentDid: RESPONDER_AGENT_DID,
+      }),
+    });
+
+    expect(response.status).toBe(403);
+    const body = (await response.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("PROXY_PAIR_OWNER_PAT_FORBIDDEN");
+  });
+});
+
+describe(`POST ${PAIR_CONFIRM_PATH}`, () => {
+  it("consumes pairing code and enables mutual trust", async () => {
+    const { app, trustStore } = createPairingApp({
+      nowMs: () => 1_700_000_000_000,
+    });
+
+    const pairingCode = await trustStore.createPairingCode({
+      initiatorAgentDid: INITIATOR_AGENT_DID,
+      responderAgentDid: RESPONDER_AGENT_DID,
+      ttlSeconds: 300,
+      nowMs: 1_700_000_000_000,
+    });
+
+    const response = await app.request(PAIR_CONFIRM_PATH, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-test-agent-did": RESPONDER_AGENT_DID,
+      },
+      body: JSON.stringify({
+        pairingCode: pairingCode.pairingCode,
+      }),
+    });
+
+    expect(response.status).toBe(201);
+    const body = (await response.json()) as {
+      initiatorAgentDid: string;
+      paired: boolean;
+      responderAgentDid: string;
+    };
+
+    expect(body).toEqual({
+      paired: true,
+      initiatorAgentDid: INITIATOR_AGENT_DID,
+      responderAgentDid: RESPONDER_AGENT_DID,
+    });
+
+    expect(
+      await trustStore.isPairAllowed({
+        initiatorAgentDid: INITIATOR_AGENT_DID,
+        responderAgentDid: RESPONDER_AGENT_DID,
+      }),
+    ).toBe(true);
+    expect(
+      await trustStore.isPairAllowed({
+        initiatorAgentDid: RESPONDER_AGENT_DID,
+        responderAgentDid: INITIATOR_AGENT_DID,
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects pair confirm when caller does not match target agent", async () => {
+    const { app, trustStore } = createPairingApp({
+      nowMs: () => 1_700_000_000_000,
+    });
+
+    const pairingCode = await trustStore.createPairingCode({
+      initiatorAgentDid: INITIATOR_AGENT_DID,
+      responderAgentDid: RESPONDER_AGENT_DID,
+      ttlSeconds: 300,
+      nowMs: 1_700_000_000_000,
+    });
+
+    const response = await app.request(PAIR_CONFIRM_PATH, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-test-agent-did": INTRUDER_AGENT_DID,
+      },
+      body: JSON.stringify({
+        pairingCode: pairingCode.pairingCode,
+      }),
+    });
+
+    expect(response.status).toBe(403);
+    const body = (await response.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("PROXY_PAIR_CODE_AGENT_MISMATCH");
+  });
+});

--- a/apps/proxy/src/pairing-route.ts
+++ b/apps/proxy/src/pairing-route.ts
@@ -1,0 +1,368 @@
+import { parseDid } from "@clawdentity/protocol";
+import { AppError, type Logger } from "@clawdentity/sdk";
+import type { Context } from "hono";
+import type { ProxyRequestVariables } from "./auth-middleware.js";
+import {
+  DEFAULT_PAIRING_CODE_TTL_SECONDS,
+  MAX_PAIRING_CODE_TTL_SECONDS,
+  OWNER_PAT_HEADER,
+  PAIR_CONFIRM_PATH,
+  PAIR_START_PATH,
+} from "./pairing-constants.js";
+import {
+  type ProxyTrustStore,
+  ProxyTrustStoreError,
+} from "./proxy-trust-store.js";
+
+const REGISTRY_AGENT_OWNERSHIP_PATH_PREFIX = "/v1/agents";
+
+export { OWNER_PAT_HEADER, PAIR_CONFIRM_PATH, PAIR_START_PATH };
+
+type PairingRouteContext = Context<{
+  Variables: ProxyRequestVariables;
+}>;
+
+export type PairStartRuntimeOptions = {
+  fetchImpl?: typeof fetch;
+  nowMs?: () => number;
+};
+
+type CreatePairStartHandlerOptions = PairStartRuntimeOptions & {
+  logger: Logger;
+  registryUrl: string;
+  trustStore: ProxyTrustStore;
+};
+
+export type PairConfirmRuntimeOptions = {
+  nowMs?: () => number;
+};
+
+type CreatePairConfirmHandlerOptions = PairConfirmRuntimeOptions & {
+  logger: Logger;
+  trustStore: ProxyTrustStore;
+};
+
+function parseOwnerPatHeader(headerValue: string | undefined): string {
+  if (typeof headerValue !== "string" || headerValue.trim().length === 0) {
+    throw new AppError({
+      code: "PROXY_PAIR_OWNER_PAT_REQUIRED",
+      message: "X-Claw-Owner-Pat header is required",
+      status: 401,
+      expose: true,
+    });
+  }
+
+  return headerValue.trim();
+}
+
+function normalizeRegistryUrl(registryUrl: string): string {
+  const baseUrl = registryUrl.endsWith("/") ? registryUrl : `${registryUrl}/`;
+  return new URL(baseUrl).toString();
+}
+
+function parseAgentDid(value: unknown, inputName: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new AppError({
+      code: "PROXY_PAIR_INVALID_BODY",
+      message: `${inputName} is required`,
+      status: 400,
+      expose: true,
+    });
+  }
+
+  const candidate = value.trim();
+  try {
+    const parsed = parseDid(candidate);
+    if (parsed.kind !== "agent") {
+      throw new Error("Invalid kind");
+    }
+  } catch {
+    throw new AppError({
+      code: "PROXY_PAIR_INVALID_BODY",
+      message: `${inputName} must be a valid agent DID`,
+      status: 400,
+      expose: true,
+    });
+  }
+
+  return candidate;
+}
+
+function parseTtlSeconds(value: unknown): number {
+  if (value === undefined) {
+    return DEFAULT_PAIRING_CODE_TTL_SECONDS;
+  }
+
+  if (typeof value !== "number" || !Number.isInteger(value)) {
+    throw new AppError({
+      code: "PROXY_PAIR_INVALID_BODY",
+      message: "ttlSeconds must be an integer",
+      status: 400,
+      expose: true,
+    });
+  }
+
+  if (value < 1 || value > MAX_PAIRING_CODE_TTL_SECONDS) {
+    throw new AppError({
+      code: "PROXY_PAIR_INVALID_BODY",
+      message: `ttlSeconds must be between 1 and ${MAX_PAIRING_CODE_TTL_SECONDS}`,
+      status: 400,
+      expose: true,
+    });
+  }
+
+  return value;
+}
+
+async function parseJsonBody(c: PairingRouteContext): Promise<unknown> {
+  try {
+    return await c.req.json();
+  } catch {
+    throw new AppError({
+      code: "PROXY_PAIR_INVALID_BODY",
+      message: "Request body must be valid JSON",
+      status: 400,
+      expose: true,
+    });
+  }
+}
+
+async function parseRegistryOwnershipResponse(response: Response): Promise<{
+  ownsAgent: boolean;
+}> {
+  const payload = (await response.json()) as {
+    ownsAgent?: unknown;
+  };
+  if (typeof payload.ownsAgent !== "boolean") {
+    throw new AppError({
+      code: "PROXY_PAIR_OWNER_PAT_UNAVAILABLE",
+      message: "Registry owner lookup payload is invalid",
+      status: 503,
+      expose: true,
+    });
+  }
+
+  return {
+    ownsAgent: payload.ownsAgent,
+  };
+}
+
+async function assertPatOwnsInitiatorAgent(input: {
+  fetchImpl: typeof fetch;
+  initiatorAgentDid: string;
+  ownerPat: string;
+  registryUrl: string;
+}): Promise<void> {
+  const parsedDid = parseDid(input.initiatorAgentDid);
+  const ownershipUrl = new URL(
+    `${REGISTRY_AGENT_OWNERSHIP_PATH_PREFIX}/${parsedDid.ulid}/ownership`,
+    input.registryUrl,
+  );
+
+  let response: Response;
+  try {
+    response = await input.fetchImpl(ownershipUrl, {
+      method: "GET",
+      headers: {
+        authorization: `Bearer ${input.ownerPat}`,
+      },
+    });
+  } catch {
+    throw new AppError({
+      code: "PROXY_PAIR_OWNER_PAT_UNAVAILABLE",
+      message: "Registry owner lookup is unavailable",
+      status: 503,
+      expose: true,
+    });
+  }
+
+  if (response.status === 401) {
+    throw new AppError({
+      code: "PROXY_PAIR_OWNER_PAT_INVALID",
+      message: "Owner PAT is invalid or expired",
+      status: 401,
+      expose: true,
+    });
+  }
+
+  if (!response.ok) {
+    throw new AppError({
+      code: "PROXY_PAIR_OWNER_PAT_UNAVAILABLE",
+      message: "Registry owner lookup is unavailable",
+      status: 503,
+      expose: true,
+    });
+  }
+
+  let parsed: Awaited<ReturnType<typeof parseRegistryOwnershipResponse>>;
+  try {
+    parsed = await parseRegistryOwnershipResponse(response);
+  } catch (error) {
+    if (error instanceof AppError) {
+      throw error;
+    }
+
+    throw new AppError({
+      code: "PROXY_PAIR_OWNER_PAT_UNAVAILABLE",
+      message: "Registry owner lookup payload is invalid",
+      status: 503,
+      expose: true,
+    });
+  }
+
+  if (parsed.ownsAgent) {
+    return;
+  }
+
+  throw new AppError({
+    code: "PROXY_PAIR_OWNER_PAT_FORBIDDEN",
+    message: "Owner PAT does not control caller agent DID",
+    status: 403,
+    expose: true,
+  });
+}
+
+function toPairingCodeAppError(error: unknown): AppError {
+  if (error instanceof ProxyTrustStoreError) {
+    return new AppError({
+      code: error.code,
+      message: error.message,
+      status: error.status,
+      expose: true,
+    });
+  }
+
+  return new AppError({
+    code: "PROXY_PAIR_STATE_UNAVAILABLE",
+    message: "Pairing state is unavailable",
+    status: 503,
+    expose: true,
+  });
+}
+
+export function createPairStartHandler(
+  options: CreatePairStartHandlerOptions,
+): (c: PairingRouteContext) => Promise<Response> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const nowMs = options.nowMs ?? Date.now;
+  const registryUrl = normalizeRegistryUrl(options.registryUrl);
+
+  return async (c) => {
+    const auth = c.get("auth");
+    if (auth === undefined) {
+      throw new AppError({
+        code: "PROXY_PAIR_AUTH_CONTEXT_MISSING",
+        message: "Verified auth context is required",
+        status: 500,
+      });
+    }
+
+    const body = (await parseJsonBody(c)) as {
+      agentDid?: unknown;
+      ttlSeconds?: unknown;
+    };
+
+    const responderAgentDid = parseAgentDid(body.agentDid, "agentDid");
+    if (responderAgentDid === auth.agentDid) {
+      throw new AppError({
+        code: "PROXY_PAIR_INVALID_BODY",
+        message: "agentDid must be different from caller agent DID",
+        status: 400,
+        expose: true,
+      });
+    }
+
+    const ttlSeconds = parseTtlSeconds(body.ttlSeconds);
+    const ownerPat = parseOwnerPatHeader(c.req.header(OWNER_PAT_HEADER));
+
+    await assertPatOwnsInitiatorAgent({
+      fetchImpl,
+      initiatorAgentDid: auth.agentDid,
+      ownerPat,
+      registryUrl,
+    });
+
+    const pairingCodeResult = await options.trustStore
+      .createPairingCode({
+        initiatorAgentDid: auth.agentDid,
+        responderAgentDid,
+        ttlSeconds,
+        nowMs: nowMs(),
+      })
+      .catch((error: unknown) => {
+        throw toPairingCodeAppError(error);
+      });
+
+    options.logger.info("proxy.pair.start", {
+      requestId: c.get("requestId"),
+      initiatorAgentDid: auth.agentDid,
+      responderAgentDid,
+      expiresAt: new Date(pairingCodeResult.expiresAtMs).toISOString(),
+    });
+
+    return c.json({
+      initiatorAgentDid: pairingCodeResult.initiatorAgentDid,
+      responderAgentDid: pairingCodeResult.responderAgentDid,
+      pairingCode: pairingCodeResult.pairingCode,
+      expiresAt: new Date(pairingCodeResult.expiresAtMs).toISOString(),
+    });
+  };
+}
+
+export function createPairConfirmHandler(
+  options: CreatePairConfirmHandlerOptions,
+): (c: PairingRouteContext) => Promise<Response> {
+  const nowMs = options.nowMs ?? Date.now;
+
+  return async (c) => {
+    const auth = c.get("auth");
+    if (auth === undefined) {
+      throw new AppError({
+        code: "PROXY_PAIR_AUTH_CONTEXT_MISSING",
+        message: "Verified auth context is required",
+        status: 500,
+      });
+    }
+
+    const body = (await parseJsonBody(c)) as {
+      pairingCode?: unknown;
+    };
+
+    if (
+      typeof body.pairingCode !== "string" ||
+      body.pairingCode.trim() === ""
+    ) {
+      throw new AppError({
+        code: "PROXY_PAIR_INVALID_BODY",
+        message: "pairingCode is required",
+        status: 400,
+        expose: true,
+      });
+    }
+
+    const consumedPairingCode = await options.trustStore
+      .confirmPairingCode({
+        pairingCode: body.pairingCode.trim(),
+        responderAgentDid: auth.agentDid,
+        nowMs: nowMs(),
+      })
+      .catch((error: unknown) => {
+        throw toPairingCodeAppError(error);
+      });
+
+    options.logger.info("proxy.pair.confirm", {
+      requestId: c.get("requestId"),
+      initiatorAgentDid: consumedPairingCode.initiatorAgentDid,
+      responderAgentDid: consumedPairingCode.responderAgentDid,
+    });
+
+    return c.json(
+      {
+        paired: true,
+        initiatorAgentDid: consumedPairingCode.initiatorAgentDid,
+        responderAgentDid: consumedPairingCode.responderAgentDid,
+      },
+      201,
+    );
+  };
+}

--- a/apps/proxy/src/proxy-trust-state.test.ts
+++ b/apps/proxy/src/proxy-trust-state.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, vi } from "vitest";
+import { ProxyTrustState } from "./proxy-trust-state.js";
+import { TRUST_STORE_ROUTES } from "./proxy-trust-store.js";
+
+function createStorageHarness(initial: Record<string, unknown> = {}) {
+  const values = new Map<string, unknown>(Object.entries(initial));
+
+  return {
+    values,
+    storage: {
+      get: vi.fn(async (key: string) => values.get(key)),
+      put: vi.fn(async (key: string, value: unknown) => {
+        values.set(key, value);
+      }),
+      setAlarm: vi.fn(async (_scheduled: number | Date) => {}),
+      deleteAlarm: vi.fn(async () => {}),
+    },
+  };
+}
+
+function createProxyTrustState(initialStorage?: Record<string, unknown>) {
+  const harness = createStorageHarness(initialStorage);
+  const state = {
+    storage: harness.storage,
+  };
+
+  return {
+    proxyTrustState: new ProxyTrustState(
+      state as unknown as DurableObjectState,
+    ),
+    harness,
+  };
+}
+
+function makeRequest(path: string, body: unknown): Request {
+  return new Request(`https://proxy-trust-state${path}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("ProxyTrustState", () => {
+  it("persists and answers known-agent checks via agent peer index", async () => {
+    const { proxyTrustState, harness } = createProxyTrustState();
+
+    const upsertResponse = await proxyTrustState.fetch(
+      makeRequest(TRUST_STORE_ROUTES.upsertPair, {
+        initiatorAgentDid: "did:claw:agent:alice",
+        responderAgentDid: "did:claw:agent:bob",
+      }),
+    );
+
+    expect(upsertResponse.status).toBe(200);
+
+    const knownAliceResponse = await proxyTrustState.fetch(
+      makeRequest(TRUST_STORE_ROUTES.isAgentKnown, {
+        agentDid: "did:claw:agent:alice",
+      }),
+    );
+    expect(knownAliceResponse.status).toBe(200);
+    expect((await knownAliceResponse.json()) as { known: boolean }).toEqual({
+      known: true,
+    });
+
+    expect(harness.values.has("trust:agent-peers")).toBe(true);
+  });
+
+  it("does not treat pairs as known agents without agent-peer index", async () => {
+    const { proxyTrustState, harness } = createProxyTrustState({
+      "trust:pairs": ["did:claw:agent:alice|did:claw:agent:bob"],
+    });
+
+    const knownResponse = await proxyTrustState.fetch(
+      makeRequest(TRUST_STORE_ROUTES.isAgentKnown, {
+        agentDid: "did:claw:agent:alice",
+      }),
+    );
+
+    expect(knownResponse.status).toBe(200);
+    expect((await knownResponse.json()) as { known: boolean }).toEqual({
+      known: false,
+    });
+
+    expect(harness.values.get("trust:agent-peers")).toBeUndefined();
+  });
+
+  it("confirms pairing code in one operation and persists trust", async () => {
+    const { proxyTrustState } = createProxyTrustState();
+    const codeResponse = await proxyTrustState.fetch(
+      makeRequest(TRUST_STORE_ROUTES.createPairingCode, {
+        initiatorAgentDid: "did:claw:agent:alice",
+        responderAgentDid: "did:claw:agent:bob",
+        ttlSeconds: 60,
+        nowMs: 1_700_000_000_000,
+      }),
+    );
+    const codeBody = (await codeResponse.json()) as { pairingCode: string };
+
+    const confirmResponse = await proxyTrustState.fetch(
+      makeRequest(TRUST_STORE_ROUTES.confirmPairingCode, {
+        pairingCode: codeBody.pairingCode,
+        responderAgentDid: "did:claw:agent:bob",
+        nowMs: 1_700_000_000_100,
+      }),
+    );
+
+    expect(confirmResponse.status).toBe(200);
+    expect(
+      (await confirmResponse.json()) as { initiatorAgentDid: string },
+    ).toEqual({
+      initiatorAgentDid: "did:claw:agent:alice",
+      responderAgentDid: "did:claw:agent:bob",
+    });
+
+    const pairCheckResponse = await proxyTrustState.fetch(
+      makeRequest(TRUST_STORE_ROUTES.isPairAllowed, {
+        initiatorAgentDid: "did:claw:agent:bob",
+        responderAgentDid: "did:claw:agent:alice",
+      }),
+    );
+    expect((await pairCheckResponse.json()) as { allowed: boolean }).toEqual({
+      allowed: true,
+    });
+  });
+});

--- a/apps/proxy/src/proxy-trust-state.ts
+++ b/apps/proxy/src/proxy-trust-state.ts
@@ -1,0 +1,438 @@
+import { generateUlid } from "@clawdentity/protocol";
+import {
+  type PairingCodeConsumeInput,
+  type PairingCodeInput,
+  TRUST_STORE_ROUTES,
+} from "./proxy-trust-store.js";
+
+type StoredPairingCode = {
+  expiresAtMs: number;
+  initiatorAgentDid: string;
+  responderAgentDid: string;
+};
+
+type PairingCodeMap = Record<string, StoredPairingCode>;
+type AgentPeersIndex = Record<string, string[]>;
+
+const PAIRS_STORAGE_KEY = "trust:pairs";
+const AGENT_PEERS_STORAGE_KEY = "trust:agent-peers";
+const PAIRING_CODES_STORAGE_KEY = "trust:pairing-codes";
+
+function toPairKey(
+  initiatorAgentDid: string,
+  responderAgentDid: string,
+): string {
+  return [initiatorAgentDid, responderAgentDid].sort().join("|");
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function addPeer(
+  index: AgentPeersIndex,
+  leftAgentDid: string,
+  rightAgentDid: string,
+): void {
+  const peers = new Set(index[leftAgentDid] ?? []);
+  peers.add(rightAgentDid);
+  index[leftAgentDid] = [...peers].sort();
+}
+
+function toErrorResponse(input: {
+  code: string;
+  message: string;
+  status: number;
+}): Response {
+  return Response.json(
+    {
+      error: {
+        code: input.code,
+        message: input.message,
+      },
+    },
+    { status: input.status },
+  );
+}
+
+async function parseBody(request: Request): Promise<unknown> {
+  try {
+    return await request.json();
+  } catch {
+    return undefined;
+  }
+}
+
+export class ProxyTrustState {
+  private readonly state: DurableObjectState;
+
+  constructor(state: DurableObjectState) {
+    this.state = state;
+  }
+
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+
+    if (request.method !== "POST") {
+      return new Response("Not found", { status: 404 });
+    }
+
+    if (url.pathname === TRUST_STORE_ROUTES.createPairingCode) {
+      return this.handleCreatePairingCode(request);
+    }
+
+    if (url.pathname === TRUST_STORE_ROUTES.consumePairingCode) {
+      return this.handleConsumePairingCode(request);
+    }
+
+    if (url.pathname === TRUST_STORE_ROUTES.confirmPairingCode) {
+      return this.handleConfirmPairingCode(request);
+    }
+
+    if (url.pathname === TRUST_STORE_ROUTES.upsertPair) {
+      return this.handleUpsertPair(request);
+    }
+
+    if (url.pathname === TRUST_STORE_ROUTES.isPairAllowed) {
+      return this.handleIsPairAllowed(request);
+    }
+
+    if (url.pathname === TRUST_STORE_ROUTES.isAgentKnown) {
+      return this.handleIsAgentKnown(request);
+    }
+
+    return new Response("Not found", { status: 404 });
+  }
+
+  async alarm(): Promise<void> {
+    const nowMs = Date.now();
+    const pairingCodes = await this.loadPairingCodes();
+
+    let mutated = false;
+    for (const [pairingCode, details] of Object.entries(pairingCodes)) {
+      if (details.expiresAtMs <= nowMs) {
+        delete pairingCodes[pairingCode];
+        mutated = true;
+      }
+    }
+
+    if (mutated) {
+      await this.savePairingCodes(pairingCodes);
+    }
+
+    await this.scheduleNextCodeCleanup(pairingCodes);
+  }
+
+  private async handleCreatePairingCode(request: Request): Promise<Response> {
+    const body = (await parseBody(request)) as
+      | Partial<PairingCodeInput>
+      | undefined;
+    if (
+      !body ||
+      !isNonEmptyString(body.initiatorAgentDid) ||
+      !isNonEmptyString(body.responderAgentDid) ||
+      typeof body.ttlSeconds !== "number" ||
+      !Number.isInteger(body.ttlSeconds) ||
+      body.ttlSeconds <= 0
+    ) {
+      return toErrorResponse({
+        code: "PROXY_PAIR_START_INVALID_BODY",
+        message: "Pairing code create input is invalid",
+        status: 400,
+      });
+    }
+
+    const nowMs = typeof body.nowMs === "number" ? body.nowMs : Date.now();
+    const pairingCode = generateUlid(nowMs);
+    const expiresAtMs = nowMs + body.ttlSeconds * 1000;
+
+    const pairingCodes = await this.loadPairingCodes();
+    pairingCodes[pairingCode] = {
+      initiatorAgentDid: body.initiatorAgentDid,
+      responderAgentDid: body.responderAgentDid,
+      expiresAtMs,
+    };
+
+    await this.savePairingCodes(pairingCodes);
+    await this.scheduleNextCodeCleanup(pairingCodes);
+
+    return Response.json({
+      pairingCode,
+      expiresAtMs,
+      initiatorAgentDid: body.initiatorAgentDid,
+      responderAgentDid: body.responderAgentDid,
+    });
+  }
+
+  private async handleConsumePairingCode(request: Request): Promise<Response> {
+    const body = (await parseBody(request)) as
+      | Partial<PairingCodeConsumeInput>
+      | undefined;
+    if (
+      !body ||
+      !isNonEmptyString(body.pairingCode) ||
+      !isNonEmptyString(body.responderAgentDid)
+    ) {
+      return toErrorResponse({
+        code: "PROXY_PAIR_CONFIRM_INVALID_BODY",
+        message: "Pairing code consume input is invalid",
+        status: 400,
+      });
+    }
+
+    const nowMs = typeof body.nowMs === "number" ? body.nowMs : Date.now();
+    const pairingCodes = await this.loadPairingCodes();
+    const stored = pairingCodes[body.pairingCode];
+
+    if (!stored) {
+      return toErrorResponse({
+        code: "PROXY_PAIR_CODE_NOT_FOUND",
+        message: "Pairing code not found",
+        status: 404,
+      });
+    }
+
+    if (stored.expiresAtMs <= nowMs) {
+      delete pairingCodes[body.pairingCode];
+      await this.savePairingCodes(pairingCodes);
+      await this.scheduleNextCodeCleanup(pairingCodes);
+      return toErrorResponse({
+        code: "PROXY_PAIR_CODE_EXPIRED",
+        message: "Pairing code has expired",
+        status: 410,
+      });
+    }
+
+    if (stored.responderAgentDid !== body.responderAgentDid) {
+      return toErrorResponse({
+        code: "PROXY_PAIR_CODE_AGENT_MISMATCH",
+        message: "Pairing code does not match caller agent DID",
+        status: 403,
+      });
+    }
+
+    delete pairingCodes[body.pairingCode];
+    await this.savePairingCodes(pairingCodes);
+    await this.scheduleNextCodeCleanup(pairingCodes);
+
+    return Response.json({
+      initiatorAgentDid: stored.initiatorAgentDid,
+      responderAgentDid: stored.responderAgentDid,
+    });
+  }
+
+  private async handleConfirmPairingCode(request: Request): Promise<Response> {
+    const body = (await parseBody(request)) as
+      | Partial<PairingCodeConsumeInput>
+      | undefined;
+    if (
+      !body ||
+      !isNonEmptyString(body.pairingCode) ||
+      !isNonEmptyString(body.responderAgentDid)
+    ) {
+      return toErrorResponse({
+        code: "PROXY_PAIR_CONFIRM_INVALID_BODY",
+        message: "Pairing code consume input is invalid",
+        status: 400,
+      });
+    }
+
+    const nowMs = typeof body.nowMs === "number" ? body.nowMs : Date.now();
+    const pairingCodes = await this.loadPairingCodes();
+    const stored = pairingCodes[body.pairingCode];
+
+    if (!stored) {
+      return toErrorResponse({
+        code: "PROXY_PAIR_CODE_NOT_FOUND",
+        message: "Pairing code not found",
+        status: 404,
+      });
+    }
+
+    if (stored.expiresAtMs <= nowMs) {
+      delete pairingCodes[body.pairingCode];
+      await this.savePairingCodes(pairingCodes);
+      await this.scheduleNextCodeCleanup(pairingCodes);
+      return toErrorResponse({
+        code: "PROXY_PAIR_CODE_EXPIRED",
+        message: "Pairing code has expired",
+        status: 410,
+      });
+    }
+
+    if (stored.responderAgentDid !== body.responderAgentDid) {
+      return toErrorResponse({
+        code: "PROXY_PAIR_CODE_AGENT_MISMATCH",
+        message: "Pairing code does not match caller agent DID",
+        status: 403,
+      });
+    }
+
+    const pairs = await this.loadPairs();
+    pairs.add(toPairKey(stored.initiatorAgentDid, stored.responderAgentDid));
+
+    const agentPeers = await this.loadAgentPeers();
+    addPeer(agentPeers, stored.initiatorAgentDid, stored.responderAgentDid);
+    addPeer(agentPeers, stored.responderAgentDid, stored.initiatorAgentDid);
+
+    await this.savePairs(pairs);
+    await this.saveAgentPeers(agentPeers);
+
+    delete pairingCodes[body.pairingCode];
+    await this.savePairingCodes(pairingCodes);
+    await this.scheduleNextCodeCleanup(pairingCodes);
+
+    return Response.json({
+      initiatorAgentDid: stored.initiatorAgentDid,
+      responderAgentDid: stored.responderAgentDid,
+    });
+  }
+
+  private async handleUpsertPair(request: Request): Promise<Response> {
+    const body = (await parseBody(request)) as
+      | { initiatorAgentDid?: unknown; responderAgentDid?: unknown }
+      | undefined;
+    if (
+      !body ||
+      !isNonEmptyString(body.initiatorAgentDid) ||
+      !isNonEmptyString(body.responderAgentDid)
+    ) {
+      return toErrorResponse({
+        code: "PROXY_PAIR_UPSERT_INVALID_BODY",
+        message: "Pair upsert input is invalid",
+        status: 400,
+      });
+    }
+
+    const pairs = await this.loadPairs();
+    pairs.add(toPairKey(body.initiatorAgentDid, body.responderAgentDid));
+    await this.savePairs(pairs);
+
+    const agentPeers = await this.loadAgentPeers();
+    addPeer(agentPeers, body.initiatorAgentDid, body.responderAgentDid);
+    addPeer(agentPeers, body.responderAgentDid, body.initiatorAgentDid);
+    await this.saveAgentPeers(agentPeers);
+
+    return Response.json({ ok: true });
+  }
+
+  private async handleIsPairAllowed(request: Request): Promise<Response> {
+    const body = (await parseBody(request)) as
+      | { initiatorAgentDid?: unknown; responderAgentDid?: unknown }
+      | undefined;
+    if (
+      !body ||
+      !isNonEmptyString(body.initiatorAgentDid) ||
+      !isNonEmptyString(body.responderAgentDid)
+    ) {
+      return toErrorResponse({
+        code: "PROXY_PAIR_CHECK_INVALID_BODY",
+        message: "Pair check input is invalid",
+        status: 400,
+      });
+    }
+
+    if (body.initiatorAgentDid === body.responderAgentDid) {
+      return Response.json({ allowed: true });
+    }
+
+    const pairs = await this.loadPairs();
+    return Response.json({
+      allowed: pairs.has(
+        toPairKey(body.initiatorAgentDid, body.responderAgentDid),
+      ),
+    });
+  }
+
+  private async handleIsAgentKnown(request: Request): Promise<Response> {
+    const body = (await parseBody(request)) as
+      | { agentDid?: unknown }
+      | undefined;
+    if (!body || !isNonEmptyString(body.agentDid)) {
+      return toErrorResponse({
+        code: "PROXY_AGENT_KNOWN_INVALID_BODY",
+        message: "Agent known check input is invalid",
+        status: 400,
+      });
+    }
+
+    const agentPeers = await this.loadAgentPeers();
+    if ((agentPeers[body.agentDid]?.length ?? 0) > 0) {
+      return Response.json({ known: true });
+    }
+
+    return Response.json({ known: false });
+  }
+
+  private async loadPairs(): Promise<Set<string>> {
+    const raw = await this.state.storage.get<string[]>(PAIRS_STORAGE_KEY);
+    if (!Array.isArray(raw)) {
+      return new Set<string>();
+    }
+
+    const normalized = raw.filter((value) => typeof value === "string");
+    return new Set(normalized);
+  }
+
+  private async savePairs(pairs: Set<string>): Promise<void> {
+    await this.state.storage.put(PAIRS_STORAGE_KEY, [...pairs].sort());
+  }
+
+  private async loadAgentPeers(): Promise<AgentPeersIndex> {
+    const raw = await this.state.storage.get<AgentPeersIndex>(
+      AGENT_PEERS_STORAGE_KEY,
+    );
+    if (typeof raw !== "object" || raw === null) {
+      return {};
+    }
+
+    const normalized: AgentPeersIndex = {};
+    for (const [agentDid, peers] of Object.entries(raw)) {
+      if (!Array.isArray(peers)) {
+        continue;
+      }
+
+      normalized[agentDid] = peers.filter((peer): peer is string =>
+        isNonEmptyString(peer),
+      );
+    }
+
+    return normalized;
+  }
+
+  private async saveAgentPeers(agentPeers: AgentPeersIndex): Promise<void> {
+    await this.state.storage.put(AGENT_PEERS_STORAGE_KEY, agentPeers);
+  }
+
+  private async loadPairingCodes(): Promise<PairingCodeMap> {
+    const raw = await this.state.storage.get<PairingCodeMap>(
+      PAIRING_CODES_STORAGE_KEY,
+    );
+
+    if (typeof raw !== "object" || raw === null) {
+      return {};
+    }
+
+    return raw;
+  }
+
+  private async savePairingCodes(pairingCodes: PairingCodeMap): Promise<void> {
+    await this.state.storage.put(PAIRING_CODES_STORAGE_KEY, pairingCodes);
+  }
+
+  private async scheduleNextCodeCleanup(
+    pairingCodes: PairingCodeMap,
+  ): Promise<void> {
+    const expiryValues = Object.values(pairingCodes).map(
+      (details) => details.expiresAtMs,
+    );
+
+    if (expiryValues.length === 0) {
+      await this.state.storage.deleteAlarm();
+      return;
+    }
+
+    const earliestExpiry = Math.min(...expiryValues);
+    await this.state.storage.setAlarm(earliestExpiry);
+  }
+}

--- a/apps/proxy/src/proxy-trust-store.test.ts
+++ b/apps/proxy/src/proxy-trust-store.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import { createInMemoryProxyTrustStore } from "./proxy-trust-store.js";
+
+describe("in-memory proxy trust store", () => {
+  it("allows same-agent sender and recipient without explicit pair entry", async () => {
+    const store = createInMemoryProxyTrustStore();
+    expect(
+      await store.isPairAllowed({
+        initiatorAgentDid: "did:claw:agent:alice",
+        responderAgentDid: "did:claw:agent:alice",
+      }),
+    ).toBe(true);
+  });
+
+  it("supports symmetric pair checks", async () => {
+    const store = createInMemoryProxyTrustStore();
+    await store.upsertPair({
+      initiatorAgentDid: "did:claw:agent:alice",
+      responderAgentDid: "did:claw:agent:bob",
+    });
+
+    expect(
+      await store.isPairAllowed({
+        initiatorAgentDid: "did:claw:agent:alice",
+        responderAgentDid: "did:claw:agent:bob",
+      }),
+    ).toBe(true);
+    expect(
+      await store.isPairAllowed({
+        initiatorAgentDid: "did:claw:agent:bob",
+        responderAgentDid: "did:claw:agent:alice",
+      }),
+    ).toBe(true);
+  });
+
+  it("tracks known agents through pair index updates", async () => {
+    const store = createInMemoryProxyTrustStore();
+    expect(await store.isAgentKnown("did:claw:agent:alice")).toBe(false);
+    expect(await store.isAgentKnown("did:claw:agent:bob")).toBe(false);
+
+    await store.upsertPair({
+      initiatorAgentDid: "did:claw:agent:alice",
+      responderAgentDid: "did:claw:agent:bob",
+    });
+
+    expect(await store.isAgentKnown("did:claw:agent:alice")).toBe(true);
+    expect(await store.isAgentKnown("did:claw:agent:bob")).toBe(true);
+    expect(await store.isAgentKnown("did:claw:agent:charlie")).toBe(false);
+  });
+
+  it("consumes one-time pairing codes", async () => {
+    const store = createInMemoryProxyTrustStore();
+    const code = await store.createPairingCode({
+      initiatorAgentDid: "did:claw:agent:alice",
+      responderAgentDid: "did:claw:agent:bob",
+      ttlSeconds: 60,
+      nowMs: 1_700_000_000_000,
+    });
+
+    const consumed = await store.consumePairingCode({
+      pairingCode: code.pairingCode,
+      responderAgentDid: "did:claw:agent:bob",
+      nowMs: 1_700_000_000_100,
+    });
+
+    expect(consumed).toEqual({
+      initiatorAgentDid: "did:claw:agent:alice",
+      responderAgentDid: "did:claw:agent:bob",
+    });
+
+    await expect(
+      store.consumePairingCode({
+        pairingCode: code.pairingCode,
+        responderAgentDid: "did:claw:agent:bob",
+        nowMs: 1_700_000_000_200,
+      }),
+    ).rejects.toMatchObject({
+      code: "PROXY_PAIR_CODE_NOT_FOUND",
+      status: 404,
+    });
+  });
+
+  it("confirms pairing code atomically and establishes trust", async () => {
+    const store = createInMemoryProxyTrustStore();
+    const code = await store.createPairingCode({
+      initiatorAgentDid: "did:claw:agent:alice",
+      responderAgentDid: "did:claw:agent:bob",
+      ttlSeconds: 60,
+      nowMs: 1_700_000_000_000,
+    });
+
+    const confirmed = await store.confirmPairingCode({
+      pairingCode: code.pairingCode,
+      responderAgentDid: "did:claw:agent:bob",
+      nowMs: 1_700_000_000_100,
+    });
+
+    expect(confirmed).toEqual({
+      initiatorAgentDid: "did:claw:agent:alice",
+      responderAgentDid: "did:claw:agent:bob",
+    });
+    expect(await store.isAgentKnown("did:claw:agent:alice")).toBe(true);
+    expect(await store.isAgentKnown("did:claw:agent:bob")).toBe(true);
+    expect(
+      await store.isPairAllowed({
+        initiatorAgentDid: "did:claw:agent:alice",
+        responderAgentDid: "did:claw:agent:bob",
+      }),
+    ).toBe(true);
+    expect(
+      await store.isPairAllowed({
+        initiatorAgentDid: "did:claw:agent:bob",
+        responderAgentDid: "did:claw:agent:alice",
+      }),
+    ).toBe(true);
+
+    await expect(
+      store.consumePairingCode({
+        pairingCode: code.pairingCode,
+        responderAgentDid: "did:claw:agent:bob",
+        nowMs: 1_700_000_000_200,
+      }),
+    ).rejects.toMatchObject({
+      code: "PROXY_PAIR_CODE_NOT_FOUND",
+      status: 404,
+    });
+  });
+});

--- a/apps/proxy/src/proxy-trust-store.ts
+++ b/apps/proxy/src/proxy-trust-store.ts
@@ -1,0 +1,336 @@
+import { generateUlid } from "@clawdentity/protocol";
+import { PROXY_TRUST_DO_NAME } from "./pairing-constants.js";
+
+export type PairingCodeInput = {
+  initiatorAgentDid: string;
+  responderAgentDid: string;
+  nowMs?: number;
+  ttlSeconds: number;
+};
+
+export type PairingCodeResult = {
+  pairingCode: string;
+  expiresAtMs: number;
+  initiatorAgentDid: string;
+  responderAgentDid: string;
+};
+
+export type PairingCodeConsumeInput = {
+  pairingCode: string;
+  responderAgentDid: string;
+  nowMs?: number;
+};
+
+export type PairingCodeConsumeResult = {
+  initiatorAgentDid: string;
+  responderAgentDid: string;
+};
+
+export type PairingInput = {
+  initiatorAgentDid: string;
+  responderAgentDid: string;
+};
+
+export interface ProxyTrustStore {
+  createPairingCode(input: PairingCodeInput): Promise<PairingCodeResult>;
+  consumePairingCode(
+    input: PairingCodeConsumeInput,
+  ): Promise<PairingCodeConsumeResult>;
+  confirmPairingCode(
+    input: PairingCodeConsumeInput,
+  ): Promise<PairingCodeConsumeResult>;
+  isAgentKnown(agentDid: string): Promise<boolean>;
+  isPairAllowed(input: PairingInput): Promise<boolean>;
+  upsertPair(input: PairingInput): Promise<void>;
+}
+
+export type ProxyTrustStateStub = {
+  fetch(request: Request): Promise<Response>;
+};
+
+export type ProxyTrustStateNamespace = {
+  get: (id: DurableObjectId) => ProxyTrustStateStub;
+  idFromName: (name: string) => DurableObjectId;
+};
+
+export class ProxyTrustStoreError extends Error {
+  readonly code: string;
+  readonly status: number;
+
+  constructor(input: { code: string; message: string; status: number }) {
+    super(input.message);
+    this.name = "ProxyTrustStoreError";
+    this.code = input.code;
+    this.status = input.status;
+  }
+}
+
+export const TRUST_STORE_ROUTES = {
+  createPairingCode: "/pairing-codes/create",
+  consumePairingCode: "/pairing-codes/consume",
+  confirmPairingCode: "/pairing-codes/confirm",
+  isAgentKnown: "/agents/known",
+  isPairAllowed: "/pairs/check",
+  upsertPair: "/pairs/upsert",
+} as const;
+
+function toPairKey(
+  initiatorAgentDid: string,
+  responderAgentDid: string,
+): string {
+  return [initiatorAgentDid, responderAgentDid].sort().join("|");
+}
+
+function parseErrorPayload(payload: unknown): {
+  code: string;
+  message: string;
+} {
+  if (typeof payload !== "object" || payload === null) {
+    return {
+      code: "PROXY_TRUST_STATE_ERROR",
+      message: "Trust state operation failed",
+    };
+  }
+
+  const error = (payload as { error?: unknown }).error;
+  if (typeof error !== "object" || error === null) {
+    return {
+      code: "PROXY_TRUST_STATE_ERROR",
+      message: "Trust state operation failed",
+    };
+  }
+
+  const code =
+    typeof (error as { code?: unknown }).code === "string"
+      ? (error as { code: string }).code
+      : "PROXY_TRUST_STATE_ERROR";
+  const message =
+    typeof (error as { message?: unknown }).message === "string"
+      ? (error as { message: string }).message
+      : "Trust state operation failed";
+
+  return { code, message };
+}
+
+async function parseJsonResponse(response: Response): Promise<unknown> {
+  try {
+    return await response.json();
+  } catch {
+    return undefined;
+  }
+}
+
+function createDurableObjectRequest(path: string, payload: unknown): Request {
+  return new Request(`https://proxy-trust-state${path}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  });
+}
+
+function resolveDurableStateStub(
+  namespace: ProxyTrustStateNamespace,
+): ProxyTrustStateStub {
+  return namespace.get(namespace.idFromName(PROXY_TRUST_DO_NAME));
+}
+
+async function callDurableState<T>(
+  namespace: ProxyTrustStateNamespace,
+  path: string,
+  payload: unknown,
+): Promise<T> {
+  const stub = resolveDurableStateStub(namespace);
+  const response = await stub.fetch(createDurableObjectRequest(path, payload));
+  if (!response.ok) {
+    const parsed = parseErrorPayload(await parseJsonResponse(response));
+    throw new ProxyTrustStoreError({
+      code: parsed.code,
+      message: parsed.message,
+      status: response.status,
+    });
+  }
+
+  return (await response.json()) as T;
+}
+
+export function createDurableProxyTrustStore(
+  namespace: ProxyTrustStateNamespace,
+): ProxyTrustStore {
+  return {
+    async createPairingCode(input) {
+      return callDurableState<PairingCodeResult>(
+        namespace,
+        TRUST_STORE_ROUTES.createPairingCode,
+        input,
+      );
+    },
+    async consumePairingCode(input) {
+      return callDurableState<PairingCodeConsumeResult>(
+        namespace,
+        TRUST_STORE_ROUTES.consumePairingCode,
+        input,
+      );
+    },
+    async confirmPairingCode(input) {
+      return callDurableState<PairingCodeConsumeResult>(
+        namespace,
+        TRUST_STORE_ROUTES.confirmPairingCode,
+        input,
+      );
+    },
+    async isAgentKnown(agentDid) {
+      const result = await callDurableState<{ known: boolean }>(
+        namespace,
+        TRUST_STORE_ROUTES.isAgentKnown,
+        { agentDid },
+      );
+      return result.known;
+    },
+    async isPairAllowed(input) {
+      const result = await callDurableState<{ allowed: boolean }>(
+        namespace,
+        TRUST_STORE_ROUTES.isPairAllowed,
+        input,
+      );
+      return result.allowed;
+    },
+    async upsertPair(input) {
+      await callDurableState<{ ok: true }>(
+        namespace,
+        TRUST_STORE_ROUTES.upsertPair,
+        input,
+      );
+    },
+  };
+}
+
+export function createInMemoryProxyTrustStore(): ProxyTrustStore {
+  const pairKeys = new Set<string>();
+  const agentPeers = new Map<string, Set<string>>();
+  const pairingCodes = new Map<
+    string,
+    {
+      expiresAtMs: number;
+      initiatorAgentDid: string;
+      responderAgentDid: string;
+    }
+  >();
+
+  function cleanup(nowMs: number): void {
+    for (const [pairingCode, details] of pairingCodes.entries()) {
+      if (details.expiresAtMs <= nowMs) {
+        pairingCodes.delete(pairingCode);
+      }
+    }
+  }
+
+  function upsertPeer(leftAgentDid: string, rightAgentDid: string): void {
+    const peers = agentPeers.get(leftAgentDid) ?? new Set<string>();
+    peers.add(rightAgentDid);
+    agentPeers.set(leftAgentDid, peers);
+  }
+
+  function resolveConsumablePairingCode(
+    input: PairingCodeConsumeInput,
+  ): PairingCodeConsumeResult {
+    const nowMs = input.nowMs ?? Date.now();
+    cleanup(nowMs);
+
+    const pairing = pairingCodes.get(input.pairingCode);
+    if (!pairing) {
+      throw new ProxyTrustStoreError({
+        code: "PROXY_PAIR_CODE_NOT_FOUND",
+        message: "Pairing code not found",
+        status: 404,
+      });
+    }
+
+    if (pairing.expiresAtMs <= nowMs) {
+      pairingCodes.delete(input.pairingCode);
+      throw new ProxyTrustStoreError({
+        code: "PROXY_PAIR_CODE_EXPIRED",
+        message: "Pairing code has expired",
+        status: 410,
+      });
+    }
+
+    if (pairing.responderAgentDid !== input.responderAgentDid) {
+      throw new ProxyTrustStoreError({
+        code: "PROXY_PAIR_CODE_AGENT_MISMATCH",
+        message: "Pairing code does not match caller agent DID",
+        status: 403,
+      });
+    }
+
+    return {
+      initiatorAgentDid: pairing.initiatorAgentDid,
+      responderAgentDid: pairing.responderAgentDid,
+    };
+  }
+
+  return {
+    async createPairingCode(input) {
+      const nowMs = input.nowMs ?? Date.now();
+      cleanup(nowMs);
+
+      const pairingCode = generateUlid(nowMs);
+      const expiresAtMs = nowMs + input.ttlSeconds * 1000;
+
+      pairingCodes.set(pairingCode, {
+        initiatorAgentDid: input.initiatorAgentDid,
+        responderAgentDid: input.responderAgentDid,
+        expiresAtMs,
+      });
+
+      return {
+        pairingCode,
+        expiresAtMs,
+        initiatorAgentDid: input.initiatorAgentDid,
+        responderAgentDid: input.responderAgentDid,
+      };
+    },
+    async consumePairingCode(input) {
+      const consumedPair = resolveConsumablePairingCode(input);
+      pairingCodes.delete(input.pairingCode);
+      return consumedPair;
+    },
+    async confirmPairingCode(input) {
+      const consumedPair = resolveConsumablePairingCode(input);
+      pairKeys.add(
+        toPairKey(
+          consumedPair.initiatorAgentDid,
+          consumedPair.responderAgentDid,
+        ),
+      );
+      upsertPeer(
+        consumedPair.initiatorAgentDid,
+        consumedPair.responderAgentDid,
+      );
+      upsertPeer(
+        consumedPair.responderAgentDid,
+        consumedPair.initiatorAgentDid,
+      );
+      pairingCodes.delete(input.pairingCode);
+      return consumedPair;
+    },
+    async isAgentKnown(agentDid) {
+      return (agentPeers.get(agentDid)?.size ?? 0) > 0;
+    },
+    async isPairAllowed(input) {
+      if (input.initiatorAgentDid === input.responderAgentDid) {
+        return true;
+      }
+
+      return pairKeys.has(
+        toPairKey(input.initiatorAgentDid, input.responderAgentDid),
+      );
+    },
+    async upsertPair(input) {
+      pairKeys.add(toPairKey(input.initiatorAgentDid, input.responderAgentDid));
+      upsertPeer(input.initiatorAgentDid, input.responderAgentDid);
+      upsertPeer(input.responderAgentDid, input.initiatorAgentDid);
+    },
+  };
+}

--- a/apps/proxy/src/server.ts
+++ b/apps/proxy/src/server.ts
@@ -21,6 +21,17 @@ import {
 } from "./auth-middleware.js";
 import type { ProxyConfig } from "./config.js";
 import { PROXY_VERSION } from "./index.js";
+import { PAIR_CONFIRM_PATH, PAIR_START_PATH } from "./pairing-constants.js";
+import {
+  createPairConfirmHandler,
+  createPairStartHandler,
+  type PairConfirmRuntimeOptions,
+  type PairStartRuntimeOptions,
+} from "./pairing-route.js";
+import {
+  createInMemoryProxyTrustStore,
+  type ProxyTrustStore,
+} from "./proxy-trust-store.js";
 import {
   createPublicRateLimitMiddleware,
   DEFAULT_PRE_AUTH_IP_RATE_LIMIT_REQUESTS_PER_MINUTE,
@@ -53,6 +64,11 @@ type CreateProxyAppOptions = {
   rateLimit?: ProxyRateLimitRuntimeOptions;
   hooks?: AgentHookRuntimeOptions;
   relay?: RelayConnectRuntimeOptions;
+  pairing?: {
+    confirm?: PairConfirmRuntimeOptions;
+    start?: PairStartRuntimeOptions;
+  };
+  trustStore?: ProxyTrustStore;
 };
 
 export type ProxyApp = Hono<{
@@ -68,6 +84,7 @@ function resolveLogger(logger?: Logger): Logger {
 
 export function createProxyApp(options: CreateProxyAppOptions): ProxyApp {
   const logger = resolveLogger(options.logger);
+  const trustStore = options.trustStore ?? createInMemoryProxyTrustStore();
   const app = new Hono<{
     Bindings: {
       AGENT_RELAY_SESSION?: AgentRelaySessionNamespace;
@@ -96,6 +113,7 @@ export function createProxyApp(options: CreateProxyAppOptions): ProxyApp {
     createProxyAuthMiddleware({
       config: options.config,
       logger,
+      trustStore,
       ...options.auth,
     }),
   );
@@ -121,7 +139,25 @@ export function createProxyApp(options: CreateProxyAppOptions): ProxyApp {
     createAgentHookHandler({
       logger,
       injectIdentityIntoMessage: options.config.injectIdentityIntoMessage,
+      trustStore,
       ...options.hooks,
+    }),
+  );
+  app.post(
+    PAIR_START_PATH,
+    createPairStartHandler({
+      logger,
+      registryUrl: options.config.registryUrl,
+      trustStore,
+      ...options.pairing?.start,
+    }),
+  );
+  app.post(
+    PAIR_CONFIRM_PATH,
+    createPairConfirmHandler({
+      logger,
+      trustStore,
+      ...options.pairing?.confirm,
     }),
   );
   app.get(

--- a/apps/proxy/src/trust-policy.ts
+++ b/apps/proxy/src/trust-policy.ts
@@ -1,0 +1,71 @@
+import { AppError } from "@clawdentity/sdk";
+import type { ProxyTrustStore } from "./proxy-trust-store.js";
+
+function toErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "unknown";
+}
+
+export async function assertKnownTrustedAgent(input: {
+  trustStore: ProxyTrustStore;
+  agentDid: string;
+}): Promise<void> {
+  let isKnownAgent = false;
+  try {
+    isKnownAgent = await input.trustStore.isAgentKnown(input.agentDid);
+  } catch (error) {
+    throw new AppError({
+      code: "PROXY_AUTH_DEPENDENCY_UNAVAILABLE",
+      message: "Proxy trust state is unavailable",
+      status: 503,
+      details: {
+        reason: toErrorMessage(error),
+      },
+      expose: true,
+    });
+  }
+
+  if (!isKnownAgent) {
+    throw new AppError({
+      code: "PROXY_AUTH_FORBIDDEN",
+      message: "Verified caller is not trusted",
+      status: 403,
+      details: {
+        agentDid: input.agentDid,
+      },
+      expose: true,
+    });
+  }
+}
+
+export async function assertTrustedPair(input: {
+  trustStore: ProxyTrustStore;
+  initiatorAgentDid: string;
+  responderAgentDid: string;
+}): Promise<void> {
+  let isPairAllowed = false;
+  try {
+    isPairAllowed = await input.trustStore.isPairAllowed({
+      initiatorAgentDid: input.initiatorAgentDid,
+      responderAgentDid: input.responderAgentDid,
+    });
+  } catch (error) {
+    throw new AppError({
+      code: "PROXY_PAIR_STATE_UNAVAILABLE",
+      message: "Pairing state is unavailable",
+      status: 503,
+      details: {
+        reason: toErrorMessage(error),
+      },
+      expose: true,
+    });
+  }
+
+  if (!isPairAllowed) {
+    throw new AppError({
+      code: "PROXY_AUTH_FORBIDDEN",
+      message: "Verified caller is not trusted for recipient",
+      status: 403,
+      expose: true,
+    });
+  }
+}

--- a/apps/proxy/src/worker.ts
+++ b/apps/proxy/src/worker.ts
@@ -9,6 +9,12 @@ import {
   parseProxyConfig,
 } from "./config.js";
 import { resolveProxyVersion } from "./index.js";
+import { ProxyTrustState } from "./proxy-trust-state.js";
+import {
+  createDurableProxyTrustStore,
+  createInMemoryProxyTrustStore,
+  type ProxyTrustStateNamespace,
+} from "./proxy-trust-store.js";
 import { createProxyApp, type ProxyApp } from "./server.js";
 
 export type ProxyWorkerBindings = {
@@ -16,14 +22,11 @@ export type ProxyWorkerBindings = {
   PORT?: string;
   OPENCLAW_BASE_URL?: string;
   OPENCLAW_HOOK_TOKEN?: string;
-  OPENCLAW_HOOKS_TOKEN?: string;
   AGENT_RELAY_SESSION?: AgentRelaySessionNamespace;
+  PROXY_TRUST_STATE?: ProxyTrustStateNamespace;
   REGISTRY_URL?: string;
   CLAWDENTITY_REGISTRY_URL?: string;
   ENVIRONMENT?: string;
-  ALLOW_LIST?: string;
-  ALLOWLIST_OWNERS?: string;
-  ALLOWLIST_AGENTS?: string;
   ALLOW_ALL_VERIFIED?: string;
   CRL_REFRESH_INTERVAL_MS?: string;
   CRL_MAX_AGE_MS?: string;
@@ -49,13 +52,11 @@ function toCacheKey(env: ProxyWorkerBindings): string {
   const keyParts = [
     env.OPENCLAW_BASE_URL,
     env.OPENCLAW_HOOK_TOKEN,
-    env.OPENCLAW_HOOKS_TOKEN,
+    env.PROXY_TRUST_STATE === undefined ? "no-trust-do" : "has-trust-do",
     env.REGISTRY_URL,
     env.CLAWDENTITY_REGISTRY_URL,
     env.ENVIRONMENT,
-    env.ALLOW_LIST,
-    env.ALLOWLIST_OWNERS,
-    env.ALLOWLIST_AGENTS,
+    env.ALLOW_ALL_VERIFIED,
     env.CRL_REFRESH_INTERVAL_MS,
     env.CRL_MAX_AGE_MS,
     env.CRL_STALE_BEHAVIOR,
@@ -79,6 +80,10 @@ function buildRuntime(env: ProxyWorkerBindings): CachedProxyRuntime {
   const app = createProxyApp({
     config,
     logger,
+    trustStore:
+      env.PROXY_TRUST_STATE !== undefined
+        ? createDurableProxyTrustStore(env.PROXY_TRUST_STATE)
+        : createInMemoryProxyTrustStore(),
     version: resolveProxyVersion(env),
   });
 
@@ -138,5 +143,5 @@ const worker = {
   },
 };
 
-export { AgentRelaySession };
+export { AgentRelaySession, ProxyTrustState };
 export default worker;

--- a/apps/proxy/vitest.config.ts
+++ b/apps/proxy/vitest.config.ts
@@ -1,6 +1,20 @@
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@clawdentity/protocol": fileURLToPath(
+        new URL("../../packages/protocol/src/index.ts", import.meta.url),
+      ),
+      "@clawdentity/sdk/testing": fileURLToPath(
+        new URL("../../packages/sdk/src/testing/index.ts", import.meta.url),
+      ),
+      "@clawdentity/sdk": fileURLToPath(
+        new URL("../../packages/sdk/src/index.ts", import.meta.url),
+      ),
+    },
+  },
   test: {
     globals: true,
   },

--- a/apps/proxy/wrangler.jsonc
+++ b/apps/proxy/wrangler.jsonc
@@ -9,6 +9,10 @@
       {
         "name": "AGENT_RELAY_SESSION",
         "class_name": "AgentRelaySession"
+      },
+      {
+        "name": "PROXY_TRUST_STATE",
+        "class_name": "ProxyTrustState"
       }
     ]
   },
@@ -16,6 +20,10 @@
     {
       "tag": "v1-agent-relay-session",
       "new_sqlite_classes": ["AgentRelaySession"]
+    },
+    {
+      "tag": "v2-proxy-trust-state",
+      "new_sqlite_classes": ["ProxyTrustState"]
     }
   ],
   "env": {
@@ -26,6 +34,10 @@
           {
             "name": "AGENT_RELAY_SESSION",
             "class_name": "AgentRelaySession"
+          },
+          {
+            "name": "PROXY_TRUST_STATE",
+            "class_name": "ProxyTrustState"
           }
         ]
       },
@@ -33,6 +45,10 @@
         {
           "tag": "v1-agent-relay-session",
           "new_sqlite_classes": ["AgentRelaySession"]
+        },
+        {
+          "tag": "v2-proxy-trust-state",
+          "new_sqlite_classes": ["ProxyTrustState"]
         }
       ],
       "vars": {
@@ -49,6 +65,10 @@
           {
             "name": "AGENT_RELAY_SESSION",
             "class_name": "AgentRelaySession"
+          },
+          {
+            "name": "PROXY_TRUST_STATE",
+            "class_name": "ProxyTrustState"
           }
         ]
       },
@@ -56,6 +76,10 @@
         {
           "tag": "v1-agent-relay-session",
           "new_sqlite_classes": ["AgentRelaySession"]
+        },
+        {
+          "tag": "v2-proxy-trust-state",
+          "new_sqlite_classes": ["ProxyTrustState"]
         }
       ],
       "vars": {
@@ -71,6 +95,10 @@
           {
             "name": "AGENT_RELAY_SESSION",
             "class_name": "AgentRelaySession"
+          },
+          {
+            "name": "PROXY_TRUST_STATE",
+            "class_name": "ProxyTrustState"
           }
         ]
       },
@@ -78,6 +106,10 @@
         {
           "tag": "v1-agent-relay-session",
           "new_sqlite_classes": ["AgentRelaySession"]
+        },
+        {
+          "tag": "v2-proxy-trust-state",
+          "new_sqlite_classes": ["ProxyTrustState"]
         }
       ],
       "vars": {

--- a/apps/registry/src/AGENTS.md
+++ b/apps/registry/src/AGENTS.md
@@ -64,6 +64,12 @@
 - Keep ordering deterministic (`id` descending) and compute `nextCursor` from the last item in the returned page.
 - Keep error detail exposure environment-aware via `shouldExposeVerboseErrors`: generic 400 message in `production`, detailed `fieldErrors` in `development`/`test`.
 
+## GET /v1/agents/:id/ownership Contract
+- Require PAT auth via `createApiKeyAuth`.
+- Validate `:id` as ULID and return `400 AGENT_OWNERSHIP_INVALID_PATH` for malformed IDs.
+- Return `{ ownsAgent: true }` when the caller owns the agent and `{ ownsAgent: false }` for foreign or missing IDs.
+- Keep this endpoint ownership-only; do not return agent metadata.
+
 ## POST /v1/invites Contract
 - Require PAT auth via `createApiKeyAuth`.
 - Enforce admin-only access with explicit `403 INVITE_CREATE_FORBIDDEN` for authenticated non-admin callers.

--- a/apps/registry/src/agent-ownership.ts
+++ b/apps/registry/src/agent-ownership.ts
@@ -1,0 +1,53 @@
+import { parseUlid } from "@clawdentity/protocol";
+import {
+  AppError,
+  type RegistryConfig,
+  shouldExposeVerboseErrors,
+} from "@clawdentity/sdk";
+
+function invalidOwnershipPath(options: {
+  environment: RegistryConfig["ENVIRONMENT"];
+  details?: {
+    fieldErrors: Record<string, string[]>;
+    formErrors: string[];
+  };
+}): AppError {
+  const exposeDetails = shouldExposeVerboseErrors(options.environment);
+  return new AppError({
+    code: "AGENT_OWNERSHIP_INVALID_PATH",
+    message: exposeDetails
+      ? "Agent ownership path is invalid"
+      : "Request could not be processed",
+    status: 400,
+    expose: exposeDetails,
+    details: exposeDetails ? options.details : undefined,
+  });
+}
+
+export function parseAgentOwnershipPath(input: {
+  id: string;
+  environment: RegistryConfig["ENVIRONMENT"];
+}): string {
+  const id = input.id.trim();
+  if (id.length === 0) {
+    throw invalidOwnershipPath({
+      environment: input.environment,
+      details: {
+        fieldErrors: { id: ["id is required"] },
+        formErrors: [],
+      },
+    });
+  }
+
+  try {
+    return parseUlid(id).value;
+  } catch {
+    throw invalidOwnershipPath({
+      environment: input.environment,
+      details: {
+        fieldErrors: { id: ["id must be a valid ULID"] },
+        formErrors: [],
+      },
+    });
+  }
+}

--- a/apps/registry/src/server.test.ts
+++ b/apps/registry/src/server.test.ts
@@ -3,7 +3,6 @@ import {
   AGENT_AUTH_REFRESH_PATH,
   AGENT_AUTH_VALIDATE_PATH,
   AGENT_REGISTRATION_CHALLENGE_PATH,
-  type AitClaims,
   canonicalizeAgentRegistrationProof,
   encodeBase64url,
   generateUlid,
@@ -23,6 +22,7 @@ import {
   verifyAIT,
   verifyCRL,
 } from "@clawdentity/sdk";
+import { buildTestAitClaims } from "@clawdentity/sdk/testing";
 import { describe, expect, it } from "vitest";
 import { DEFAULT_AGENT_LIST_LIMIT } from "./agent-list.js";
 import {
@@ -41,27 +41,18 @@ import {
 import { RESOLVE_RATE_LIMIT_MAX_REQUESTS } from "./rate-limit.js";
 import app, { createRegistryApp } from "./server.js";
 
-function makeAitClaims(publicKey: Uint8Array): AitClaims {
-  const now = Math.floor(Date.now() / 1000);
-  return {
-    iss: "https://registry.clawdentity.dev",
-    sub: makeAgentDid(generateUlid(1700100000000)),
-    ownerDid: makeHumanDid(generateUlid(1700100001000)),
+function makeAitClaims(publicKey: Uint8Array) {
+  return buildTestAitClaims({
+    publicKeyX: encodeBase64url(publicKey),
+    issuer: "https://registry.clawdentity.dev",
+    nowSeconds: Math.floor(Date.now() / 1000),
+    ttlSeconds: 3600,
+    nbfSkewSeconds: 5,
+    seedMs: 1_700_100_000_000,
     name: "agent-registry-01",
     framework: "openclaw",
     description: "registry key publishing verification path",
-    cnf: {
-      jwk: {
-        kty: "OKP",
-        crv: "Ed25519",
-        x: encodeBase64url(publicKey),
-      },
-    },
-    iat: now,
-    nbf: now - 5,
-    exp: now + 3600,
-    jti: generateUlid(1700100002000),
-  };
+  });
 }
 
 type FakeD1Row = {
@@ -4493,6 +4484,125 @@ describe("GET /v1/agents", () => {
     expect(body.error.code).toBe("AGENT_LIST_INVALID_QUERY");
     expect(body.error.message).toBe("Request could not be processed");
     expect(body.error.details).toBeUndefined();
+  });
+});
+
+describe("GET /v1/agents/:id/ownership", () => {
+  it("returns 401 when PAT is missing", async () => {
+    const agentId = generateUlid(1700100017000);
+    const res = await createRegistryApp().request(
+      `/v1/agents/${agentId}/ownership`,
+      {},
+      { DB: {} as D1Database, ENVIRONMENT: "test" },
+    );
+
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as {
+      error: { code: string };
+    };
+    expect(body.error.code).toBe("API_KEY_MISSING");
+  });
+
+  it("returns ownsAgent=true when caller owns the agent", async () => {
+    const { token, authRow } = await makeValidPatContext();
+    const ownedAgentId = generateUlid(1700100017100);
+    const { database } = createFakeDb(
+      [authRow],
+      [
+        {
+          id: ownedAgentId,
+          did: makeAgentDid(ownedAgentId),
+          ownerId: "human-1",
+          name: "owned-agent",
+          framework: "openclaw",
+          status: "active",
+          expiresAt: "2026-03-01T00:00:00.000Z",
+        },
+      ],
+    );
+
+    const res = await createRegistryApp().request(
+      `/v1/agents/${ownedAgentId}/ownership`,
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      },
+      { DB: database, ENVIRONMENT: "test" },
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ownsAgent: boolean };
+    expect(body).toEqual({ ownsAgent: true });
+  });
+
+  it("returns ownsAgent=false for non-owned or missing agent ids", async () => {
+    const { token, authRow } = await makeValidPatContext();
+    const foreignAgentId = generateUlid(1700100017200);
+    const missingAgentId = generateUlid(1700100017300);
+    const { database } = createFakeDb(
+      [authRow],
+      [
+        {
+          id: foreignAgentId,
+          did: makeAgentDid(foreignAgentId),
+          ownerId: "human-2",
+          name: "foreign-agent",
+          framework: "openclaw",
+          status: "active",
+          expiresAt: "2026-03-01T00:00:00.000Z",
+        },
+      ],
+    );
+
+    const foreignRes = await createRegistryApp().request(
+      `/v1/agents/${foreignAgentId}/ownership`,
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      },
+      { DB: database, ENVIRONMENT: "test" },
+    );
+    expect(foreignRes.status).toBe(200);
+    expect((await foreignRes.json()) as { ownsAgent: boolean }).toEqual({
+      ownsAgent: false,
+    });
+
+    const missingRes = await createRegistryApp().request(
+      `/v1/agents/${missingAgentId}/ownership`,
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      },
+      { DB: database, ENVIRONMENT: "test" },
+    );
+    expect(missingRes.status).toBe(200);
+    expect((await missingRes.json()) as { ownsAgent: boolean }).toEqual({
+      ownsAgent: false,
+    });
+  });
+
+  it("returns path validation errors for invalid ids", async () => {
+    const { token, authRow } = await makeValidPatContext();
+    const { database } = createFakeDb([authRow]);
+
+    const res = await createRegistryApp().request(
+      "/v1/agents/not-a-ulid/ownership",
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      },
+      { DB: database, ENVIRONMENT: "test" },
+    );
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as {
+      error: {
+        code: string;
+        message: string;
+        details?: { fieldErrors?: Record<string, unknown> };
+      };
+    };
+    expect(body.error.code).toBe("AGENT_OWNERSHIP_INVALID_PATH");
+    expect(body.error.message).toBe("Agent ownership path is invalid");
+    expect(body.error.details?.fieldErrors).toMatchObject({
+      id: expect.any(Array),
+    });
   });
 });
 

--- a/apps/registry/src/server.ts
+++ b/apps/registry/src/server.ts
@@ -33,6 +33,7 @@ import {
   toAgentAuthResponse,
 } from "./agent-auth-lifecycle.js";
 import { mapAgentListRow, parseAgentListQuery } from "./agent-list.js";
+import { parseAgentOwnershipPath } from "./agent-ownership.js";
 import {
   buildAgentRegistrationChallenge,
   buildAgentRegistrationFromParsed,
@@ -1319,6 +1320,28 @@ function createRegistryApp(options: CreateRegistryAppOptions = {}) {
         limit: query.limit,
         nextCursor,
       },
+    });
+  });
+
+  app.get("/v1/agents/:id/ownership", createApiKeyAuth(), async (c) => {
+    const config = getConfig(c.env);
+    const agentId = parseAgentOwnershipPath({
+      id: c.req.param("id"),
+      environment: config.ENVIRONMENT,
+    });
+    const human = c.get("human");
+    const db = createDb(c.env.DB);
+
+    const rows = await db
+      .select({
+        id: agents.id,
+      })
+      .from(agents)
+      .where(and(eq(agents.owner_id, human.id), eq(agents.id, agentId)))
+      .limit(1);
+
+    return c.json({
+      ownsAgent: rows.length > 0,
     });
   });
 

--- a/apps/registry/vitest.config.ts
+++ b/apps/registry/vitest.config.ts
@@ -7,6 +7,9 @@ export default defineConfig({
       "@clawdentity/protocol": fileURLToPath(
         new URL("../../packages/protocol/src/index.ts", import.meta.url),
       ),
+      "@clawdentity/sdk/testing": fileURLToPath(
+        new URL("../../packages/sdk/src/testing/index.ts", import.meta.url),
+      ),
       "@clawdentity/sdk": fileURLToPath(
         new URL("../../packages/sdk/src/index.ts", import.meta.url),
       ),

--- a/packages/sdk/AGENTS.md
+++ b/packages/sdk/AGENTS.md
@@ -17,6 +17,7 @@
 - `http/sign` + `http/verify`: PoP request signing and verification that binds method, path+query, timestamp, nonce, and body hash.
 - `security/nonce-cache`: in-memory TTL nonce replay protection keyed by `agentDid + nonce`.
 - `agent-auth-client`: shared agent auth refresh client + retry orchestration (`executeWithAgentAuthRefreshRetry`) for CLI/runtime integrations.
+- `testing/*`: shared deterministic test fixtures (e.g. AIT claims) for app/package tests.
 - Tests should prove tamper cases (payload change, header kid swap, signature corruption).
 
 ## Design Rules
@@ -45,6 +46,7 @@
 - Keep `agent-auth-client` runtime-portable (no Node-only filesystem APIs); delegate persistence/locking to callers.
 - Keep refresh retry policy strict: a single refresh attempt and a single request retry on retryable auth failures.
 - Keep per-agent refresh single-flight keyed by explicit caller-provided key to avoid duplicate refresh races.
+- Keep shared test fixtures in `src/testing/*` and consume via `@clawdentity/sdk/testing` to avoid copy/paste helpers across apps.
 
 ## Testing Rules
 - Unit test each shared module.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -9,6 +9,10 @@
     ".": {
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
+    },
+    "./testing": {
+      "import": "./dist/testing/index.js",
+      "types": "./dist/testing/index.d.ts"
     }
   },
   "scripts": {

--- a/packages/sdk/src/testing/ait-fixtures.test.ts
+++ b/packages/sdk/src/testing/ait-fixtures.test.ts
@@ -1,0 +1,44 @@
+import { parseDid, parseUlid } from "@clawdentity/protocol";
+import { describe, expect, it } from "vitest";
+import { buildTestAitClaims } from "./ait-fixtures.js";
+
+describe("buildTestAitClaims", () => {
+  it("builds deterministic claims from a fixed seed", () => {
+    const claims = buildTestAitClaims({
+      publicKeyX: "test-public-key-x",
+      seedMs: 1_700_000_000_000,
+      nowSeconds: 1_700_000_000,
+    });
+
+    expect(claims.iss).toBe("https://api.clawdentity.com");
+    expect(parseDid(claims.sub).kind).toBe("agent");
+    expect(parseDid(claims.ownerDid).kind).toBe("human");
+    expect(parseUlid(parseDid(claims.sub).ulid).timestampMs).toBe(
+      1_700_000_000_010,
+    );
+    expect(parseUlid(parseDid(claims.ownerDid).ulid).timestampMs).toBe(
+      1_700_000_000_020,
+    );
+    expect(parseUlid(claims.jti).timestampMs).toBe(1_700_000_000_030);
+    expect(claims.exp).toBe(1_700_000_600);
+  });
+
+  it("allows caller override fields", () => {
+    const claims = buildTestAitClaims({
+      publicKeyX: "test-public-key-x",
+      issuer: "https://registry.clawdentity.dev",
+      name: "registry-agent",
+      framework: "custom",
+      description: "fixture",
+      ttlSeconds: 60,
+      nowSeconds: 1_700_000_000,
+      seedMs: 1_700_100_000_000,
+    });
+
+    expect(claims.iss).toBe("https://registry.clawdentity.dev");
+    expect(claims.name).toBe("registry-agent");
+    expect(claims.framework).toBe("custom");
+    expect(claims.description).toBe("fixture");
+    expect(claims.exp).toBe(1_700_000_060);
+  });
+});

--- a/packages/sdk/src/testing/ait-fixtures.ts
+++ b/packages/sdk/src/testing/ait-fixtures.ts
@@ -1,0 +1,53 @@
+import {
+  type AitClaims,
+  generateUlid,
+  makeAgentDid,
+  makeHumanDid,
+} from "@clawdentity/protocol";
+
+export type BuildTestAitClaimsInput = {
+  publicKeyX: string;
+  issuer?: string;
+  nowSeconds?: number;
+  seedMs?: number;
+  ttlSeconds?: number;
+  nbfSkewSeconds?: number;
+  name?: string;
+  framework?: string;
+  description?: string;
+};
+
+const DEFAULT_SEED_MS = 1_700_000_000_000;
+const DEFAULT_ISSUER = "https://api.clawdentity.com";
+const DEFAULT_NAME = "Proxy Agent";
+const DEFAULT_FRAMEWORK = "openclaw";
+const DEFAULT_DESCRIPTION = "test agent";
+const DEFAULT_TTL_SECONDS = 600;
+
+export function buildTestAitClaims(input: BuildTestAitClaimsInput): AitClaims {
+  const seedMs = input.seedMs ?? DEFAULT_SEED_MS;
+  const nowSeconds =
+    input.nowSeconds ?? Math.floor((input.seedMs ?? Date.now()) / 1000);
+  const ttlSeconds = input.ttlSeconds ?? DEFAULT_TTL_SECONDS;
+  const nbfSkewSeconds = input.nbfSkewSeconds ?? 5;
+
+  return {
+    iss: input.issuer ?? DEFAULT_ISSUER,
+    sub: makeAgentDid(generateUlid(seedMs + 10)),
+    ownerDid: makeHumanDid(generateUlid(seedMs + 20)),
+    name: input.name ?? DEFAULT_NAME,
+    framework: input.framework ?? DEFAULT_FRAMEWORK,
+    description: input.description ?? DEFAULT_DESCRIPTION,
+    cnf: {
+      jwk: {
+        kty: "OKP",
+        crv: "Ed25519",
+        x: input.publicKeyX,
+      },
+    },
+    iat: nowSeconds,
+    nbf: nowSeconds - nbfSkewSeconds,
+    exp: nowSeconds + ttlSeconds,
+    jti: generateUlid(seedMs + 30),
+  };
+}

--- a/packages/sdk/src/testing/index.ts
+++ b/packages/sdk/src/testing/index.ts
@@ -1,0 +1,2 @@
+export type { BuildTestAitClaimsInput } from "./ait-fixtures.js";
+export { buildTestAitClaims } from "./ait-fixtures.js";

--- a/packages/sdk/tsup.config.ts
+++ b/packages/sdk/tsup.config.ts
@@ -1,7 +1,10 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: ["src/index.ts"],
+  entry: {
+    index: "src/index.ts",
+    "testing/index": "src/testing/index.ts",
+  },
   format: ["esm"],
   dts: true,
   clean: true,

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -17,7 +17,8 @@
     "paths": {
       "@clawdentity/connector": ["packages/connector/src/index.ts"],
       "@clawdentity/protocol": ["packages/protocol/src/index.ts"],
-      "@clawdentity/sdk": ["packages/sdk/src/index.ts"]
+      "@clawdentity/sdk": ["packages/sdk/src/index.ts"],
+      "@clawdentity/sdk/testing": ["packages/sdk/src/testing/index.ts"]
     }
   },
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Summary
- implement durable pairing trust store and pairing routes in proxy (`/pair/start`, `/pair/confirm`)
- remove static allowlist env dependency and enforce trust from pairing state
- add durable trust state DO wiring and wrangler env bindings/migrations
- enforce pairing-aware auth/trust checks for relay delivery
- update OpenClaw skill docs to current connector-based runtime, pairing prerequisite, and required CLI command utilization
- sync bundled OpenClaw skill docs in CLI package

## Validation
- pre-commit lint-staged checks
- pre-push affected checks (`lint`, `format`, `typecheck`, `test`)
- root lint (`pnpm lint`)

## Notes
- no backward compatibility path for removed static allowlist envs
- pairing bootstrap is currently API-based (`/pair/start`, `/pair/confirm`)
