### PR TITLE
ci(deploy): harden dev health URL resolution

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -50,7 +50,9 @@
   - `REGISTRY_INTERNAL_SERVICE_ID`
   - `REGISTRY_INTERNAL_SERVICE_SECRET`
 - Mirror to `CF_API_TOKEN` and `CF_ACCOUNT_ID` for tooling compatibility.
-- Optional deploy secret: `PROXY_HEALTH_URL` (only needed when dev proxy health endpoint is not `https://dev.proxy.clawdentity.com`; CI now falls back to that URL if workers.dev output is unavailable).
+- Optional deploy secrets:
+  - `REGISTRY_HEALTH_URL` (only needed when dev registry health endpoint is not `https://dev.registry.clawdentity.com`; CI falls back to that URL by default).
+  - `PROXY_HEALTH_URL` (only needed when dev proxy health endpoint is not `https://dev.proxy.clawdentity.com`; CI now falls back to that URL if workers.dev output is unavailable).
 - Required publish secret: `NPM_TOKEN`.
 - Keep Cloudflare token scope minimal for current workflows:
   - `Workers Scripts:Edit`

--- a/.github/workflows/deploy-develop.yml
+++ b/.github/workflows/deploy-develop.yml
@@ -22,6 +22,7 @@ jobs:
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       CF_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       APP_VERSION: ${{ github.sha }}
+      REGISTRY_HEALTH_URL_OVERRIDE: ${{ secrets.REGISTRY_HEALTH_URL }}
       PROXY_HEALTH_URL_OVERRIDE: ${{ secrets.PROXY_HEALTH_URL }}
       REGISTRY_INTERNAL_SERVICE_ID: ${{ secrets.REGISTRY_INTERNAL_SERVICE_ID }}
       REGISTRY_INTERNAL_SERVICE_SECRET: ${{ secrets.REGISTRY_INTERNAL_SERVICE_SECRET }}
@@ -114,7 +115,10 @@ jobs:
           python3 - <<'PY'
           import json, os, sys, time, urllib.request, urllib.error
 
-          url = "https://dev.registry.clawdentity.com/health"
+          configured_url = os.environ.get("REGISTRY_HEALTH_URL_OVERRIDE", "").strip()
+          if configured_url and not configured_url.endswith("/health"):
+              configured_url = f"{configured_url.rstrip('/')}/health"
+          url = configured_url or "https://dev.registry.clawdentity.com/health"
           expected_version = os.environ.get("APP_VERSION", "")
           if not expected_version:
               raise SystemExit("APP_VERSION was not set in workflow environment")


### PR DESCRIPTION
## Summary
- keep deploy workflow deterministic when wrangler output has no workers.dev URL
- add deterministic fallback health URLs for both proxy and registry dev environments
- keep optional secret overrides for non-standard health endpoints

## Changes
- proxy deploy health URL resolution now falls back to `https://dev.proxy.clawdentity.com/health`
- registry health verification now supports `REGISTRY_HEALTH_URL` override and otherwise falls back to `https://dev.registry.clawdentity.com/health`
- docs update in `.github/AGENTS.md` for both optional health URL override secrets

## Why
The previous run failed after successful proxy deploy because no workers.dev URL was emitted and no override secret was set. This makes health checks robust for custom-domain-only deployments.
