### PR TITLE
Promote Rust CLI 0.1.7 to production

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -297,7 +297,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "clawdentity-cli"
-version = "0.1.2"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "clawdentity-core"
-version = "0.1.2"
+version = "0.1.6"
 dependencies = [
  "axum",
  "base64",
@@ -883,7 +883,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -1613,7 +1613,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -2046,8 +2046,12 @@ checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
 dependencies = [
  "futures-util",
  "log",
+ "rustls",
+ "rustls-pki-types",
  "tokio",
+ "tokio-rustls",
  "tungstenite",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -2189,6 +2193,8 @@ dependencies = [
  "httparse",
  "log",
  "rand",
+ "rustls",
+ "rustls-pki-types",
  "sha1",
  "thiserror",
  "utf-8",
@@ -2420,6 +2426,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]

--- a/crates/clawdentity-cli/Cargo.toml
+++ b/crates/clawdentity-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clawdentity-cli"
-version = "0.1.6"
+version = "0.1.7"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -11,7 +11,7 @@ readme = "../../README.md"
 anyhow.workspace = true
 chrono = { version = "0.4.43", default-features = false, features = ["clock"] }
 clap.workspace = true
-clawdentity-core = { version = "0.1.6", path = "../clawdentity-core" }
+clawdentity-core = { version = "0.1.7", path = "../clawdentity-core" }
 reqwest = { version = "0.12.24", default-features = false, features = ["json", "rustls-tls"] }
 serde_json.workspace = true
 tokio = { version = "1.49.0", features = ["macros", "rt-multi-thread", "signal"] }

--- a/crates/clawdentity-core/Cargo.toml
+++ b/crates/clawdentity-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clawdentity-core"
-version = "0.1.6"
+version = "0.1.7"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/clawdentity-core/Cargo.toml
+++ b/crates/clawdentity-core/Cargo.toml
@@ -26,7 +26,7 @@ sha2 = "0.10.9"
 thiserror.workspace = true
 tracing.workspace = true
 tokio = { version = "1.49.0", features = ["macros", "net", "rt-multi-thread", "sync", "time"] }
-tokio-tungstenite = "0.28.0"
+tokio-tungstenite = { version = "0.28.0", features = ["rustls-tls-webpki-roots"] }
 ulid = "1.2.1"
 url.workspace = true
 

--- a/crates/clawdentity-core/src/connector/AGENTS.md
+++ b/crates/clawdentity-core/src/connector/AGENTS.md
@@ -8,3 +8,4 @@
 - Service install/uninstall must stay idempotent across macOS launchd and Linux systemd.
 - Keep connector helpers `clippy -D warnings` clean, especially `format!` calls that can use inline named arguments.
 - Keep connector runtime contracts backward compatible with published OpenClaw relay transform payloads unless a coordinated release updates both sides.
+- Keep websocket client dependencies compiled with TLS support; production proxy connectivity requires `wss://` and must never rely on plaintext-only websocket builds.


### PR DESCRIPTION
## Summary
- promote the 0.1.7 release and TLS-enabled connector hotfix to main
- align production source with the published 0.1.7 binaries
- keep production relay over wss:// working with the released CLI

## Validation
- cargo check -p clawdentity-core -p clawdentity-cli
- cargo test -p clawdentity-core -p clawdentity-cli
- production E2E with published 0.1.7: two users paired, 5 messages each direction
