### PR TITLE
fix(pair): route confirm to issuer and persist peer proxy origin

### DIFF
--- a/apps/cli/src/commands/AGENTS.md
+++ b/apps/cli/src/commands/AGENTS.md
@@ -116,9 +116,11 @@
 - `pair start --qr` must generate a one-time local PNG QR containing the returned ticket and print the filesystem path.
 - `pair start --qr` must sweep expired QR artifacts in `~/.clawdentity/pairing` before writing a new file.
 - `pair confirm <agentName>` must call proxy `/pair/confirm` with `Authorization: Claw <AIT>` and signed PoP headers from local agent `secret.key`.
+- `pair confirm <agentName>` must send `/pair/confirm` to the proxy origin embedded in the pairing ticket issuer (`iss`), not the local resolved proxy URL.
 - `pair confirm` must accept either `--qr-file <path>` (primary) or `--ticket <clwpair1_...>` (fallback), never both.
 - `pair confirm --qr-file` must delete the consumed QR file after successful confirm (best effort, non-fatal on cleanup failure).
 - `pair status <agentName> --ticket <clwpair1_...>` must poll `/pair/status` and persist peers locally when status transitions to `confirmed`.
+- Pair profile payloads/responses may include `proxyOrigin`; persistence must prefer the peer's `proxyOrigin` (when present) and only fall back to ticket issuer origin.
 - After peer persistence, pair flows must best-effort sync OpenClaw transform peer snapshot (`hooks/transforms/clawdentity-peers.json`) when `~/.clawdentity/openclaw-relay.json` provides `relayTransformPeersPath`, so relay delivery works without manual file copying.
 - `pair start --wait` should use `/pair/status` polling and auto-save the responder peer locally so reverse pairing is not required.
 - `pair` commands must resolve proxy URL automatically from CLI config/registry metadata, with `CLAWDENTITY_PROXY_URL` env override support.

--- a/apps/cli/src/commands/pair.test.ts
+++ b/apps/cli/src/commands/pair.test.ts
@@ -304,46 +304,72 @@ describe("pair command helpers", () => {
     });
   });
 
-  it("fails confirm when ticket issuer does not match configured proxy URL", async () => {
+  it("routes confirm to ticket issuer proxy when local proxy origin differs", async () => {
     const fixture = await createPairFixture();
     const ticket = `clwpair1_${Buffer.from(
       JSON.stringify({ iss: "https://alpha.proxy.example" }),
     ).toString("base64url")}`;
+    const fetchImpl = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url.endsWith("/v1/metadata")) {
+        return Response.json(
+          {
+            status: "ok",
+            proxyUrl: "https://beta.proxy.example",
+          },
+          { status: 200 },
+        );
+      }
 
-    await expect(
-      confirmPairing(
-        "beta",
+      expect(url).toBe("https://alpha.proxy.example/pair/confirm");
+      const requestBody = JSON.parse(String(init?.body ?? "{}")) as {
+        responderProfile?: { proxyOrigin?: string };
+      };
+      expect(requestBody.responderProfile?.proxyOrigin).toBe(
+        "https://beta.proxy.example",
+      );
+
+      return Response.json(
         {
-          ticket,
+          paired: true,
+          initiatorAgentDid: "did:claw:agent:01HAAA11111111111111111111",
+          initiatorProfile: INITIATOR_PROFILE,
+          responderAgentDid: "did:claw:agent:01HBBB22222222222222222222",
+          responderProfile: RESPONDER_PROFILE,
         },
-        {
-          fetchImpl: (async (url: string) => {
-            if (url.endsWith("/v1/metadata")) {
-              return Response.json(
-                {
-                  status: "ok",
-                  proxyUrl: "https://beta.proxy.example",
-                },
-                { status: 200 },
-              );
-            }
-            return Response.json({}, { status: 200 });
-          }) as unknown as typeof fetch,
-          nowSecondsImpl: () => 1_700_000_000,
-          nonceFactoryImpl: () => "nonce-confirm",
-          readFileImpl: createReadFileMock(
-            fixture,
-          ) as unknown as typeof import("node:fs/promises").readFile,
-          resolveConfigImpl: async () => ({
-            registryUrl: "https://registry.clawdentity.com/",
-            humanName: RESPONDER_PROFILE.humanName,
-          }),
-          getConfigDirImpl: () => "/tmp/.clawdentity",
-        },
-      ),
-    ).rejects.toMatchObject({
-      code: "CLI_PAIR_TICKET_ISSUER_MISMATCH",
+        { status: 201 },
+      );
     });
+
+    const result = await confirmPairing(
+      "beta",
+      {
+        ticket,
+      },
+      {
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        nowSecondsImpl: () => 1_700_000_000,
+        nonceFactoryImpl: () => "nonce-confirm",
+        readFileImpl: createReadFileMock(
+          fixture,
+        ) as unknown as typeof import("node:fs/promises").readFile,
+        writeFileImpl: vi.fn(
+          async () => undefined,
+        ) as unknown as typeof import("node:fs/promises").writeFile,
+        mkdirImpl: vi.fn(
+          async () => undefined,
+        ) as unknown as typeof import("node:fs/promises").mkdir,
+        chmodImpl: vi.fn(
+          async () => undefined,
+        ) as unknown as typeof import("node:fs/promises").chmod,
+        resolveConfigImpl: async () => ({
+          registryUrl: "https://registry.clawdentity.com/",
+          humanName: RESPONDER_PROFILE.humanName,
+        }),
+        getConfigDirImpl: () => "/tmp/.clawdentity",
+      },
+    );
+
+    expect(result.proxyUrl).toBe("https://alpha.proxy.example/");
   });
 
   it("normalizes wrapped tickets before pair status request", async () => {
@@ -646,7 +672,13 @@ describe("pair command helpers", () => {
 
   it("polls pair status until confirmed and persists peer for initiator", async () => {
     const fixture = await createPairFixture();
-    const writeFileImpl = vi.fn(async () => undefined);
+    const writeFileImpl = vi.fn(
+      async (
+        _filePath: string,
+        _data: string | Uint8Array,
+        _encoding?: BufferEncoding,
+      ) => undefined,
+    );
     const mkdirImpl = vi.fn(async () => undefined);
     const chmodImpl = vi.fn(async () => undefined);
     const sleepImpl = vi.fn(async () => undefined);
@@ -665,7 +697,10 @@ describe("pair command helpers", () => {
         initiatorAgentDid: "did:claw:agent:01HAAA11111111111111111111",
         initiatorProfile: INITIATOR_PROFILE,
         responderAgentDid: "did:claw:agent:01HBBB22222222222222222222",
-        responderProfile: RESPONDER_PROFILE,
+        responderProfile: {
+          ...RESPONDER_PROFILE,
+          proxyOrigin: "https://beta.proxy.example",
+        },
         expiresAt: "2026-02-18T00:00:00.000Z",
         confirmedAt: "2026-02-18T00:00:05.000Z",
       },
@@ -724,6 +759,18 @@ describe("pair command helpers", () => {
     expect(writeFileImpl).toHaveBeenCalledTimes(1);
     expect(mkdirImpl).toHaveBeenCalledTimes(1);
     expect(chmodImpl).toHaveBeenCalledTimes(1);
+    const peerWriteCall = writeFileImpl.mock.calls[0];
+    const persistedPeers = JSON.parse(String(peerWriteCall?.[1] ?? "{}")) as {
+      peers: {
+        [key: string]: {
+          did: string;
+          proxyUrl: string;
+        };
+      };
+    };
+    expect(persistedPeers.peers["peer-22222222"]?.proxyUrl).toBe(
+      "https://beta.proxy.example/hooks/agent",
+    );
   });
 });
 

--- a/apps/cli/src/commands/pair.ts
+++ b/apps/cli/src/commands/pair.ts
@@ -143,6 +143,7 @@ type LocalAgentProofMaterial = {
 type PeerProfile = {
   agentName: string;
   humanName: string;
+  proxyOrigin?: string;
 };
 
 const isRecord = (value: unknown): value is Record<string, unknown> => {
@@ -213,10 +214,26 @@ function parsePeerProfile(payload: unknown): PeerProfile {
     );
   }
 
-  return {
+  const profile: PeerProfile = {
     agentName: parseProfileName(payload.agentName, "agentName"),
     humanName: parseProfileName(payload.humanName, "humanName"),
   };
+
+  const proxyOrigin = parseNonEmptyString(payload.proxyOrigin);
+  if (proxyOrigin.length > 0) {
+    let parsedProxyOrigin: string;
+    try {
+      parsedProxyOrigin = new URL(parseProxyUrl(proxyOrigin)).origin;
+    } catch {
+      throw createCliError(
+        "CLI_PAIR_PROFILE_INVALID",
+        "proxyOrigin is invalid for pairing",
+      );
+    }
+    profile.proxyOrigin = parsedProxyOrigin;
+  }
+
+  return profile;
 }
 
 function parsePairingTicket(value: unknown): string {
@@ -697,6 +714,7 @@ function parsePositiveIntegerOption(input: {
 function resolveLocalPairProfile(input: {
   config: CliConfig;
   agentName: string;
+  proxyUrl?: string;
 }): PeerProfile {
   const humanName = parseNonEmptyString(input.config.humanName);
   if (humanName.length === 0) {
@@ -706,10 +724,91 @@ function resolveLocalPairProfile(input: {
     );
   }
 
-  return {
+  const profile: PeerProfile = {
     agentName: parseProfileName(input.agentName, "agentName"),
     humanName: parseProfileName(humanName, "humanName"),
   };
+  const proxyUrl = parseNonEmptyString(input.proxyUrl);
+  if (proxyUrl.length > 0) {
+    profile.proxyOrigin = new URL(parseProxyUrl(proxyUrl)).origin;
+  }
+  return profile;
+}
+
+function normalizeProxyOrigin(candidate: string): string {
+  return new URL(parseProxyUrl(candidate)).origin;
+}
+
+function resolvePeerProxyUrl(input: {
+  ticket: string;
+  peerProfile: PeerProfile;
+  peerProxyOrigin?: string;
+}): string {
+  const configuredPeerOrigin = parseNonEmptyString(input.peerProxyOrigin);
+  const profilePeerOrigin = parseNonEmptyString(input.peerProfile.proxyOrigin);
+  const fallbackPeerOrigin = parsePairingTicketIssuerOrigin(input.ticket);
+  const peerOrigin =
+    configuredPeerOrigin.length > 0
+      ? configuredPeerOrigin
+      : profilePeerOrigin.length > 0
+        ? profilePeerOrigin
+        : fallbackPeerOrigin;
+
+  return new URL(
+    "/hooks/agent",
+    `${normalizeProxyOrigin(peerOrigin)}/`,
+  ).toString();
+}
+
+function toIssuerProxyUrl(ticket: string): string {
+  return parseProxyUrl(parsePairingTicketIssuerOrigin(ticket));
+}
+
+function toIssuerProxyRequestUrl(ticket: string, path: string): string {
+  return toProxyRequestUrl(toIssuerProxyUrl(ticket), path);
+}
+
+function toPeerProxyOriginFromStatus(input: {
+  callerAgentDid: string;
+  initiatorAgentDid: string;
+  responderAgentDid: string;
+  initiatorProfile: PeerProfile;
+  responderProfile?: PeerProfile;
+}): string | undefined {
+  if (input.callerAgentDid === input.initiatorAgentDid) {
+    return input.responderProfile?.proxyOrigin;
+  }
+
+  if (input.callerAgentDid === input.responderAgentDid) {
+    return input.initiatorProfile.proxyOrigin;
+  }
+
+  return undefined;
+}
+
+function toPeerProxyOriginFromConfirm(input: {
+  ticket: string;
+  initiatorProfile: PeerProfile;
+}): string {
+  const initiatorOrigin = parseNonEmptyString(
+    input.initiatorProfile.proxyOrigin,
+  );
+  if (initiatorOrigin.length > 0) {
+    return initiatorOrigin;
+  }
+  return parsePairingTicketIssuerOrigin(input.ticket);
+}
+
+function toResponderProfile(input: {
+  config: CliConfig;
+  agentName: string;
+  localProxyUrl: string;
+}): PeerProfile {
+  return resolveLocalPairProfile({
+    config: input.config,
+    agentName: input.agentName,
+    proxyUrl: input.localProxyUrl,
+  });
 }
 
 function parseProxyUrl(candidate: string): string {
@@ -1337,6 +1436,7 @@ async function persistPairedPeer(input: {
   ticket: string;
   peerDid: string;
   peerProfile: PeerProfile;
+  peerProxyOrigin?: string;
   dependencies: PairRequestOptions;
 }): Promise<string> {
   const getConfigDirImpl = input.dependencies.getConfigDirImpl ?? getConfigDir;
@@ -1345,8 +1445,11 @@ async function persistPairedPeer(input: {
   const writeFileImpl = input.dependencies.writeFileImpl ?? writeFile;
   const chmodImpl = input.dependencies.chmodImpl ?? chmod;
 
-  const issuerOrigin = parsePairingTicketIssuerOrigin(input.ticket);
-  const peerProxyUrl = new URL("/hooks/agent", `${issuerOrigin}/`).toString();
+  const peerProxyUrl = resolvePeerProxyUrl({
+    ticket: input.ticket,
+    peerProfile: input.peerProfile,
+    peerProxyOrigin: input.peerProxyOrigin,
+  });
   const peersConfig = await loadPeersConfig({
     getConfigDirImpl,
     readFileImpl,
@@ -1403,6 +1506,7 @@ export async function startPairing(
   const initiatorProfile = resolveLocalPairProfile({
     config,
     agentName: normalizedAgentName,
+    proxyUrl,
   });
 
   const { ait, secretKey } = await readAgentProofMaterial(
@@ -1486,16 +1590,17 @@ export async function confirmPairing(
   const qrDecodeImpl = dependencies.qrDecodeImpl ?? decodeTicketFromPng;
   const config = await resolveConfigImpl();
   const normalizedAgentName = assertValidAgentName(agentName);
-  const responderProfile = resolveLocalPairProfile({
-    config,
-    agentName: normalizedAgentName,
-  });
-
-  const ticketSource = resolveConfirmTicketSource(options);
-  const proxyUrl = await resolveProxyUrl({
+  const localProxyUrl = await resolveProxyUrl({
     config,
     fetchImpl,
   });
+  const responderProfile = toResponderProfile({
+    config,
+    agentName: normalizedAgentName,
+    localProxyUrl,
+  });
+
+  const ticketSource = resolveConfirmTicketSource(options);
 
   let ticket = ticketSource.ticket;
   if (ticketSource.source === "qr-file") {
@@ -1524,18 +1629,14 @@ export async function confirmPairing(
     ticket = parsePairingTicket(qrDecodeImpl(new Uint8Array(imageBytes)));
   }
   ticket = parsePairingTicket(ticket);
-  assertTicketIssuerMatchesProxy({
-    ticket,
-    proxyUrl,
-    context: "confirm",
-  });
+  const proxyUrl = toIssuerProxyUrl(ticket);
 
   const { ait, secretKey } = await readAgentProofMaterial(
     normalizedAgentName,
     dependencies,
   );
 
-  const requestUrl = toProxyRequestUrl(proxyUrl, PAIR_CONFIRM_PATH);
+  const requestUrl = toIssuerProxyRequestUrl(ticket, PAIR_CONFIRM_PATH);
   const requestBody = JSON.stringify({
     ticket,
     responderProfile,
@@ -1577,10 +1678,15 @@ export async function confirmPairing(
   }
 
   const parsed = parsePairConfirmResponse(responseBody);
+  const peerProxyOrigin = toPeerProxyOriginFromConfirm({
+    ticket,
+    initiatorProfile: parsed.initiatorProfile,
+  });
   const peerAlias = await persistPairedPeer({
     ticket,
     peerDid: parsed.initiatorAgentDid,
     peerProfile: parsed.initiatorProfile,
+    peerProxyOrigin,
     dependencies,
   });
 
@@ -1714,6 +1820,13 @@ async function getPairingStatusOnce(
       ticket,
       peerDid,
       peerProfile,
+      peerProxyOrigin: toPeerProxyOriginFromStatus({
+        callerAgentDid,
+        initiatorAgentDid: parsed.initiatorAgentDid,
+        responderAgentDid,
+        initiatorProfile: parsed.initiatorProfile,
+        responderProfile: parsed.responderProfile,
+      }),
       dependencies,
     });
   }

--- a/apps/proxy/src/AGENTS.md
+++ b/apps/proxy/src/AGENTS.md
@@ -49,6 +49,7 @@
 - Keep pairing profile contract strict:
   - `/pair/start` requires `initiatorProfile.{agentName,humanName}`
   - `/pair/confirm` requires `responderProfile.{agentName,humanName}`
+  - `/pair/start` and `/pair/confirm` may include optional `*.proxyOrigin` values; when present they must be valid `http(s)` URL origins and must be preserved in `/pair/status` responses.
   - `/pair/status` returns stored profile fields for initiator and responder
 - Keep pairing tickets issuer-authenticated via local signature in `/pair/start`; `/pair/confirm` must consume only locally stored tickets in single-proxy mode.
 - Keep ticket parsing tolerant for operator copy/paste paths: normalize surrounding markdown/backticks and whitespace before parse + trust-store lookup in both in-memory and Durable Object backends.

--- a/apps/proxy/src/pairing-route.test.ts
+++ b/apps/proxy/src/pairing-route.test.ts
@@ -17,6 +17,10 @@ const RESPONDER_PROFILE = {
   agentName: "beta",
   humanName: "Ira",
 };
+const RESPONDER_PROFILE_WITH_PROXY_ORIGIN = {
+  ...RESPONDER_PROFILE,
+  proxyOrigin: "https://beta.proxy.example",
+};
 
 vi.mock("./auth-middleware.js", async () => {
   const { createMiddleware } = await import("hono/factory");
@@ -291,7 +295,7 @@ describe(`POST ${PAIR_CONFIRM_PATH}`, () => {
       },
       body: JSON.stringify({
         ticket: ticket.ticket,
-        responderProfile: RESPONDER_PROFILE,
+        responderProfile: RESPONDER_PROFILE_WITH_PROXY_ORIGIN,
       }),
     });
 
@@ -315,7 +319,7 @@ describe(`POST ${PAIR_CONFIRM_PATH}`, () => {
       initiatorAgentDid: INITIATOR_AGENT_DID,
       initiatorProfile: INITIATOR_PROFILE,
       responderAgentDid: RESPONDER_AGENT_DID,
-      responderProfile: RESPONDER_PROFILE,
+      responderProfile: RESPONDER_PROFILE_WITH_PROXY_ORIGIN,
     });
 
     expect(
@@ -401,7 +405,7 @@ describe(`POST ${PAIR_STATUS_PATH}`, () => {
     await trustStore.confirmPairingTicket({
       ticket: ticket.ticket,
       responderAgentDid: RESPONDER_AGENT_DID,
-      responderProfile: RESPONDER_PROFILE,
+      responderProfile: RESPONDER_PROFILE_WITH_PROXY_ORIGIN,
       nowMs: 1_700_000_000_200,
     });
 
@@ -436,7 +440,7 @@ describe(`POST ${PAIR_STATUS_PATH}`, () => {
       initiatorAgentDid: INITIATOR_AGENT_DID,
       initiatorProfile: INITIATOR_PROFILE,
       responderAgentDid: RESPONDER_AGENT_DID,
-      responderProfile: RESPONDER_PROFILE,
+      responderProfile: RESPONDER_PROFILE_WITH_PROXY_ORIGIN,
       expiresAt: "2023-11-14T22:28:20.000Z",
       confirmedAt: "2023-11-14T22:13:20.000Z",
     });

--- a/apps/proxy/src/pairing-route.ts
+++ b/apps/proxy/src/pairing-route.ts
@@ -184,11 +184,52 @@ function parsePeerProfile(value: unknown, label: string): PeerProfile {
     });
   }
 
-  const payload = value as { agentName?: unknown; humanName?: unknown };
-  return {
+  const payload = value as {
+    agentName?: unknown;
+    humanName?: unknown;
+    proxyOrigin?: unknown;
+  };
+  const profile: PeerProfile = {
     agentName: parseProfileName(payload.agentName, `${label}.agentName`),
     humanName: parseProfileName(payload.humanName, `${label}.humanName`),
   };
+
+  if (payload.proxyOrigin !== undefined) {
+    if (typeof payload.proxyOrigin !== "string") {
+      throw new AppError({
+        code: "PROXY_PAIR_INVALID_BODY",
+        message: `${label}.proxyOrigin must be a valid URL origin`,
+        status: 400,
+        expose: true,
+      });
+    }
+
+    let parsedProxyOrigin: URL;
+    try {
+      parsedProxyOrigin = new URL(payload.proxyOrigin.trim());
+    } catch {
+      throw new AppError({
+        code: "PROXY_PAIR_INVALID_BODY",
+        message: `${label}.proxyOrigin must be a valid URL origin`,
+        status: 400,
+        expose: true,
+      });
+    }
+    if (
+      parsedProxyOrigin.protocol !== "https:" &&
+      parsedProxyOrigin.protocol !== "http:"
+    ) {
+      throw new AppError({
+        code: "PROXY_PAIR_INVALID_BODY",
+        message: `${label}.proxyOrigin must be a valid URL origin`,
+        status: 400,
+        expose: true,
+      });
+    }
+    profile.proxyOrigin = parsedProxyOrigin.origin;
+  }
+
+  return profile;
 }
 
 async function parseJsonBody(c: PairingRouteContext): Promise<unknown> {

--- a/apps/proxy/src/proxy-trust-state.test.ts
+++ b/apps/proxy/src/proxy-trust-state.test.ts
@@ -16,6 +16,10 @@ const RESPONDER_PROFILE = {
   agentName: "beta",
   humanName: "Ira",
 };
+const RESPONDER_PROFILE_WITH_PROXY_ORIGIN = {
+  ...RESPONDER_PROFILE,
+  proxyOrigin: "https://beta.proxy.example",
+};
 
 function tamperTicketNonce(ticket: string): string {
   const prefix = "clwpair1_";
@@ -143,7 +147,7 @@ describe("ProxyTrustState", () => {
       makeRequest(TRUST_STORE_ROUTES.confirmPairingTicket, {
         ticket: ticketBody.ticket,
         responderAgentDid: "did:claw:agent:bob",
-        responderProfile: RESPONDER_PROFILE,
+        responderProfile: RESPONDER_PROFILE_WITH_PROXY_ORIGIN,
         nowMs: 1_700_000_000_100,
       }),
     );
@@ -159,7 +163,7 @@ describe("ProxyTrustState", () => {
       initiatorAgentDid: "did:claw:agent:alice",
       initiatorProfile: INITIATOR_PROFILE,
       responderAgentDid: "did:claw:agent:bob",
-      responderProfile: RESPONDER_PROFILE,
+      responderProfile: RESPONDER_PROFILE_WITH_PROXY_ORIGIN,
       issuerProxyUrl: "https://proxy-a.example.com",
     });
 
@@ -192,7 +196,7 @@ describe("ProxyTrustState", () => {
       initiatorAgentDid: "did:claw:agent:alice",
       initiatorProfile: INITIATOR_PROFILE,
       responderAgentDid: "did:claw:agent:bob",
-      responderProfile: RESPONDER_PROFILE,
+      responderProfile: RESPONDER_PROFILE_WITH_PROXY_ORIGIN,
       expiresAtMs: 1_700_000_060_000,
       confirmedAtMs: 1_700_000_000_000,
     });

--- a/apps/proxy/src/proxy-trust-state.ts
+++ b/apps/proxy/src/proxy-trust-state.ts
@@ -53,7 +53,11 @@ function parsePeerProfile(value: unknown): PeerProfile | undefined {
     return undefined;
   }
 
-  const entry = value as { agentName?: unknown; humanName?: unknown };
+  const entry = value as {
+    agentName?: unknown;
+    humanName?: unknown;
+    proxyOrigin?: unknown;
+  };
   if (
     !isNonEmptyString(entry.agentName) ||
     !isNonEmptyString(entry.humanName)
@@ -61,10 +65,31 @@ function parsePeerProfile(value: unknown): PeerProfile | undefined {
     return undefined;
   }
 
-  return {
+  const profile: PeerProfile = {
     agentName: entry.agentName.trim(),
     humanName: entry.humanName.trim(),
   };
+  if (entry.proxyOrigin !== undefined) {
+    if (!isNonEmptyString(entry.proxyOrigin)) {
+      return undefined;
+    }
+
+    let parsedProxyOrigin: URL;
+    try {
+      parsedProxyOrigin = new URL(entry.proxyOrigin.trim());
+    } catch {
+      return undefined;
+    }
+    if (
+      parsedProxyOrigin.protocol !== "https:" &&
+      parsedProxyOrigin.protocol !== "http:"
+    ) {
+      return undefined;
+    }
+    profile.proxyOrigin = parsedProxyOrigin.origin;
+  }
+
+  return profile;
 }
 
 function addPeer(

--- a/apps/proxy/src/proxy-trust-store.ts
+++ b/apps/proxy/src/proxy-trust-store.ts
@@ -67,6 +67,7 @@ export type PairingTicketStatusResult =
 export type PeerProfile = {
   agentName: string;
   humanName: string;
+  proxyOrigin?: string;
 };
 
 export type PairingInput = {


### PR DESCRIPTION
## Summary
- route pair confirm requests to the ticket issuer proxy origin (iss) instead of the local resolved proxy URL
- persist peer proxy URLs from proxyOrigin when available, with ticket-issuer fallback
- propagate optional proxyOrigin through proxy pairing route/trust state profile handling so /pair/status returns responder origin when provided
- add CLI and proxy tests to cover issuer-routed confirm and responder-origin peer persistence
- update CLI/proxy AGENTS pairing rules to document issuer routing and proxyOrigin handling

## Validation
- pnpm lint
- pnpm -r typecheck
- pnpm -r test
- pnpm -r build

## Notes
- push-time hooks also ran affected checks successfully (nx affected -t lint,format,typecheck,test).
