### PR TITLE
ci(rust): automate versioned crates publish and binary release

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -5,7 +5,7 @@
 
 ## Rust Binary Release Rules
 - `release-rust-binaries.yml` is the canonical workflow for Rust CLI binary releases.
-- Keep this workflow manual-only (`workflow_dispatch`) unless maintainers explicitly decide otherwise.
+- Keep this workflow operator-invokable via `workflow_dispatch`; it may also be called by `publish-rust.yml` through `workflow_call`.
 - Validate release tag input format strictly as `rust/vX.Y.Z`; fail fast on invalid or missing tags.
 - Build and publish these platform targets in every release:
   - `x86_64-unknown-linux-gnu`
@@ -26,7 +26,20 @@
 - Always generate and publish SHA256 checksums.
 - Keep release uploads idempotent (`overwrite_files` / clobber-safe behavior) so reruns replace assets cleanly.
 
+## Rust Crate Publish Rules
+- `publish-rust.yml` is the canonical workflow for automated crates.io publishes.
+- Resolve next version from crates.io and bump both crate manifests consistently:
+  - `crates/clawdentity-core/Cargo.toml`
+  - `crates/clawdentity-cli/Cargo.toml`
+- Keep `clawdentity-cli` dependency on `clawdentity-core` version-locked to the same release version before publish.
+- Publish order is strict:
+  - first `clawdentity-core`
+  - then `clawdentity-cli`
+- Tag contract remains strict: `rust/vX.Y.Z`.
+- After crate publish and tag creation, invoke `release-rust-binaries.yml` for the same tag so crates and binaries stay aligned.
+
 ## Separation of Concerns
 - Keep `.github/workflows/ci.yml` focused on validation gates.
 - Keep `.github/workflows/publish-cli.yml` focused on npm package publishing.
-- Do not couple Rust binary release workflow with npm publish workflow.
+- Keep `.github/workflows/publish-rust.yml` focused on Cargo version/publish orchestration.
+- Do not couple Rust release workflows with npm publish workflow.

--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -1,0 +1,246 @@
+name: Publish Rust
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: "Semantic version bump type"
+        required: true
+        default: "patch"
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+      draft:
+        description: "Create GitHub release as draft"
+        required: false
+        default: false
+        type: boolean
+      prerelease:
+        description: "Mark GitHub release as prerelease"
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: publish-rust-release
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  prepare:
+    name: Resolve next Rust version
+    runs-on: ubuntu-latest
+    outputs:
+      current_version: ${{ steps.version.outputs.current_version }}
+      next_version: ${{ steps.version.outputs.next_version }}
+      tag: ${{ steps.version.outputs.tag }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate required secrets
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          test -n "${CARGO_REGISTRY_TOKEN}"
+
+      - name: Resolve current and next crate version
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          RELEASE_TYPE="${{ inputs.release_type }}"
+          STATUS_CODE="$(curl -sS -o /tmp/core-crate.json -w '%{http_code}' https://crates.io/api/v1/crates/clawdentity-core)"
+          if [[ "${STATUS_CODE}" == "200" ]]; then
+            CURRENT_VERSION="$(jq -r '.crate.max_version // empty' /tmp/core-crate.json)"
+          elif [[ "${STATUS_CODE}" == "404" ]]; then
+            CURRENT_VERSION="0.0.0"
+          else
+            echo "Failed to resolve current version from crates.io (status: ${STATUS_CODE})"
+            cat /tmp/core-crate.json
+            exit 1
+          fi
+
+          if [[ ! "${CURRENT_VERSION}" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+            echo "Unable to parse crates.io semver: ${CURRENT_VERSION}"
+            exit 1
+          fi
+
+          MAJOR="${BASH_REMATCH[1]}"
+          MINOR="${BASH_REMATCH[2]}"
+          PATCH="${BASH_REMATCH[3]}"
+
+          case "${RELEASE_TYPE}" in
+            major)
+              MAJOR=$((MAJOR + 1))
+              MINOR=0
+              PATCH=0
+              ;;
+            minor)
+              MINOR=$((MINOR + 1))
+              PATCH=0
+              ;;
+            patch)
+              PATCH=$((PATCH + 1))
+              ;;
+            *)
+              echo "Unsupported release_type: ${RELEASE_TYPE}"
+              exit 1
+              ;;
+          esac
+
+          NEXT_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+          TAG="rust/v${NEXT_VERSION}"
+
+          git fetch --tags --force origin
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+            echo "Tag already exists: ${TAG}"
+            exit 1
+          fi
+
+          echo "current_version=${CURRENT_VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "next_version=${NEXT_VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "tag=${TAG}" >> "${GITHUB_OUTPUT}"
+          echo "Resolved Rust release: ${CURRENT_VERSION} -> ${NEXT_VERSION} (${RELEASE_TYPE})"
+
+      - name: Assert target versions are unpublished
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          NEXT_VERSION="${{ steps.version.outputs.next_version }}"
+
+          for CRATE in clawdentity-core clawdentity-cli; do
+            STATUS_CODE="$(curl -s -o /dev/null -w '%{http_code}' "https://crates.io/api/v1/crates/${CRATE}/${NEXT_VERSION}")"
+            if [[ "${STATUS_CODE}" == "200" ]]; then
+              echo "${CRATE} ${NEXT_VERSION} already exists on crates.io"
+              exit 1
+            fi
+            if [[ "${STATUS_CODE}" != "404" ]]; then
+              echo "Unexpected crates.io status for ${CRATE} ${NEXT_VERSION}: ${STATUS_CODE}"
+              exit 1
+            fi
+          done
+
+  publish:
+    name: Publish Rust crates
+    needs: prepare
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ needs.prepare.outputs.tag }}
+      next_version: ${{ needs.prepare.outputs.next_version }}
+    env:
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate branch context
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.ref_type }}" != "branch" ]]; then
+            echo "Publish workflow must run from a branch ref. Current ref: ${{ github.ref }}"
+            exit 1
+          fi
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Update Cargo versions
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          NEXT_VERSION="${{ needs.prepare.outputs.next_version }}"
+
+          sed -i '0,/^version = "[0-9]\+\.[0-9]\+\.[0-9]\+"/s//version = "'"${NEXT_VERSION}"'"/' crates/clawdentity-core/Cargo.toml
+          sed -i '0,/^version = "[0-9]\+\.[0-9]\+\.[0-9]\+"/s//version = "'"${NEXT_VERSION}"'"/' crates/clawdentity-cli/Cargo.toml
+          sed -i 's|^clawdentity-core = { version = "[0-9]\+\.[0-9]\+\.[0-9]\+", path = "../clawdentity-core" }|clawdentity-core = { version = "'"${NEXT_VERSION}"'", path = "../clawdentity-core" }|' crates/clawdentity-cli/Cargo.toml
+
+          grep -n '^version = "' crates/clawdentity-core/Cargo.toml | head -n 1
+          grep -n '^version = "' crates/clawdentity-cli/Cargo.toml | head -n 1
+          grep -n '^clawdentity-core = { version = "' crates/clawdentity-cli/Cargo.toml
+
+      - name: Cargo check
+        working-directory: crates
+        run: cargo check -p clawdentity-core -p clawdentity-cli
+
+      - name: Commit release version and create tag
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          NEXT_VERSION="${{ needs.prepare.outputs.next_version }}"
+          TAG="${{ needs.prepare.outputs.tag }}"
+
+          git add crates/clawdentity-core/Cargo.toml crates/clawdentity-cli/Cargo.toml
+          if git diff --cached --quiet; then
+            echo "No manifest changes to commit."
+            exit 1
+          fi
+
+          git commit -m "chore(rust): release v${NEXT_VERSION}"
+          git tag -a "${TAG}" -m "Rust release ${TAG}"
+
+      - name: Push commit and tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          git push origin "HEAD:${{ github.ref_name }}"
+          git push origin "refs/tags/${{ needs.prepare.outputs.tag }}"
+
+      - name: Publish clawdentity-core
+        working-directory: crates
+        run: cargo publish -p clawdentity-core --locked
+
+      - name: Wait for clawdentity-core index propagation
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          VERSION="${{ needs.prepare.outputs.next_version }}"
+          ATTEMPTS=40
+          SLEEP_SECONDS=10
+
+          for ((i = 1; i <= ATTEMPTS; i++)); do
+            STATUS_CODE="$(curl -s -o /dev/null -w '%{http_code}' "https://crates.io/api/v1/crates/clawdentity-core/${VERSION}")"
+            if [[ "${STATUS_CODE}" == "200" ]]; then
+              echo "clawdentity-core ${VERSION} is available on crates.io"
+              exit 0
+            fi
+
+            echo "Waiting for clawdentity-core ${VERSION} propagation (${i}/${ATTEMPTS})"
+            sleep "${SLEEP_SECONDS}"
+          done
+
+          echo "Timed out waiting for clawdentity-core ${VERSION} on crates.io"
+          exit 1
+
+      - name: Publish clawdentity-cli
+        working-directory: crates
+        run: cargo publish -p clawdentity-cli --locked
+
+  release-binaries:
+    name: Publish Rust binaries
+    needs: publish
+    uses: ./.github/workflows/release-rust-binaries.yml
+    with:
+      tag: ${{ needs.publish.outputs.tag }}
+      draft: ${{ inputs.draft }}
+      prerelease: ${{ inputs.prerelease }}
+    secrets: inherit

--- a/.github/workflows/release-rust-binaries.yml
+++ b/.github/workflows/release-rust-binaries.yml
@@ -17,6 +17,22 @@ on:
         required: false
         default: false
         type: boolean
+  workflow_call:
+    inputs:
+      tag:
+        description: "Git tag to release (format: rust/vX.Y.Z)"
+        required: true
+        type: string
+      draft:
+        description: "Create as draft release"
+        required: false
+        default: false
+        type: boolean
+      prerelease:
+        description: "Mark release as prerelease"
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: release-rust-binaries-${{ inputs.tag }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,8 +81,12 @@ Use `docs/` as system of record:
 - Keep docs synchronized with implementation changes, especially when changing CLI flows or skill behavior.
 
 ## 7) Release Automation
-- Keep Rust binary release automation in `.github/workflows/release-rust-binaries.yml` manual-only (`workflow_dispatch`) so maintainers control release timing.
+- Keep Rust binary release automation in `.github/workflows/release-rust-binaries.yml` available for direct manual runs and workflow reuse by Rust publish automation.
+- Keep Rust crate publish automation in `.github/workflows/publish-rust.yml` as the canonical path for version bump + crates.io publish + tag creation.
 - Rust binary release tag input must stay strict: `rust/vX.Y.Z`.
+- Rust crate publish flow must derive next version from crates.io and keep `clawdentity-core` / `clawdentity-cli` versions aligned.
+- Rust crate publish order is strict: publish `clawdentity-core` before `clawdentity-cli`.
+- Rust crate publish must invoke binary release for the same `rust/vX.Y.Z` tag.
 - Rust binary releases must publish cross-platform assets for Windows x64, Linux x64/aarch64, and macOS x64/aarch64.
 - Keep release asset names stable:
   - `clawdentity-<version>-linux-x86_64.tar.gz`


### PR DESCRIPTION
## Summary\n- automate crates publish workflow versioning for Rust packages\n- align binary release workflow with crate version automation\n- include release pipeline guardrails and docs updates\n\n## Validation\n- pnpm lint\n- pnpm -r typecheck\n- pnpm -r test\n- pnpm -r build