### PR TITLE
Fix local registry/proxy URL remapping and OpenClaw inbound delivery recovery

### DIFF
--- a/apps/proxy/src/auth-middleware.test/url.test.ts
+++ b/apps/proxy/src/auth-middleware.test/url.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import {
+  isLoopbackRegistryUrl,
+  resolveExpectedIssuer,
+} from "../auth-middleware/url.js";
+
+describe("proxy auth url helpers", () => {
+  it("keeps remote registry origins unchanged", () => {
+    expect(
+      resolveExpectedIssuer(
+        "https://registry.clawdentity.com",
+        new Request("https://proxy.clawdentity.com/protected"),
+      ),
+    ).toBe("https://registry.clawdentity.com");
+  });
+
+  it("keeps loopback registry origin for localhost requests", () => {
+    expect(
+      resolveExpectedIssuer(
+        "http://127.0.0.1:8788",
+        new Request("http://localhost:8787/protected"),
+      ),
+    ).toBe("http://127.0.0.1:8788");
+  });
+
+  it("maps loopback registry origin to docker-facing host when present", () => {
+    expect(
+      resolveExpectedIssuer(
+        "http://127.0.0.1:8788",
+        new Request("http://host.docker.internal:8787/protected", {
+          headers: {
+            host: "host.docker.internal:8787",
+            "x-forwarded-host": "host.docker.internal:8787",
+            "x-forwarded-proto": "http",
+          },
+        }),
+      ),
+    ).toBe("http://host.docker.internal:8788");
+  });
+
+  it("keeps the registry port when remapping to a forwarded host", () => {
+    expect(
+      resolveExpectedIssuer(
+        "http://127.0.0.1:8788",
+        new Request("http://127.0.0.1:8787/protected", {
+          headers: {
+            host: "registry.example.test:9443",
+            "x-forwarded-host": "registry.example.test:9443",
+            "x-forwarded-proto": "https",
+          },
+        }),
+      ),
+    ).toBe("https://registry.example.test:8788");
+  });
+
+  it("drops the loopback registry port when the forwarded public host omits it", () => {
+    expect(
+      resolveExpectedIssuer(
+        "http://127.0.0.1:8788",
+        new Request("http://127.0.0.1:8787/protected", {
+          headers: {
+            host: "registry.example.test",
+            "x-forwarded-host": "registry.example.test",
+            "x-forwarded-proto": "https",
+          },
+        }),
+      ),
+    ).toBe("https://registry.example.test");
+  });
+
+  it("treats bracketed ipv6 loopback registry urls as local", () => {
+    expect(
+      resolveExpectedIssuer(
+        "http://[::1]:8788",
+        new Request("http://[::1]:8787/protected", {
+          headers: {
+            host: "registry.example.test",
+            "x-forwarded-host": "registry.example.test",
+            "x-forwarded-proto": "https",
+          },
+        }),
+      ),
+    ).toBe("https://registry.example.test");
+  });
+
+  it("detects loopback registry urls", () => {
+    expect(isLoopbackRegistryUrl("http://127.0.0.1:8788")).toBe(true);
+    expect(isLoopbackRegistryUrl("http://[::1]:8788")).toBe(true);
+    expect(isLoopbackRegistryUrl("https://registry.clawdentity.com")).toBe(
+      false,
+    );
+  });
+});

--- a/apps/proxy/src/auth-middleware/AGENTS.md
+++ b/apps/proxy/src/auth-middleware/AGENTS.md
@@ -1,18 +1,10 @@
 # AGENTS.md (apps/proxy/src/auth-middleware)
 
 ## Purpose
-- Keep proxy auth verification modular, testable, and failure-mode explicit.
-
-## Module ownership
-- `middleware.ts`: orchestration only (verification flow and context wiring).
-- `request-auth.ts`: header parsing, timestamp skew validation, proof input shaping.
-- `registry-keys.ts`: registry key payload parsing + verification-key projection.
-- `url.ts`: registry URL normalization, issuer resolution, path helpers.
-- `errors.ts`: standardized auth/dependency error constructors.
-- `types.ts`: shared types and defaults.
+- Keep proxy auth URL/issuer handling deterministic across local, Docker, and reverse-proxied deployments.
 
 ## Rules
-- Keep error codes/messages stable; route tests depend on them.
-- Prefer pure helpers in leaf modules and inject side-effectful dependencies (`fetch`, caches, clock) from `middleware.ts`.
-- Do not mix registry fetch/parsing logic into request-header helpers.
-- Keep replay/nonce and CRL decisions fail-safe and explicit.
+- Loopback registry URLs may be rewritten to caller-facing origins only when the request proves a non-loopback host via forwarded or host headers.
+- When rewriting a loopback registry issuer, always inherit the caller-facing protocol and hostname. Keep the configured registry port when the proxy request itself is on a sibling service port, but drop the local loopback port when the forwarded public host omitted any explicit port.
+- Treat bracketed IPv6 loopback hosts (`[::1]`) as loopback everywhere URL helpers classify local origins.
+- Registry issuer normalization must stay side-effect free and must never guess public ports beyond what the forwarded/request origin already proves.

--- a/apps/proxy/src/auth-middleware/url.ts
+++ b/apps/proxy/src/auth-middleware/url.ts
@@ -6,6 +6,66 @@ import {
   PAIR_STATUS_PATH,
 } from "../pairing-constants.js";
 
+const FORWARDED_HOST_HEADER = "x-forwarded-host";
+const FORWARDED_PROTO_HEADER = "x-forwarded-proto";
+const HOST_HEADER = "host";
+
+function firstHeaderValue(value: string | null): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  return value
+    .split(",")
+    .map((part) => part.trim())
+    .find((part) => part.length > 0);
+}
+
+function normalizeHostname(hostname: string): string {
+  const normalized = hostname.trim().toLowerCase();
+  if (normalized.startsWith("[") && normalized.endsWith("]")) {
+    return normalized.slice(1, -1);
+  }
+  return normalized;
+}
+
+function isLoopbackHostname(hostname: string): boolean {
+  const normalized = normalizeHostname(hostname);
+  return (
+    normalized === "localhost" ||
+    normalized === "127.0.0.1" ||
+    normalized === "0.0.0.0" ||
+    normalized === "::1"
+  );
+}
+
+function resolveRequestOrigin(request: Request): string | undefined {
+  let fallbackUrl: URL | undefined;
+  try {
+    fallbackUrl = new URL(request.url);
+  } catch {
+    fallbackUrl = undefined;
+  }
+
+  const host =
+    firstHeaderValue(request.headers.get(FORWARDED_HOST_HEADER)) ??
+    firstHeaderValue(request.headers.get(HOST_HEADER));
+  if (!host) {
+    return fallbackUrl?.origin;
+  }
+
+  const proto =
+    firstHeaderValue(request.headers.get(FORWARDED_PROTO_HEADER)) ??
+    fallbackUrl?.protocol.replace(/:$/, "") ??
+    "https";
+
+  try {
+    return new URL(`${proto}://${host}`).origin;
+  } catch {
+    return fallbackUrl?.origin;
+  }
+}
+
 export function toPathWithQuery(url: string): string {
   const parsed = new URL(url, "http://localhost");
   return `${parsed.pathname}${parsed.search}`;
@@ -31,9 +91,40 @@ export function toRegistryUrl(registryUrl: string, path: string): string {
   return new URL(path, normalizedBaseUrl).toString();
 }
 
-export function resolveExpectedIssuer(registryUrl: string): string | undefined {
+export function isLoopbackRegistryUrl(registryUrl: string): boolean {
   try {
-    return new URL(registryUrl).origin;
+    return isLoopbackHostname(new URL(registryUrl).hostname);
+  } catch {
+    return false;
+  }
+}
+
+export function resolveExpectedIssuer(
+  registryUrl: string,
+  request?: Request,
+): string | undefined {
+  try {
+    const parsedRegistryUrl = new URL(registryUrl);
+    if (!request || !isLoopbackHostname(parsedRegistryUrl.hostname)) {
+      return parsedRegistryUrl.origin;
+    }
+
+    const requestOrigin = resolveRequestOrigin(request);
+    if (!requestOrigin) {
+      return parsedRegistryUrl.origin;
+    }
+
+    const requestUrl = new URL(requestOrigin);
+    if (isLoopbackHostname(requestUrl.hostname)) {
+      return parsedRegistryUrl.origin;
+    }
+
+    parsedRegistryUrl.protocol = requestUrl.protocol;
+    parsedRegistryUrl.hostname = requestUrl.hostname;
+    if (requestUrl.port.length === 0) {
+      parsedRegistryUrl.port = "";
+    }
+    return parsedRegistryUrl.origin;
   } catch {
     return undefined;
   }

--- a/apps/registry/src/agent-registration/AGENTS.md
+++ b/apps/registry/src/agent-registration/AGENTS.md
@@ -15,3 +15,4 @@
 - Preserve environment-aware validation error exposure rules (`shouldExposeVerboseErrors`) for parse failures.
 - Preserve challenge nonce length, TTL, and proof canonicalization inputs exactly; changes here are auth-sensitive.
 - Preserve reissue expiry behavior: do not extend lifetime beyond prior valid expiry when previous expiry is still active.
+- Keep the `local` issuer default aligned with the local Docker registry authority (`http://127.0.0.1:8788`) so issued AITs stay consistent with stored local DIDs.

--- a/apps/registry/src/agent-registration/constants.ts
+++ b/apps/registry/src/agent-registration/constants.ts
@@ -15,7 +15,7 @@ const REGISTRY_ISSUER_BY_ENVIRONMENT: Record<
   RegistryConfig["ENVIRONMENT"],
   string
 > = {
-  local: "https://dev.registry.clawdentity.com",
+  local: "http://127.0.0.1:8788",
   development: "https://dev.registry.clawdentity.com",
   production: "https://registry.clawdentity.com",
 };

--- a/apps/registry/src/server.test/agent-auth-refresh.test.ts
+++ b/apps/registry/src/server.test/agent-auth-refresh.test.ts
@@ -14,7 +14,7 @@ import {
 import { createRegistryApp } from "../server.js";
 import { createFakeDb, createSignedAgentRefreshRequest } from "./helpers.js";
 
-const DID_AUTHORITY = "dev.registry.clawdentity.com";
+const DID_AUTHORITY = "127.0.0.1";
 
 describe(`POST ${AGENT_AUTH_REFRESH_PATH}`, () => {
   async function buildRefreshFixture() {
@@ -29,7 +29,7 @@ describe(`POST ${AGENT_AUTH_REFRESH_PATH}`, () => {
     const refreshTokenHash = await hashAgentToken(refreshToken);
     const ait = await signAIT({
       claims: {
-        iss: "https://dev.registry.clawdentity.com",
+        iss: "http://127.0.0.1:8788",
         sub: agentDid,
         ownerDid: makeHumanDid(DID_AUTHORITY, generateUlid(Date.now() + 2)),
         name: "agent-refresh-01",

--- a/apps/registry/src/server.test/agent-registration-create.success.test.ts
+++ b/apps/registry/src/server.test/agent-registration-create.success.test.ts
@@ -203,7 +203,7 @@ describe("POST /v1/agents", () => {
 
     const claims = await verifyAIT({
       token: registerBody.ait,
-      expectedIssuer: "https://dev.registry.clawdentity.com",
+      expectedIssuer: "http://127.0.0.1:8788",
       registryKeys: keysBody.keys
         .filter((key) => key.status === "active")
         .map((key) => ({
@@ -216,7 +216,7 @@ describe("POST /v1/agents", () => {
         })),
     });
 
-    expect(claims.iss).toBe("https://dev.registry.clawdentity.com");
+    expect(claims.iss).toBe("http://127.0.0.1:8788");
     expect(claims.sub).toBe(registerBody.agent.did);
     expect(claims.ownerDid).toBe(registerBody.agent.ownerDid);
     expect(claims.name).toBe(registerBody.agent.name);

--- a/apps/registry/src/server.test/agents-reissue.test.ts
+++ b/apps/registry/src/server.test/agents-reissue.test.ts
@@ -8,7 +8,7 @@ import { describe, expect, it } from "vitest";
 import { createRegistryApp } from "../server.js";
 import { createFakeDb, makeValidPatContext } from "./helpers.js";
 
-const DID_AUTHORITY = "dev.registry.clawdentity.com";
+const DID_AUTHORITY = "127.0.0.1";
 
 describe("POST /v1/agents/:id/reissue", () => {
   it("returns 401 when PAT is missing", async () => {
@@ -322,7 +322,7 @@ describe("POST /v1/agents/:id/reissue", () => {
 
     const claims = await verifyAIT({
       token: body.ait,
-      expectedIssuer: "https://dev.registry.clawdentity.com",
+      expectedIssuer: "http://127.0.0.1:8788",
       registryKeys: keysBody.keys
         .filter((key) => key.status === "active")
         .map((key) => ({
@@ -485,7 +485,7 @@ describe("POST /v1/agents/:id/reissue", () => {
 
     const claims = await verifyAIT({
       token: body.ait,
-      expectedIssuer: "https://dev.registry.clawdentity.com",
+      expectedIssuer: "http://127.0.0.1:8788",
       registryKeys: [
         {
           kid: "reg-key-1",
@@ -503,5 +503,82 @@ describe("POST /v1/agents/:id/reissue", () => {
     expect(claims.exp).toBe(
       Math.floor(Date.parse(body.agent.expiresAt) / 1000),
     );
+  });
+
+  it("keeps the configured issuer authority when the request comes through a different local alias", async () => {
+    const { token, authRow } = await makeValidPatContext();
+    const agentId = generateUlid(1700300000600);
+    const previousJti = generateUlid(1700300000601);
+    const signer = await generateEd25519Keypair();
+    const agentKeypair = await generateEd25519Keypair();
+    const signingKeyset = JSON.stringify([
+      {
+        kid: "reg-key-1",
+        alg: "EdDSA",
+        crv: "Ed25519",
+        x: encodeBase64url(signer.publicKey),
+        status: "active",
+      },
+    ]);
+    const { database } = createFakeDb(
+      [authRow],
+      [
+        {
+          id: agentId,
+          did: makeAgentDid(DID_AUTHORITY, agentId),
+          ownerId: "human-1",
+          name: "owned-agent",
+          framework: "openclaw",
+          publicKey: encodeBase64url(agentKeypair.publicKey),
+          status: "active",
+          expiresAt: "2026-04-01T00:00:00.000Z",
+          currentJti: previousJti,
+        },
+      ],
+    );
+    const appInstance = createRegistryApp();
+
+    const res = await appInstance.request(
+      `http://host.docker.internal:8788/v1/agents/${agentId}/reissue`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          host: "host.docker.internal:8788",
+          "x-forwarded-host": "host.docker.internal:8788",
+          "x-forwarded-proto": "http",
+        },
+      },
+      {
+        DB: database,
+        ENVIRONMENT: "local",
+        BOOTSTRAP_INTERNAL_SERVICE_ID: "proxy-pairing",
+        BOOTSTRAP_INTERNAL_SERVICE_SECRET: "bootstrap-test-secret",
+        REGISTRY_SIGNING_KEY: encodeBase64url(signer.secretKey),
+        REGISTRY_SIGNING_KEYS: signingKeyset,
+      },
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ait: string };
+
+    const claims = await verifyAIT({
+      token: body.ait,
+      expectedIssuer: "http://127.0.0.1:8788",
+      registryKeys: [
+        {
+          kid: "reg-key-1",
+          jwk: {
+            kty: "OKP",
+            crv: "Ed25519",
+            x: encodeBase64url(signer.publicKey),
+          },
+        },
+      ],
+    });
+
+    expect(claims.iss).toBe("http://127.0.0.1:8788");
+    expect(claims.sub).toBe(makeAgentDid(DID_AUTHORITY, agentId));
+    expect(claims.ownerDid).toBe(authRow.humanDid);
   });
 });

--- a/apps/registry/src/server.test/health-metadata-admin.test.ts
+++ b/apps/registry/src/server.test/health-metadata-admin.test.ts
@@ -135,6 +135,49 @@ describe(`GET ${REGISTRY_METADATA_PATH}`, () => {
       proxyUrl: "https://dev.proxy.clawdentity.com",
     });
   });
+
+  it("returns caller-facing local registry and proxy URLs when runtime uses loopback", async () => {
+    const res = await createRegistryApp().request(
+      `https://dev.registry.clawdentity.com${REGISTRY_METADATA_PATH}`,
+      {
+        headers: {
+          host: "host.docker.internal:8788",
+          "x-forwarded-host": "host.docker.internal:8788",
+          "x-forwarded-proto": "http",
+        },
+      },
+      {
+        DB: {} as D1Database,
+        ENVIRONMENT: "local",
+        BOOTSTRAP_INTERNAL_SERVICE_ID: "proxy-pairing",
+        BOOTSTRAP_INTERNAL_SERVICE_SECRET:
+          TEST_BOOTSTRAP_INTERNAL_SERVICE_SECRET,
+        APP_VERSION: "sha-meta-local",
+        PROXY_URL: "http://127.0.0.1:8787",
+        REGISTRY_ISSUER_URL: "https://dev.registry.clawdentity.com",
+        EVENT_BUS_BACKEND: "memory",
+        BOOTSTRAP_SECRET: "bootstrap-secret",
+        REGISTRY_SIGNING_KEY: "test-signing-key",
+        REGISTRY_SIGNING_KEYS: JSON.stringify([
+          {
+            kid: "reg-key-1",
+            alg: "EdDSA",
+            crv: "Ed25519",
+            x: "AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA",
+            status: "active",
+          },
+        ]),
+      },
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      registryUrl: string;
+      proxyUrl: string;
+    };
+    expect(body.registryUrl).toBe("http://host.docker.internal:8788");
+    expect(body.proxyUrl).toBe("http://host.docker.internal:8787");
+  });
 });
 
 describe(`POST ${ADMIN_BOOTSTRAP_PATH}`, () => {
@@ -357,7 +400,7 @@ describe(`POST ${ADMIN_BOOTSTRAP_PATH}`, () => {
 
     expect(body.human.id).toBe("00000000000000000000000000");
     expect(body.human.did).toBe(
-      "did:cdi:dev.registry.clawdentity.com:human:00000000000000000000000000",
+      "did:cdi:127.0.0.1:human:00000000000000000000000000",
     );
     expect(body.human.displayName).toBe("Primary Admin");
     expect(body.human.role).toBe("admin");

--- a/apps/registry/src/server.test/helpers/AGENTS.md
+++ b/apps/registry/src/server.test/helpers/AGENTS.md
@@ -14,6 +14,7 @@
 - Preserve SQL parsing/matching semantics in fake DB helpers unless a test explicitly requires a change.
 - Reuse shared parser/resolver/run-handler utilities; avoid duplicated query handling logic.
 - Keep fixtures deterministic (fixed timestamps/IDs/nonces) and avoid randomization.
+- Keep local PAT and human fixtures aligned with the local registry DID authority (`127.0.0.1`) whenever `ENVIRONMENT` is `local`; mixed authorities create false-negative auth and reissue failures.
 
 ## Validation
 - For helper changes, run:

--- a/apps/registry/src/server.test/helpers/pat.ts
+++ b/apps/registry/src/server.test/helpers/pat.ts
@@ -13,8 +13,7 @@ export function makeValidPatContext(token = "clw_pat_valid-token-value") {
       apiKeyStatus: "active",
       apiKeyName: "ci",
       humanId: "human-1",
-      humanDid:
-        "did:cdi:dev.registry.clawdentity.com:human:01HF7YAT31JZHSMW1CG6Q6MHB7",
+      humanDid: "did:cdi:127.0.0.1:human:01HF7YAT31JZHSMW1CG6Q6MHB7",
       humanDisplayName: "Ravi",
       humanRole: "admin",
       humanStatus: "active",

--- a/apps/registry/src/server.test/invites.test.ts
+++ b/apps/registry/src/server.test/invites.test.ts
@@ -305,7 +305,7 @@ describe(`POST ${INVITES_REDEEM_PATH}`, () => {
     const appInstance = createRegistryApp();
 
     const redeemResponse = await appInstance.request(
-      INVITES_REDEEM_PATH,
+      `http://host.docker.internal:8788${INVITES_REDEEM_PATH}`,
       {
         method: "POST",
         headers: {
@@ -345,7 +345,7 @@ describe(`POST ${INVITES_REDEEM_PATH}`, () => {
     expect(redeemBody.human.role).toBe("user");
     expect(redeemBody.apiKey.name).toBe("primary-invite-key");
     expect(redeemBody.apiKey.token.startsWith("clw_pat_")).toBe(true);
-    expect(redeemBody.proxyUrl).toBe("https://dev.proxy.clawdentity.com");
+    expect(redeemBody.proxyUrl).toBe("http://host.docker.internal:8787");
 
     expect(humanInserts).toHaveLength(1);
     expect(apiKeyInserts).toHaveLength(1);
@@ -448,5 +448,51 @@ describe(`POST ${INVITES_REDEEM_PATH}`, () => {
     expect(secondResponse.status).toBe(201);
     expect(humanRows).toHaveLength(2);
     expect(inviteRows[0]?.redeemedBy).toEqual(expect.any(String));
+  });
+
+  it("returns caller-facing proxy URL when invite redeem runtime uses loopback", async () => {
+    const inviteCode = "clw_inv_local_proxy";
+    const { database } = createFakeDb([], [], {
+      inviteRows: [
+        {
+          id: generateUlid(1700700003100),
+          code: inviteCode,
+          createdBy: "human-1",
+          redeemedBy: null,
+          agentId: null,
+          expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      ],
+    });
+
+    const response = await createRegistryApp().request(
+      "https://dev.registry.clawdentity.com/v1/invites/redeem",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          host: "host.docker.internal:8788",
+          "x-forwarded-host": "host.docker.internal:8788",
+          "x-forwarded-proto": "http",
+        },
+        body: JSON.stringify({
+          code: inviteCode,
+          displayName: "Invitee Beta",
+          apiKeyName: "invite-local",
+        }),
+      },
+      {
+        DB: database,
+        ENVIRONMENT: "local",
+        PROXY_URL: "http://127.0.0.1:8787",
+        BOOTSTRAP_INTERNAL_SERVICE_ID: "proxy-pairing",
+        BOOTSTRAP_INTERNAL_SERVICE_SECRET: "bootstrap-test-secret",
+      },
+    );
+
+    expect(response.status).toBe(201);
+    const body = (await response.json()) as { proxyUrl: string };
+    expect(body.proxyUrl).toBe("http://host.docker.internal:8787");
   });
 });

--- a/apps/registry/src/server.test/keys-crl.test.ts
+++ b/apps/registry/src/server.test/keys-crl.test.ts
@@ -13,7 +13,7 @@ import { describe, expect, it } from "vitest";
 import { createRegistryApp } from "../server.js";
 import { createFakeDb, makeAitClaims } from "./helpers.js";
 
-const DID_AUTHORITY = "dev.registry.clawdentity.com";
+const DID_AUTHORITY = "127.0.0.1";
 
 describe("GET /.well-known/claw-keys.json", () => {
   it("returns configured registry signing keys with cache headers", async () => {
@@ -280,7 +280,7 @@ describe("GET /v1/crl", () => {
 
     const claims = await verifyCRL({
       token: body.crl,
-      expectedIssuer: "https://dev.registry.clawdentity.com",
+      expectedIssuer: "http://127.0.0.1:8788",
       registryKeys: keysBody.keys
         .filter((key) => key.status === "active")
         .map((key) => ({

--- a/apps/registry/src/server.test/resolve-me.test.ts
+++ b/apps/registry/src/server.test/resolve-me.test.ts
@@ -292,7 +292,7 @@ describe("GET /v1/me", () => {
     };
     expect(body.human).toEqual({
       id: "human-1",
-      did: "did:cdi:dev.registry.clawdentity.com:human:01HF7YAT31JZHSMW1CG6Q6MHB7",
+      did: "did:cdi:127.0.0.1:human:01HF7YAT31JZHSMW1CG6Q6MHB7",
       displayName: "Ravi",
       role: "admin",
       onboardingSource: "admin_bootstrap",

--- a/apps/registry/src/server/constants.ts
+++ b/apps/registry/src/server/constants.ts
@@ -145,7 +145,7 @@ export const PROXY_URL_BY_ENVIRONMENT: Record<
   RegistryConfig["ENVIRONMENT"],
   string
 > = {
-  local: "https://dev.proxy.clawdentity.com",
+  local: "http://127.0.0.1:8787",
   development: "https://dev.proxy.clawdentity.com",
   production: "https://proxy.clawdentity.com",
 };
@@ -154,7 +154,7 @@ export const LANDING_URL_BY_ENVIRONMENT: Record<
   RegistryConfig["ENVIRONMENT"],
   string
 > = {
-  local: "https://clawdentity-site-dev.pages.dev",
+  local: "http://localhost:4321",
   development: "https://clawdentity-site-dev.pages.dev",
   production: "https://clawdentity.com",
 };

--- a/apps/registry/src/server/helpers/AGENTS.md
+++ b/apps/registry/src/server/helpers/AGENTS.md
@@ -8,3 +8,6 @@
 - Production-like queue validation must fail fast with `CONFIG_VALIDATION_FAILED` when `EVENT_BUS_BACKEND=queue` and `EVENT_BUS_QUEUE` is missing.
 - Keep helper outputs free of route-specific response shaping; helpers should expose reusable data or side-effect boundaries, not inline HTTP responses.
 - Prefer explicit config-driven branching over hostname or branch-name heuristics.
+- Public URL helpers must translate loopback runtime URLs into caller-facing URLs using forwarded/host headers so Docker, localhost, and reverse-proxy onboarding flows persist reachable endpoints.
+- Registry-facing loopback URLs may adopt the forwarded origin's port semantics, but sibling service URLs such as the proxy must keep their own configured service port when only the hostname/protocol are being remapped.
+- Treat bracketed IPv6 loopback hosts (`[::1]`) the same as bare `::1` so local IPv6 setups follow the same caller-facing origin remap path.

--- a/apps/registry/src/server/helpers/parsers.test.ts
+++ b/apps/registry/src/server/helpers/parsers.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { resolvePublicUrl } from "./parsers.js";
+
+describe("registry public url helpers", () => {
+  it("uses the forwarded origin for registry-facing loopback urls", () => {
+    expect(
+      resolvePublicUrl({
+        request: new Request("http://127.0.0.1:8788/v1/health", {
+          headers: {
+            host: "registry.example.test",
+            "x-forwarded-host": "registry.example.test",
+            "x-forwarded-proto": "https",
+          },
+        }),
+        configuredUrl: "http://127.0.0.1:8788/",
+      }),
+    ).toBe("https://registry.example.test/");
+  });
+
+  it("preserves the configured proxy port when rewriting to the caller-facing host", () => {
+    expect(
+      resolvePublicUrl({
+        request: new Request("http://host.docker.internal:8788/v1/metadata", {
+          headers: {
+            host: "host.docker.internal:8788",
+            "x-forwarded-host": "host.docker.internal:8788",
+            "x-forwarded-proto": "http",
+          },
+        }),
+        configuredUrl: "http://127.0.0.1:8787",
+        preserveConfiguredPort: true,
+      }),
+    ).toBe("http://host.docker.internal:8787");
+  });
+
+  it("treats bracketed ipv6 loopback urls as local origins", () => {
+    expect(
+      resolvePublicUrl({
+        request: new Request("http://[::1]:8788/v1/health", {
+          headers: {
+            host: "registry.example.test",
+            "x-forwarded-host": "registry.example.test",
+            "x-forwarded-proto": "https",
+          },
+        }),
+        configuredUrl: "http://[::1]:8788/",
+      }),
+    ).toBe("https://registry.example.test/");
+  });
+});

--- a/apps/registry/src/server/helpers/parsers.ts
+++ b/apps/registry/src/server/helpers/parsers.ts
@@ -10,6 +10,7 @@ import {
   type RegistryConfig,
   shouldExposeVerboseErrors,
 } from "@clawdentity/sdk";
+import { resolveRegistryIssuer } from "../../agent-registration.js";
 import { parseAccessToken } from "../../auth/agent-auth-token.js";
 import { constantTimeEqual } from "../../auth/api-key-token.js";
 import { parseInternalServiceScopesPayload } from "../../auth/internal-service-scopes.js";
@@ -19,6 +20,121 @@ import {
   LANDING_URL_BY_ENVIRONMENT,
   PROXY_URL_BY_ENVIRONMENT,
 } from "../constants.js";
+
+const FORWARDED_HOST_HEADER = "x-forwarded-host";
+const FORWARDED_PROTO_HEADER = "x-forwarded-proto";
+const HOST_HEADER = "host";
+
+function firstHeaderValue(value: string | null): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  return value
+    .split(",")
+    .map((part) => part.trim())
+    .find((part) => part.length > 0);
+}
+
+function normalizeHostname(hostname: string): string {
+  const normalized = hostname.trim().toLowerCase();
+  if (normalized.startsWith("[") && normalized.endsWith("]")) {
+    return normalized.slice(1, -1);
+  }
+  return normalized;
+}
+
+function isLoopbackHostname(hostname: string): boolean {
+  const normalized = normalizeHostname(hostname);
+  return (
+    normalized === "localhost" ||
+    normalized === "127.0.0.1" ||
+    normalized === "0.0.0.0" ||
+    normalized === "::1"
+  );
+}
+
+export function resolveRequestOrigin(request: Request): string | undefined {
+  let fallbackUrl: URL | undefined;
+  try {
+    fallbackUrl = new URL(request.url);
+  } catch {
+    fallbackUrl = undefined;
+  }
+
+  const host =
+    firstHeaderValue(request.headers.get(FORWARDED_HOST_HEADER)) ??
+    firstHeaderValue(request.headers.get(HOST_HEADER));
+  if (!host) {
+    return fallbackUrl?.origin;
+  }
+
+  const proto =
+    firstHeaderValue(request.headers.get(FORWARDED_PROTO_HEADER)) ??
+    fallbackUrl?.protocol.replace(/:$/, "") ??
+    "https";
+
+  try {
+    return new URL(`${proto}://${host}`).origin;
+  } catch {
+    return fallbackUrl?.origin;
+  }
+}
+
+export function resolvePublicUrl(input: {
+  request: Request;
+  configuredUrl: string;
+  preserveConfiguredPort?: boolean;
+}): string {
+  const configured = new URL(input.configuredUrl);
+  if (!isLoopbackHostname(configured.hostname)) {
+    return input.configuredUrl;
+  }
+
+  const requestOrigin = resolveRequestOrigin(input.request);
+  if (!requestOrigin) {
+    return configured.toString();
+  }
+
+  const requestUrl = new URL(requestOrigin);
+  if (isLoopbackHostname(requestUrl.hostname)) {
+    return input.configuredUrl;
+  }
+
+  configured.protocol = requestUrl.protocol;
+  configured.hostname = requestUrl.hostname;
+  if (!input.preserveConfiguredPort) {
+    configured.port = requestUrl.port;
+  }
+
+  if (configured.pathname === "/" && configured.search.length === 0) {
+    const origin = configured.origin;
+    return input.configuredUrl.endsWith("/") ? `${origin}/` : origin;
+  }
+
+  return configured.toString();
+}
+
+export function resolvePublicRegistryIssuer(input: {
+  request: Request;
+  config: Pick<RegistryConfig, "ENVIRONMENT" | "REGISTRY_ISSUER_URL">;
+}): string {
+  return resolvePublicUrl({
+    request: input.request,
+    configuredUrl: resolveRegistryIssuer(input.config),
+  });
+}
+
+export function resolvePublicProxyUrl(input: {
+  request: Request;
+  config: Pick<RegistryConfig, "ENVIRONMENT" | "PROXY_URL">;
+}): string {
+  return resolvePublicUrl({
+    request: input.request,
+    configuredUrl: resolveProxyUrl(input.config),
+    preserveConfiguredPort: true,
+  });
+}
 
 function crlBuildError(options: {
   environment: RegistryConfig["ENVIRONMENT"];
@@ -394,11 +510,15 @@ export function adminBootstrapAlreadyCompletedError(): AppError {
   });
 }
 
-export function resolveProxyUrl(config: RegistryConfig): string {
+export function resolveProxyUrl(
+  config: Pick<RegistryConfig, "ENVIRONMENT" | "PROXY_URL">,
+): string {
   return config.PROXY_URL ?? PROXY_URL_BY_ENVIRONMENT[config.ENVIRONMENT];
 }
 
-export function resolveLandingUrl(config: RegistryConfig): string {
+export function resolveLandingUrl(
+  config: Pick<RegistryConfig, "ENVIRONMENT" | "LANDING_URL">,
+): string {
   return config.LANDING_URL ?? LANDING_URL_BY_ENVIRONMENT[config.ENVIRONMENT];
 }
 

--- a/apps/registry/src/server/routes/AGENTS.md
+++ b/apps/registry/src/server/routes/AGENTS.md
@@ -7,9 +7,12 @@
 - Route modules register handlers only; shared config parsing, database helpers, and event-bus behavior belong in `../helpers` or higher-level server composition.
 - `/health` must preserve the existing top-level fields while allowing additive readiness metadata for deployment verification.
 - New route-level readiness or metadata fields must be additive and must not break existing clients that only read `status`, `version`, or `environment`.
+- Caller-facing onboarding routes must publish reachable URLs. `/v1/metadata`, invite redeem, and starter-pass onboarding must not leak loopback-only registry/proxy addresses when the request came through Docker or another external host.
+- When a registry request rewrites a loopback proxy URL to a caller-facing host, keep the proxy's configured port instead of copying the registry request port.
 - Keep GitHub onboarding starter-pass logic in dedicated onboarding routes; do not overload invite routes with public hosted onboarding behavior.
 - Public hosted onboarding must stay additive: admin invites remain available for operator/self-hosted flows even when landing/docs prefer GitHub starter passes.
 - For repeat GitHub login, reissue an expired starter pass for the same provider subject instead of returning an "already issued" dead-end.
 - GitHub OAuth state cookies must set `Secure` only on HTTPS requests so local/plain-HTTP deployments can complete callback state validation.
 - Enforce human-level agent quotas server-side in agent registration routes before challenge finalization; UI copy is not a substitute for quota enforcement.
 - Enforce starter-pass agent quotas inside the guarded registration mutation itself so parallel `/v1/agents` requests cannot bypass the cap between challenge verification and insert.
+- Reissued AITs must stay aligned with the stored agent/human DID authority; do not switch issuer authority just because the current request arrived through a different hostname alias.

--- a/apps/registry/src/server/routes/health.ts
+++ b/apps/registry/src/server/routes/health.ts
@@ -16,7 +16,12 @@ import {
   REGISTRY_KEY_CACHE_CONTROL,
   type RegistryRouteDependencies,
 } from "../constants.js";
-import { buildCrlClaims, resolveProxyUrl } from "../helpers/parsers.js";
+import {
+  buildCrlClaims,
+  resolvePublicProxyUrl,
+  resolvePublicRegistryIssuer,
+  resolveRequestOrigin,
+} from "../helpers/parsers.js";
 
 export function registerHealthRoutes(
   input: RegistryRouteDependencies & {
@@ -69,8 +74,11 @@ export function registerHealthRoutes(
       status: "ok",
       environment: config.ENVIRONMENT,
       version: config.APP_VERSION ?? "0.0.0",
-      registryUrl: c.req.url ? new URL(c.req.url).origin : undefined,
-      proxyUrl: resolveProxyUrl(config),
+      registryUrl: resolveRequestOrigin(c.req.raw),
+      proxyUrl: resolvePublicProxyUrl({
+        request: c.req.raw,
+        config,
+      }),
     });
   });
 
@@ -117,7 +125,10 @@ export function registerHealthRoutes(
     const claims = buildCrlClaims({
       rows,
       environment: config.ENVIRONMENT,
-      issuer: resolveRegistryIssuer(config),
+      issuer: resolvePublicRegistryIssuer({
+        request: c.req.raw,
+        config,
+      }),
       nowSeconds,
     });
     const crl = await signCRL({

--- a/apps/registry/src/server/routes/invites.ts
+++ b/apps/registry/src/server/routes/invites.ts
@@ -40,7 +40,10 @@ import {
   isUnsupportedLocalTransactionError,
   resolveInviteRedeemStateError,
 } from "../helpers/db-queries.js";
-import { resolveProxyUrl } from "../helpers/parsers.js";
+import {
+  resolvePublicProxyUrl,
+  resolvePublicRegistryIssuer,
+} from "../helpers/parsers.js";
 
 export function registerInviteRoutes(input: RegistryRouteDependencies): void {
   const { app, getConfig } = input;
@@ -149,7 +152,10 @@ export function registerInviteRoutes(input: RegistryRouteDependencies): void {
       throw inviteRedeemExpiredError();
     }
 
-    const issuer = resolveRegistryIssuer(config);
+    const issuer = resolvePublicRegistryIssuer({
+      request: c.req.raw,
+      config,
+    });
     const didAuthority = resolveDidAuthorityFromIssuer(issuer);
     const humanId = generateUlid(nowMillis);
     const humanDid = makeHumanDid(didAuthority, humanId);
@@ -275,7 +281,10 @@ export function registerInviteRoutes(input: RegistryRouteDependencies): void {
           name: parsedPayload.apiKeyName,
           token: apiKeyToken,
         },
-        proxyUrl: resolveProxyUrl(config),
+        proxyUrl: resolvePublicProxyUrl({
+          request: c.req.raw,
+          config,
+        }),
       },
       201,
     );

--- a/apps/registry/src/server/routes/onboarding.ts
+++ b/apps/registry/src/server/routes/onboarding.ts
@@ -13,10 +13,7 @@ import {
 } from "@clawdentity/sdk";
 import { and, eq, isNull } from "drizzle-orm";
 import { deleteCookie, getCookie, setCookie } from "hono/cookie";
-import {
-  resolveDidAuthorityFromIssuer,
-  resolveRegistryIssuer,
-} from "../../agent-registration.js";
+import { resolveDidAuthorityFromIssuer } from "../../agent-registration.js";
 import {
   deriveApiKeyLookupPrefix,
   generateApiKeyToken,
@@ -53,7 +50,10 @@ import {
   isUnsupportedLocalTransactionError,
   resolveStarterPassRedeemStateError,
 } from "../helpers/db-queries.js";
-import { resolveProxyUrl } from "../helpers/parsers.js";
+import {
+  resolvePublicProxyUrl,
+  resolvePublicRegistryIssuer,
+} from "../helpers/parsers.js";
 
 const GITHUB_STARTER_PASS_PROVIDER = "github";
 
@@ -221,7 +221,10 @@ export function registerOnboardingRoutes(
         );
       }
 
-      const issuer = resolveRegistryIssuer(config);
+      const issuer = resolvePublicRegistryIssuer({
+        request: c.req.raw,
+        config,
+      });
       const starterPassId = generateUlid(nowMillis);
       const starterPassCode = generateStarterPassCode();
       const issuedAt = nowIso();
@@ -325,7 +328,10 @@ export function registerOnboardingRoutes(
       throw starterPassExpiredError();
     }
 
-    const issuer = resolveRegistryIssuer(config);
+    const issuer = resolvePublicRegistryIssuer({
+      request: c.req.raw,
+      config,
+    });
     const didAuthority = resolveDidAuthorityFromIssuer(issuer);
     const humanId = generateUlid(nowMillis);
     const humanDid = makeHumanDid(didAuthority, humanId);
@@ -442,7 +448,10 @@ export function registerOnboardingRoutes(
           name: parsedPayload.apiKeyName,
           token: apiKeyToken,
         },
-        proxyUrl: resolveProxyUrl(config),
+        proxyUrl: resolvePublicProxyUrl({
+          request: c.req.raw,
+          config,
+        }),
       },
       201,
     );

--- a/crates/clawdentity-cli/src/commands/AGENTS.md
+++ b/crates/clawdentity-cli/src/commands/AGENTS.md
@@ -7,6 +7,9 @@
 - New user-facing commands belong here, not in a parallel JS CLI.
 - Keep command JSON output stable and machine-readable.
 - Any command that mixes blocking filesystem or blocking HTTP with async runtime must isolate the blocking work with `spawn_blocking` or an equivalent boundary.
+- Connector inbound failure handling must not leave stale `inbound_pending` rows forever: successful redelivery must clear pending state, and retry/backoff must either reschedule or dead-letter exhausted items.
+- If inbound delivery fails but the connector successfully persists the frame for local retry, ACK the relay as accepted so only one retry path exists.
+- Wake payloads must not force `sessionId: "main"`; only send `sessionId` when the inbound payload explicitly carries one so OpenClaw's configured default session stays in control.
 - Provider-specific command docs and help text must use `--for <provider>`.
 - Commands that accept `--home-dir` must pass that exact state root through every follow-up verification step; do not install into one home and verify another.
 - Keep command implementations `clippy -D warnings` clean; fold oversized argument lists into small input structs instead of sprinkling `allow` attributes.

--- a/crates/clawdentity-cli/src/commands/connector.rs
+++ b/crates/clawdentity-cli/src/commands/connector.rs
@@ -430,20 +430,11 @@ fn build_deliver_ack_reason(
     delivery_error: Option<&anyhow::Error>,
     persistence_error: Option<&anyhow::Error>,
 ) -> Option<String> {
-    let mut reasons: Vec<String> = Vec::new();
-    if let Some(error) = delivery_error {
-        reasons.push(error.to_string());
-    }
-    if let Some(error) = persistence_error {
-        reasons.push(format!(
-            "failed to persist inbound delivery result: {error}"
-        ));
-    }
-
-    if reasons.is_empty() {
-        None
-    } else {
-        Some(reasons.join("; "))
+    match (delivery_error, persistence_error) {
+        (Some(delivery_error), Some(persistence_error)) => Some(format!(
+            "{delivery_error}; failed to persist inbound delivery result: {persistence_error}"
+        )),
+        _ => None,
     }
 }
 
@@ -482,22 +473,69 @@ async fn forward_deliver_to_openclaw(
 }
 
 fn build_openclaw_hook_payload(deliver: &DeliverFrame) -> Value {
-    json!({
-        "content": extract_content(&deliver.payload),
-        "senderDid": deliver.from_agent_did,
-        "recipientDid": deliver.to_agent_did,
-        "requestId": deliver.id,
-        "metadata": {
-            "conversationId": deliver.conversation_id,
-            "replyTo": deliver.reply_to,
-            "payload": deliver.payload,
-        },
-    })
+    let wake_text = render_openclaw_wake_text(deliver);
+    let session_id = deliver
+        .payload
+        .get("sessionId")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let mut payload = json!({
+        "message": wake_text,
+        "text": wake_text,
+        "mode": "now",
+    });
+    if let Some(session_id) = session_id {
+        payload["sessionId"] = Value::String(session_id.to_string());
+    }
+    payload
+}
+
+fn render_openclaw_wake_text(deliver: &DeliverFrame) -> String {
+    let message = extract_content(&deliver.payload);
+    let mut lines = vec![format!(
+        "Clawdentity peer message from {}",
+        deliver.from_agent_did
+    )];
+
+    if !message.trim().is_empty() {
+        lines.push(String::new());
+        lines.push(message);
+    }
+
+    if let Some(request_id) = Some(deliver.id.as_str()).filter(|value| !value.trim().is_empty()) {
+        lines.push(String::new());
+        lines.push(format!("Request ID: {request_id}"));
+    }
+    if let Some(conversation_id) = deliver
+        .conversation_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        lines.push(format!("Conversation ID: {conversation_id}"));
+    }
+    if let Some(reply_to) = deliver
+        .reply_to
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        lines.push(format!("Reply To: {reply_to}"));
+    }
+
+    lines.join("\n")
 }
 
 fn extract_content(payload: &Value) -> String {
     if let Some(content) = payload.get("content").and_then(Value::as_str) {
         return content.to_string();
+    }
+    if let Some(message) = payload.get("message").and_then(Value::as_str) {
+        return message.to_string();
+    }
+    if let Some(text) = payload.get("text").and_then(Value::as_str) {
+        return text.to_string();
     }
     if let Some(text) = payload.as_str() {
         return text.to_string();

--- a/crates/clawdentity-cli/src/commands/connector/tests.rs
+++ b/crates/clawdentity-cli/src/commands/connector/tests.rs
@@ -1,14 +1,18 @@
 use anyhow::anyhow;
 use chrono::{Duration as ChronoDuration, Utc};
+use clawdentity_core::DeliverFrame;
 use clawdentity_core::agent::AgentAuthRecord;
+use serde_json::json;
 
 use super::runtime_config::{agent_access_requires_refresh, normalize_proxy_ws_url};
-use super::{build_deliver_ack_reason, normalize_hook_path};
+use super::{build_deliver_ack_reason, build_openclaw_hook_payload, normalize_hook_path};
 
 #[test]
 fn normalizes_hook_path_with_leading_slash() {
     assert_eq!(normalize_hook_path("hooks/agent"), "/hooks/agent");
     assert_eq!(normalize_hook_path("/hooks/agent"), "/hooks/agent");
+    assert_eq!(normalize_hook_path("hooks/wake"), "/hooks/wake");
+    assert_eq!(normalize_hook_path("/hooks/wake"), "/hooks/wake");
 }
 
 #[test]
@@ -31,13 +35,10 @@ fn deliver_ack_reason_is_none_when_delivery_and_persistence_succeed() {
 }
 
 #[test]
-fn deliver_ack_reason_reports_persistence_failure() {
+fn deliver_ack_reason_is_none_when_delivery_succeeds_but_persistence_fails() {
     let persistence_error = anyhow!("sqlite unavailable");
     let reason = build_deliver_ack_reason(None, Some(&persistence_error));
-    assert_eq!(
-        reason.as_deref(),
-        Some("failed to persist inbound delivery result: sqlite unavailable")
-    );
+    assert!(reason.is_none());
 }
 
 #[test]
@@ -50,6 +51,93 @@ fn deliver_ack_reason_combines_delivery_and_persistence_failures() {
         Some(
             "openclaw hook returned HTTP 500; failed to persist inbound delivery result: sqlite unavailable"
         )
+    );
+}
+
+#[test]
+fn deliver_ack_reason_is_none_when_delivery_failed_but_retry_was_persisted() {
+    let delivery_error = anyhow!("openclaw hook returned HTTP 500");
+    let reason = build_deliver_ack_reason(Some(&delivery_error), None);
+    assert!(reason.is_none());
+}
+
+#[test]
+fn openclaw_hook_payload_uses_wake_message_contract() {
+    let deliver = DeliverFrame {
+        v: 1,
+        id: "req-1".to_string(),
+        ts: "2026-03-20T05:55:00Z".to_string(),
+        from_agent_did: "did:cdi:test:agent:sender".to_string(),
+        to_agent_did: "did:cdi:test:agent:recipient".to_string(),
+        payload: json!({
+            "content": "hello from alpha",
+        }),
+        content_type: Some("application/json".to_string()),
+        conversation_id: Some("conv-1".to_string()),
+        reply_to: Some("reply-1".to_string()),
+    };
+
+    let payload = build_openclaw_hook_payload(&deliver);
+    assert_eq!(
+        payload.get("message").and_then(|value| value.as_str()),
+        payload.get("text").and_then(|value| value.as_str())
+    );
+    let text = payload
+        .get("text")
+        .and_then(|value| value.as_str())
+        .expect("wake text");
+    assert!(text.contains("Clawdentity peer message from did:cdi:test:agent:sender"));
+    assert!(text.contains("hello from alpha"));
+    assert!(text.contains("Request ID: req-1"));
+    assert!(text.contains("Conversation ID: conv-1"));
+    assert!(text.contains("Reply To: reply-1"));
+}
+
+#[test]
+fn openclaw_wake_payload_omits_default_session_override() {
+    let deliver = DeliverFrame {
+        v: 1,
+        id: "req-2".to_string(),
+        ts: "2026-03-20T05:55:00Z".to_string(),
+        from_agent_did: "did:cdi:test:agent:sender".to_string(),
+        to_agent_did: "did:cdi:test:agent:recipient".to_string(),
+        payload: json!({
+            "message": "plain peer text",
+        }),
+        content_type: Some("application/json".to_string()),
+        conversation_id: None,
+        reply_to: None,
+    };
+
+    let payload = build_openclaw_hook_payload(&deliver);
+    assert!(payload.get("sessionId").is_none());
+    assert_eq!(
+        payload.get("message").and_then(|value| value.as_str()),
+        payload.get("text").and_then(|value| value.as_str())
+    );
+}
+
+#[test]
+fn openclaw_wake_payload_preserves_explicit_session_id() {
+    let deliver = DeliverFrame {
+        v: 1,
+        id: "req-3".to_string(),
+        ts: "2026-03-20T05:55:00Z".to_string(),
+        from_agent_did: "did:cdi:test:agent:sender".to_string(),
+        to_agent_did: "did:cdi:test:agent:recipient".to_string(),
+        payload: json!({
+            "content": "hello in explicit session",
+            "sessionId": "agent:main:main",
+        }),
+        content_type: Some("application/json".to_string()),
+        conversation_id: None,
+        reply_to: None,
+    };
+
+    let payload = build_openclaw_hook_payload(&deliver);
+    assert_eq!(
+        payload.get("sessionId").and_then(|value| value.as_str()),
+        Some("agent:main:main")
     );
 }
 


### PR DESCRIPTION
## Summary
- preserve local proxy ports when registry responses rewrite loopback URLs for Docker/public hosts
- keep registry issuer handling aligned with stored local DID authority and local runtime defaults
- prevent duplicate inbound retries and stop forcing OpenClaw wake traffic into the `main` session

## Testing
- pnpm -F @clawdentity/registry test -- src/server/helpers/parsers.test.ts src/server.test/health-metadata-admin.test.ts src/server.test/invites.test.ts src/server.test/agents-reissue.test.ts
- pnpm -F @clawdentity/proxy test -- src/auth-middleware.test/url.test.ts
- cargo test -p clawdentity-cli connector
- git push hook: nx affected -t lint,format,typecheck,test --base=origin/main --head=HEAD