### PR TITLE
feat(receipts): end-to-end receipt frame + queue routing

### DIFF
--- a/apps/proxy/src/AGENTS.md
+++ b/apps/proxy/src/AGENTS.md
@@ -20,6 +20,7 @@
   - preserve `status`, `version`, and `environment`
   - expose `ready` plus binding/config readiness booleans without breaking older clients
 - Keep Cloudflare Worker fetch startup in `worker.ts`.
+- Keep Cloudflare Queue consumer routing in `worker.ts` and delegate event-specific logic to `queue-consumer/` modules.
 - Keep Node runtime startup in `node-server.ts`; use `bin.ts` as Node process entrypoint.
 - Keep inbound auth verification in `auth-middleware.ts` with focused helpers for token parsing, registry material loading, CRL checks, and replay protection.
 - Keep per-agent DID throttling in `agent-rate-limit-middleware.ts`; do not blend rate-limit state or counters into `auth-middleware.ts`.
@@ -57,6 +58,7 @@
 - Keep DO runtime behavior in `agent-relay-session.ts` (websocket accept, heartbeat alarm, connector delivery RPC).
 - Keep websocket relay behavior complete inside `agent-relay-session/`: sender-side `enqueue` frames from authenticated connector sockets must be authorized, routed to the recipient session, and answered with `enqueue_ack` rather than being dropped silently.
 - Keep relay delivery-receipt HTTP handlers isolated in `relay-delivery-receipt-route.ts`; `server.ts` should only compose `POST/GET /v1/relay/delivery-receipts`.
+- Keep receipt queue event parsing/routing isolated in `queue-consumer/receipt-events.ts`; queue handlers should route events to sender relay sessions, not embed DO RPC JSON inline in `worker.ts`.
 - Do not import Node-only startup helpers into `worker.ts`; Worker runtime must stay free of process/port startup concerns.
 - Keep worker runtime cache keys sensitive to deploy-time version bindings so `/health` reflects fresh `APP_VERSION` after deploy.
 - Keep production request logging policy in `server.ts` restrictive (`onlyErrors` with a slow-request threshold) and keep development/local verbose for debugging.
@@ -118,6 +120,7 @@
 - Keep relay delivery receipt persistence in `agent-relay-session.ts` with explicit RPC routes:
   - `/rpc/record-delivery-receipt`
   - `/rpc/get-delivery-receipt`
+- Keep receipt event fanout behavior in `agent-relay-session.ts`: `recordDeliveryReceipt` must update durable receipt state and push websocket `receipt` frames for connected sender connectors.
 - Receipt states must remain constrained to `processed_by_openclaw` and `dead_lettered`.
 - Reject blank/whitespace `requestId`, `senderAgentDid`, and `recipientAgentDid` in `relay-delivery-receipt-route.ts` so invalid receipt payloads fail as `400` client errors before DO RPC.
 - Receipt reads/writes must verify authenticated/trusted sender-recipient pairs and enforce recipient DID ownership at the route layer.

--- a/apps/proxy/src/agent-relay-session.delivery.test.ts
+++ b/apps/proxy/src/agent-relay-session.delivery.test.ts
@@ -13,6 +13,36 @@ import {
 import { createInMemoryProxyTrustStore } from "./proxy-trust-store.js";
 
 describe("AgentRelaySession delivery", () => {
+  it("pushes receipt frames to active websocket connectors when receipts are recorded", async () => {
+    const harness = createStateHarness();
+    const relaySession = new AgentRelaySession(harness.state, {
+      ...LOCAL_RELAY_ENV,
+      RELAY_RETRY_JITTER_RATIO: "0",
+    });
+    const connectorSocket = createMockSocket();
+    const ws = connectorSocket as unknown as WebSocket;
+    harness.connectedSockets.push(ws);
+
+    const receiptRequestId = generateUlid(Date.now());
+    await relaySession.recordDeliveryReceipt({
+      requestId: receiptRequestId,
+      senderAgentDid: SENDER_AGENT_DID,
+      recipientAgentDid: RECIPIENT_AGENT_DID,
+      status: "dead_lettered",
+      reason: "hook rejected",
+    });
+
+    expect(connectorSocket.send).toHaveBeenCalledTimes(1);
+    const frame = parseFrame(connectorSocket.send.mock.calls[0]?.[0]);
+    expect(frame.type).toBe("receipt");
+    if (frame.type === "receipt") {
+      expect(frame.originalFrameId).toBe(receiptRequestId);
+      expect(frame.toAgentDid).toBe(RECIPIENT_AGENT_DID);
+      expect(frame.status).toBe("dead_lettered");
+      expect(frame.reason).toBe("hook rejected");
+    }
+  });
+
   it("delivers relay frames to active websocket connectors", async () => {
     const harness = createStateHarness();
     const relaySession = new AgentRelaySession(harness.state, {
@@ -209,6 +239,57 @@ describe("AgentRelaySession delivery", () => {
     if (senderAckFrame.type === "enqueue_ack") {
       expect(senderAckFrame.ackId).toBeTruthy();
       expect(senderAckFrame.accepted).toBe(true);
+    }
+  });
+
+  it("drains stored receipt frames to connector on reconnect", async () => {
+    const harness = createStateHarness();
+    const relaySession = new AgentRelaySession(harness.state, {
+      ...LOCAL_RELAY_ENV,
+      RELAY_RETRY_JITTER_RATIO: "0",
+    });
+
+    const receiptRequestId = generateUlid(Date.now());
+    await relaySession.recordDeliveryReceipt({
+      requestId: receiptRequestId,
+      senderAgentDid: SENDER_AGENT_DID,
+      recipientAgentDid: RECIPIENT_AGENT_DID,
+      status: "processed_by_openclaw",
+    });
+
+    const pairClient = createMockSocket();
+    const pairServer = createMockSocket();
+    await withMockWebSocketPair(pairClient, pairServer, async () => {
+      let connectError: unknown;
+      try {
+        await relaySession.fetch(
+          new Request(`https://relay.example.test${RELAY_CONNECT_PATH}`, {
+            method: "GET",
+            headers: {
+              upgrade: "websocket",
+              "x-claw-connector-agent-did": RECIPIENT_AGENT_DID,
+            },
+          }),
+        );
+      } catch (error) {
+        connectError = error;
+      }
+
+      if (connectError !== undefined) {
+        expect(connectError).toBeInstanceOf(RangeError);
+      }
+    });
+
+    expect(pairServer.send).toHaveBeenCalled();
+    const sentFrames = pairServer.send.mock.calls.map((call) =>
+      parseFrame(call[0]),
+    );
+    const receiptFrame = sentFrames.find((frame) => frame.type === "receipt");
+    expect(receiptFrame?.type).toBe("receipt");
+    if (receiptFrame?.type === "receipt") {
+      expect(receiptFrame.originalFrameId).toBe(receiptRequestId);
+      expect(receiptFrame.status).toBe("processed_by_openclaw");
+      expect(receiptFrame.toAgentDid).toBe(RECIPIENT_AGENT_DID);
     }
   });
 

--- a/apps/proxy/src/agent-relay-session/AGENTS.md
+++ b/apps/proxy/src/agent-relay-session/AGENTS.md
@@ -9,7 +9,7 @@
 - Keep connector frame send + in-flight ack tracking in `delivery.ts`.
 - Keep websocket frame/close/error dispatch in `websocket.ts`.
 - Keep socket liveness/heartbeat/pending-close tracking in `socket-tracker.ts`.
-- Keep frame construction/parsing helpers in `frames.ts`; do not duplicate frame payload logic in `core.ts`.
+- Keep frame construction/parsing helpers in `frames.ts`; do not duplicate deliver/enqueue/receipt frame payload logic in `core.ts`.
 - Keep queue receipt normalization/pruning/upsert/delete behavior in `queue-state.ts`.
 - Keep retry delay math in `policy.ts` and alarm scheduling in `scheduler.ts`.
 - Keep request payload validation in `parsers.ts` and RPC error envelopes in `rpc.ts`.
@@ -20,3 +20,4 @@
 - Prefer extracting concrete collaborators (queue management, connector delivery transport, and RPC wiring) so `core.ts` stays a high-level orchestrator with well-defined dependencies.
 - When adding new helpers, document the exported signatures and the direction of dependencies (e.g., `core.ts` → `queue-manager` → `queue-state`, `core.ts` → `rpc-handlers` → `parsers`).
 - Preserve the existing request/queue/workflow contracts; refactors should not change how RPC paths, receipt state, or delivery retries behave.
+- Receipt persistence must support sender-notification flows: recording a `processed_by_openclaw`/`dead_lettered` receipt may create a new receipt row (sender DO) and should emit websocket `receipt` frames to active sockets.

--- a/apps/proxy/src/agent-relay-session/core.ts
+++ b/apps/proxy/src/agent-relay-session/core.ts
@@ -16,6 +16,7 @@ import {
 import { RelayDeliveryTransport } from "./delivery.js";
 import { RelayQueueFullError } from "./errors.js";
 import {
+  toReceiptFramePayload,
   toRelayDeliveryInputFromEnqueueFrame,
   toRelayDeliveryResult,
 } from "./frames.js";
@@ -305,23 +306,45 @@ export class AgentRelaySession {
     const nowMs = nowUtcMs();
     const queueState = await this.queueManager.loadQueueState(nowMs);
     const existing = queueState.receipts[input.requestId];
-    if (existing === undefined) {
-      return;
-    }
-
     if (
-      existing.senderAgentDid !== input.senderAgentDid ||
-      existing.recipientAgentDid !== input.recipientAgentDid
+      existing !== undefined &&
+      (existing.senderAgentDid !== input.senderAgentDid ||
+        existing.recipientAgentDid !== input.recipientAgentDid)
     ) {
       return;
     }
 
-    existing.state = input.status;
-    existing.reason = input.reason;
-    existing.expiresAtMs = nowMs + this.deliveryPolicy.queueTtlMs;
-    existing.statusUpdatedAt = toIso(nowMs);
+    const previousState = existing?.state;
+    const previousReason = existing?.reason;
+
+    const receipt =
+      existing ??
+      ({
+        deliveryId: generateUlid(nowMs),
+        requestId: input.requestId,
+        senderAgentDid: input.senderAgentDid,
+        recipientAgentDid: input.recipientAgentDid,
+      } as const);
+
+    queueState.receipts[input.requestId] = {
+      ...receipt,
+      state: input.status,
+      reason: input.reason,
+      expiresAtMs: nowMs + this.deliveryPolicy.queueTtlMs,
+      statusUpdatedAt: toIso(nowMs),
+    };
     await this.queueManager.saveQueueState(queueState);
     await this.queueManager.scheduleNextAlarm(queueState, nowMs);
+
+    if (previousState !== input.status || previousReason !== input.reason) {
+      this.pushReceiptFrameToActiveSockets({
+        nowMs,
+        originalFrameId: input.requestId,
+        reason: input.reason,
+        status: input.status,
+        toAgentDid: input.recipientAgentDid,
+      });
+    }
   }
 
   async getDeliveryReceipt(
@@ -439,6 +462,7 @@ export class AgentRelaySession {
     this.rememberSocketAgentDid(server, connectorAgentDid);
     this.socketTracker.touchSocketAck(server, nowMs);
     void this.queueManager.drainQueueOnReconnect(nowMs);
+    void this.drainReceiptFramesOnReconnect(nowMs);
 
     return new Response(null, {
       status: 101,
@@ -556,6 +580,55 @@ export class AgentRelaySession {
 
   private closeSocket(socket: WebSocket, code: number, reason: string): void {
     this.socketTracker.closeSocket(socket, code, reason);
+  }
+
+  private pushReceiptFrameToActiveSockets(input: {
+    nowMs: number;
+    originalFrameId: string;
+    reason?: string;
+    status: "processed_by_openclaw" | "dead_lettered";
+    toAgentDid: string;
+  }): void {
+    const payload = toReceiptFramePayload({
+      nowMs: input.nowMs,
+      originalFrameId: input.originalFrameId,
+      reason: input.reason,
+      status: input.status,
+      toAgentDid: input.toAgentDid,
+    });
+    for (const socket of this.getActiveSockets(input.nowMs)) {
+      try {
+        socket.send(payload);
+      } catch {
+        // Best-effort notification; socket health is enforced by heartbeat sweeps.
+      }
+    }
+  }
+
+  private async drainReceiptFramesOnReconnect(nowMs: number): Promise<void> {
+    const sockets = this.getActiveSockets(nowMs);
+    if (sockets.length === 0) {
+      return;
+    }
+
+    const queueState = await this.queueManager.loadQueueState(nowMs);
+    for (const receipt of Object.values(queueState.receipts)) {
+      if (
+        receipt.expiresAtMs <= nowMs ||
+        (receipt.state !== "processed_by_openclaw" &&
+          receipt.state !== "dead_lettered")
+      ) {
+        continue;
+      }
+
+      this.pushReceiptFrameToActiveSockets({
+        nowMs,
+        originalFrameId: receipt.requestId,
+        reason: receipt.reason,
+        status: receipt.state,
+        toAgentDid: receipt.recipientAgentDid,
+      });
+    }
   }
 }
 

--- a/apps/proxy/src/agent-relay-session/frames.ts
+++ b/apps/proxy/src/agent-relay-session/frames.ts
@@ -4,6 +4,7 @@ import {
   type EnqueueAckFrame,
   type EnqueueFrame,
   type HeartbeatAckFrame,
+  type ReceiptFrame,
   serializeFrame,
 } from "@clawdentity/connector";
 import { generateUlid } from "@clawdentity/protocol";
@@ -75,6 +76,27 @@ export function toEnqueueAckFrame(input: {
   };
 
   return serializeFrame(ackFrame);
+}
+
+export function toReceiptFramePayload(input: {
+  originalFrameId: string;
+  toAgentDid: string;
+  status: "processed_by_openclaw" | "dead_lettered";
+  reason?: string;
+  nowMs: number;
+}): string {
+  const receiptFrame: ReceiptFrame = {
+    v: CONNECTOR_FRAME_VERSION,
+    type: "receipt",
+    id: generateUlid(input.nowMs),
+    ts: toIso(input.nowMs),
+    originalFrameId: input.originalFrameId,
+    toAgentDid: input.toAgentDid,
+    status: input.status,
+    reason: input.reason,
+  };
+
+  return serializeFrame(receiptFrame);
 }
 
 export function toRelayDeliveryInputFromEnqueueFrame(input: {

--- a/apps/proxy/src/queue-consumer/AGENTS.md
+++ b/apps/proxy/src/queue-consumer/AGENTS.md
@@ -1,0 +1,11 @@
+# AGENTS.md (apps/proxy/src/queue-consumer)
+
+## Purpose
+- Keep queue-consumer event parsing and routing deterministic, strict, and easy to audit.
+
+## Rules
+- Parse queue payloads with explicit field validation; reject malformed messages early so retries/DLQ behavior is intentional.
+- Keep each event handler focused by event type (`delivery_receipt`, `agent.auth.*`) and avoid mixing multiple workflows in one function.
+- Route `delivery_receipt` events to the sender relay Durable Object using typed RPC helpers (`recordRelayDeliveryReceipt`) rather than ad-hoc `fetch` payload strings.
+- Treat queue events as at-least-once: handlers must be idempotent against duplicate messages.
+- Keep the `delivery_receipt` queue contract minimal (sender/recipient/request/status/reason/timestamp) and avoid carrying callback-origin metadata that is not consumed by handlers.

--- a/apps/proxy/src/queue-consumer/receipt-events.test.ts
+++ b/apps/proxy/src/queue-consumer/receipt-events.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  DELIVERY_RECEIPT_EVENT_TYPE,
+  handleReceiptQueueEvent,
+  parseReceiptQueueEvent,
+} from "./receipt-events.js";
+
+describe("receipt queue events", () => {
+  it("parses valid delivery receipt events", () => {
+    const event = parseReceiptQueueEvent({
+      type: DELIVERY_RECEIPT_EVENT_TYPE,
+      requestId: "req-1",
+      senderAgentDid:
+        "did:cdi:registry.clawdentity.dev:agent:01HF7YAT31JZHSMW1CG6Q6MHB7",
+      recipientAgentDid:
+        "did:cdi:registry.clawdentity.dev:agent:01HF7YAT00EXEKCZ140TBBFB97",
+      status: "processed_by_openclaw",
+    });
+
+    expect(event.type).toBe("delivery_receipt");
+    expect(event.status).toBe("processed_by_openclaw");
+  });
+
+  it("rejects invalid delivery receipt status", () => {
+    expect(() =>
+      parseReceiptQueueEvent({
+        type: DELIVERY_RECEIPT_EVENT_TYPE,
+        requestId: "req-2",
+        senderAgentDid:
+          "did:cdi:registry.clawdentity.dev:agent:01HF7YAT31JZHSMW1CG6Q6MHB7",
+        recipientAgentDid:
+          "did:cdi:registry.clawdentity.dev:agent:01HF7YAT00EXEKCZ140TBBFB97",
+        status: "delivered",
+      }),
+    ).toThrow("Unsupported receipt queue status");
+  });
+
+  it("routes queue receipt events to sender relay durable object", async () => {
+    const fetchSpy = vi.fn(async (_request: Request) =>
+      Response.json({ accepted: true }, { status: 202 }),
+    );
+    const relaySessionNamespace = {
+      idFromName: vi.fn((name: string) => name as unknown as DurableObjectId),
+      get: vi.fn(() => ({
+        fetch: fetchSpy,
+      })),
+    };
+
+    await handleReceiptQueueEvent({
+      event: parseReceiptQueueEvent({
+        type: DELIVERY_RECEIPT_EVENT_TYPE,
+        requestId: "req-3",
+        senderAgentDid:
+          "did:cdi:registry.clawdentity.dev:agent:01HF7YAT31JZHSMW1CG6Q6MHB7",
+        recipientAgentDid:
+          "did:cdi:registry.clawdentity.dev:agent:01HF7YAT00EXEKCZ140TBBFB97",
+        status: "dead_lettered",
+        reason: "hook failed",
+      }),
+      relaySessionNamespace,
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const request = fetchSpy.mock.calls[0]?.[0] as Request;
+    expect(new URL(request.url).pathname).toBe("/rpc/record-delivery-receipt");
+    const payload = (await request.json()) as {
+      requestId?: string;
+      status?: string;
+      reason?: string;
+    };
+    expect(payload).toMatchObject({
+      requestId: "req-3",
+      status: "dead_lettered",
+      reason: "hook failed",
+    });
+  });
+});

--- a/apps/proxy/src/queue-consumer/receipt-events.ts
+++ b/apps/proxy/src/queue-consumer/receipt-events.ts
@@ -1,0 +1,79 @@
+import {
+  type AgentRelaySessionNamespace,
+  recordRelayDeliveryReceipt,
+} from "../agent-relay-session.js";
+
+export const DELIVERY_RECEIPT_EVENT_TYPE = "delivery_receipt";
+
+export type ReceiptQueueEvent = {
+  type: typeof DELIVERY_RECEIPT_EVENT_TYPE;
+  requestId: string;
+  senderAgentDid: string;
+  recipientAgentDid: string;
+  status: "processed_by_openclaw" | "dead_lettered";
+  reason?: string;
+  processedAt?: string;
+};
+
+function ensureNonBlankString(value: unknown, field: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`Missing or invalid receipt queue field: ${field}`);
+  }
+  return value.trim();
+}
+
+export function parseReceiptQueueEvent(payload: unknown): ReceiptQueueEvent {
+  if (typeof payload !== "object" || payload === null) {
+    throw new Error("Receipt queue event payload must be an object");
+  }
+  const input = payload as Partial<ReceiptQueueEvent>;
+  if (input.type !== DELIVERY_RECEIPT_EVENT_TYPE) {
+    throw new Error("Unsupported receipt queue event type");
+  }
+
+  return {
+    type: DELIVERY_RECEIPT_EVENT_TYPE,
+    requestId: ensureNonBlankString(input.requestId, "requestId"),
+    senderAgentDid: ensureNonBlankString(
+      input.senderAgentDid,
+      "senderAgentDid",
+    ),
+    recipientAgentDid: ensureNonBlankString(
+      input.recipientAgentDid,
+      "recipientAgentDid",
+    ),
+    status:
+      input.status === "processed_by_openclaw" ||
+      input.status === "dead_lettered"
+        ? input.status
+        : (() => {
+            throw new Error("Unsupported receipt queue status");
+          })(),
+    reason:
+      typeof input.reason === "string" && input.reason.trim().length > 0
+        ? input.reason.trim()
+        : undefined,
+    processedAt:
+      typeof input.processedAt === "string" &&
+      input.processedAt.trim().length > 0
+        ? input.processedAt.trim()
+        : undefined,
+  };
+}
+
+export async function handleReceiptQueueEvent(input: {
+  event: ReceiptQueueEvent;
+  relaySessionNamespace: AgentRelaySessionNamespace;
+}): Promise<void> {
+  const relaySession = input.relaySessionNamespace.get(
+    input.relaySessionNamespace.idFromName(input.event.senderAgentDid),
+  );
+
+  await recordRelayDeliveryReceipt(relaySession, {
+    requestId: input.event.requestId,
+    senderAgentDid: input.event.senderAgentDid,
+    recipientAgentDid: input.event.recipientAgentDid,
+    status: input.event.status,
+    reason: input.event.reason,
+  });
+}

--- a/apps/proxy/src/relay-delivery-receipt-route.test.ts
+++ b/apps/proxy/src/relay-delivery-receipt-route.test.ts
@@ -139,6 +139,23 @@ function createApp(input: {
   });
 }
 
+function createReceiptQueueHarness() {
+  const sentMessages: string[] = [];
+  return {
+    sentMessages,
+    queue: {
+      send: vi.fn(async (body: string) => {
+        sentMessages.push(body);
+      }),
+      sendBatch: vi.fn(async (messages: MessageSendRequest<string>[]) => {
+        for (const message of messages) {
+          sentMessages.push(message.body);
+        }
+      }),
+    } as unknown as Queue<string>,
+  };
+}
+
 describe("relay delivery receipt route", () => {
   it("accepts POST receipt updates for authenticated recipient", async () => {
     const relayHarness = createRelayReceiptHarness();
@@ -180,6 +197,55 @@ describe("relay delivery receipt route", () => {
     expect(relayHarness.recordInputs).toHaveLength(1);
     expect(relayHarness.recordInputs[0]?.requestId).toBe("req-1");
     expect(relayHarness.recordInputs[0]?.status).toBe("processed_by_openclaw");
+  });
+
+  it("publishes receipt events to queue when RECEIPT_QUEUE binding is configured", async () => {
+    const relayHarness = createRelayReceiptHarness();
+    const queueHarness = createReceiptQueueHarness();
+    const app = createApp({
+      allowedPairs: [
+        {
+          initiator:
+            "did:cdi:registry.clawdentity.dev:agent:01HF7YAT31JZHSMW1CG6Q6MHB7",
+          responder:
+            "did:cdi:registry.clawdentity.dev:agent:01HF7YAT00EXEKCZ140TBBFB97",
+        },
+      ],
+    });
+
+    const response = await app.request(
+      RELAY_DELIVERY_RECEIPTS_PATH,
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-claw-agent-access": "token",
+        },
+        body: JSON.stringify({
+          requestId: "req-queue-1",
+          senderAgentDid:
+            "did:cdi:registry.clawdentity.dev:agent:01HF7YAT31JZHSMW1CG6Q6MHB7",
+          recipientAgentDid:
+            "did:cdi:registry.clawdentity.dev:agent:01HF7YAT00EXEKCZ140TBBFB97",
+          status: "processed_by_openclaw",
+        }),
+      },
+      {
+        AGENT_RELAY_SESSION: relayHarness.namespace,
+        RECEIPT_QUEUE: queueHarness.queue,
+      },
+    );
+
+    expect(response.status).toBe(202);
+    expect(queueHarness.sentMessages).toHaveLength(1);
+    const queued = JSON.parse(queueHarness.sentMessages[0] ?? "{}") as {
+      type?: string;
+      requestId?: string;
+      status?: string;
+    };
+    expect(queued.type).toBe("delivery_receipt");
+    expect(queued.requestId).toBe("req-queue-1");
+    expect(queued.status).toBe("processed_by_openclaw");
   });
 
   it("rejects POST when recipient differs from authenticated agent DID", async () => {

--- a/apps/proxy/src/relay-delivery-receipt-route.ts
+++ b/apps/proxy/src/relay-delivery-receipt-route.ts
@@ -1,4 +1,5 @@
-import { AppError, type Logger } from "@clawdentity/sdk";
+import { RELAY_DELIVERY_RECEIPTS_PATH } from "@clawdentity/protocol";
+import { AppError, type Logger, nowIso } from "@clawdentity/sdk";
 import type { Context } from "hono";
 import {
   type AgentRelaySessionNamespace,
@@ -9,14 +10,16 @@ import {
 } from "./agent-relay-session.js";
 import type { ProxyRequestVariables } from "./auth-middleware.js";
 import type { ProxyTrustStore } from "./proxy-trust-store.js";
+import { DELIVERY_RECEIPT_EVENT_TYPE } from "./queue-consumer/receipt-events.js";
 import { assertTrustedPair } from "./trust-policy.js";
 
-export { RELAY_DELIVERY_RECEIPTS_PATH } from "@clawdentity/protocol";
+export { RELAY_DELIVERY_RECEIPTS_PATH };
 
 type ProxyContext = Context<{
   Variables: ProxyRequestVariables;
   Bindings: {
     AGENT_RELAY_SESSION?: AgentRelaySessionNamespace;
+    RECEIPT_QUEUE?: Queue<string>;
   };
 }>;
 
@@ -114,8 +117,8 @@ export function createRelayDeliveryReceiptPostHandler(
       });
     }
 
-    const payload = parseRecordInput(await c.req.json());
-    if (payload.recipientAgentDid !== auth.agentDid) {
+    const parsedPayload = parseRecordInput(await c.req.json());
+    if (parsedPayload.recipientAgentDid !== auth.agentDid) {
       throw new AppError({
         code: "PROXY_RELAY_RECEIPT_FORBIDDEN",
         message: "Recipient DID does not match authenticated agent",
@@ -126,17 +129,17 @@ export function createRelayDeliveryReceiptPostHandler(
 
     await assertTrustedPair({
       trustStore: input.trustStore,
-      initiatorAgentDid: payload.senderAgentDid,
-      responderAgentDid: payload.recipientAgentDid,
+      initiatorAgentDid: parsedPayload.senderAgentDid,
+      responderAgentDid: parsedPayload.recipientAgentDid,
     });
 
     const sessionNamespace = resolveSessionNamespace(c);
     const relaySession = sessionNamespace.get(
-      sessionNamespace.idFromName(payload.recipientAgentDid),
+      sessionNamespace.idFromName(parsedPayload.recipientAgentDid),
     );
 
     try {
-      await recordRelayDeliveryReceipt(relaySession, payload);
+      await recordRelayDeliveryReceipt(relaySession, parsedPayload);
     } catch (error) {
       if (error instanceof RelaySessionDeliveryError) {
         input.logger.warn("proxy.relay.receipt_record_failed", {
@@ -149,6 +152,32 @@ export function createRelayDeliveryReceiptPostHandler(
         message: "Failed to record relay delivery receipt",
         status: 502,
       });
+    }
+
+    const receiptQueue = c.env.RECEIPT_QUEUE;
+    if (receiptQueue !== undefined) {
+      try {
+        await receiptQueue.send(
+          JSON.stringify({
+            type: DELIVERY_RECEIPT_EVENT_TYPE,
+            requestId: parsedPayload.requestId,
+            senderAgentDid: parsedPayload.senderAgentDid,
+            recipientAgentDid: parsedPayload.recipientAgentDid,
+            status: parsedPayload.status,
+            reason: parsedPayload.reason,
+            processedAt: nowIso(),
+          }),
+        );
+      } catch (error) {
+        input.logger.warn("proxy.relay.receipt_queue_publish_failed", {
+          reason: error instanceof Error ? error.message : String(error),
+        });
+        throw new AppError({
+          code: "PROXY_RELAY_RECEIPT_QUEUE_FAILED",
+          message: "Failed to queue relay delivery receipt",
+          status: 502,
+        });
+      }
     }
 
     return c.json({ accepted: true }, 202);

--- a/apps/proxy/src/server.ts
+++ b/apps/proxy/src/server.ts
@@ -91,6 +91,7 @@ export type ProxyApp = Hono<{
     AGENT_RELAY_SESSION?: AgentRelaySessionNamespace;
     PROXY_TRUST_STATE?: object;
     NONCE_REPLAY_GUARD?: NonceReplayGuardNamespace;
+    RECEIPT_QUEUE?: Queue<string>;
   };
   Variables: ProxyRequestVariables;
 }>;
@@ -166,6 +167,7 @@ export function createProxyApp(options: CreateProxyAppOptions): ProxyApp {
       AGENT_RELAY_SESSION?: AgentRelaySessionNamespace;
       PROXY_TRUST_STATE?: object;
       NONCE_REPLAY_GUARD?: NonceReplayGuardNamespace;
+      RECEIPT_QUEUE?: Queue<string>;
     };
     Variables: ProxyRequestVariables;
   }>();

--- a/apps/proxy/src/worker.test.ts
+++ b/apps/proxy/src/worker.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import type { AgentRelaySessionStub } from "./agent-relay-session.js";
 import { PROXY_VERSION } from "./index.js";
 import { type ProxyWorkerBindings, worker } from "./worker.js";
 
@@ -48,6 +49,25 @@ function createRelaySessionNamespace(): NonNullable<
   ProxyWorkerBindings["AGENT_RELAY_SESSION"]
 > {
   return {} as NonNullable<ProxyWorkerBindings["AGENT_RELAY_SESSION"]>;
+}
+
+function createRelaySessionNamespaceWithFetchSpy(
+  fetchSpy: ReturnType<typeof vi.fn>,
+): NonNullable<ProxyWorkerBindings["AGENT_RELAY_SESSION"]> {
+  const invokeFetchSpy = fetchSpy as unknown as (
+    request: Request,
+  ) => Promise<Response>;
+  const relayStub: AgentRelaySessionStub = {
+    fetch: async (request: Request) => invokeFetchSpy(request),
+  };
+
+  return {
+    idFromName: vi.fn(
+      (name: string) =>
+        ({ toString: () => name }) as unknown as DurableObjectId,
+    ),
+    get: vi.fn(() => relayStub),
+  };
 }
 
 function createRequiredBindings(
@@ -283,5 +303,83 @@ describe("proxy worker", () => {
     expect(
       payload.error.details.fieldErrors?.BOOTSTRAP_INTERNAL_SERVICE_SECRET?.[0],
     ).toBe("BOOTSTRAP_INTERNAL_SERVICE_SECRET is required");
+  });
+
+  it("routes delivery_receipt queue events to sender relay session", async () => {
+    const fetchSpy = vi.fn(async (_request: Request) =>
+      Response.json({ accepted: true }, { status: 202 }),
+    );
+    const bindings = createRequiredBindings({
+      AGENT_RELAY_SESSION: createRelaySessionNamespaceWithFetchSpy(fetchSpy),
+    });
+    const ack = vi.fn();
+    const retry = vi.fn();
+    const queueBatch = {
+      messages: [
+        {
+          body: JSON.stringify({
+            type: "delivery_receipt",
+            requestId: "req-queue-2",
+            senderAgentDid:
+              "did:cdi:registry.clawdentity.dev:agent:01HF7YAT31JZHSMW1CG6Q6MHB7",
+            recipientAgentDid:
+              "did:cdi:registry.clawdentity.dev:agent:01HF7YAT00EXEKCZ140TBBFB97",
+            status: "dead_lettered",
+            reason: "hook failed",
+          }),
+          ack,
+          retry,
+        },
+      ],
+    } as unknown as MessageBatch<string>;
+
+    await worker.queue(queueBatch, bindings);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const request = fetchSpy.mock.calls[0]?.[0] as Request;
+    expect(request.method).toBe("POST");
+    expect(new URL(request.url).pathname).toBe("/rpc/record-delivery-receipt");
+    const body = (await request.json()) as {
+      requestId?: string;
+      senderAgentDid?: string;
+      recipientAgentDid?: string;
+      status?: string;
+      reason?: string;
+    };
+    expect(body).toMatchObject({
+      requestId: "req-queue-2",
+      status: "dead_lettered",
+      reason: "hook failed",
+    });
+    expect(ack).toHaveBeenCalledTimes(1);
+    expect(retry).not.toHaveBeenCalled();
+  });
+
+  it("does not ack unsupported queue event types", async () => {
+    const fetchSpy = vi.fn();
+    const bindings = createRequiredBindings({
+      AGENT_RELAY_SESSION: createRelaySessionNamespaceWithFetchSpy(fetchSpy),
+    });
+    const ack = vi.fn();
+    const retry = vi.fn();
+    const queueBatch = {
+      messages: [
+        {
+          body: JSON.stringify({
+            type: "agent.auth.created",
+            agentDid:
+              "did:cdi:registry.clawdentity.dev:agent:01HF7YAT31JZHSMW1CG6Q6MHB7",
+          }),
+          ack,
+          retry,
+        },
+      ],
+    } as unknown as MessageBatch<string>;
+
+    await worker.queue(queueBatch, bindings);
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(ack).not.toHaveBeenCalled();
+    expect(retry).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/proxy/src/worker.ts
+++ b/apps/proxy/src/worker.ts
@@ -15,6 +15,11 @@ import { NonceReplayGuard } from "./nonce-replay-guard.js";
 import type { NonceReplayGuardNamespace } from "./nonce-replay-store.js";
 import { ProxyTrustState } from "./proxy-trust-state.js";
 import type { ProxyTrustStateNamespace } from "./proxy-trust-store.js";
+import {
+  DELIVERY_RECEIPT_EVENT_TYPE,
+  handleReceiptQueueEvent,
+  parseReceiptQueueEvent,
+} from "./queue-consumer/receipt-events.js";
 import { createProxyApp, type ProxyApp } from "./server.js";
 import { resolveWorkerTrustStore } from "./trust-store-backend.js";
 
@@ -49,6 +54,7 @@ export type ProxyWorkerBindings = {
   RELAY_MAX_FRAME_BYTES?: string;
   APP_VERSION?: string;
   PROXY_VERSION?: string;
+  RECEIPT_QUEUE?: Queue<string>;
   [key: string]: unknown;
 };
 
@@ -195,6 +201,43 @@ const worker = {
         },
         { status: 500 },
       );
+    }
+  },
+  async queue(
+    batch: MessageBatch<string>,
+    env: ProxyWorkerBindings,
+  ): Promise<void> {
+    for (const message of batch.messages) {
+      try {
+        const parsed =
+          typeof message.body === "string" ? JSON.parse(message.body) : null;
+        if (typeof parsed !== "object" || parsed === null) {
+          throw new Error("Queue message body must be a JSON object");
+        }
+
+        const eventType = (parsed as { type?: unknown }).type;
+        if (eventType !== DELIVERY_RECEIPT_EVENT_TYPE) {
+          throw new Error("Unsupported queue event type");
+        }
+
+        const relaySessionNamespace = env.AGENT_RELAY_SESSION;
+        if (relaySessionNamespace === undefined) {
+          throw new Error("Relay session namespace is unavailable");
+        }
+
+        const event = parseReceiptQueueEvent(parsed);
+        await handleReceiptQueueEvent({
+          event,
+          relaySessionNamespace,
+        });
+
+        message.ack();
+      } catch (error) {
+        logger.warn("proxy.queue.message_failed", {
+          reason: error instanceof Error ? error.message : String(error),
+        });
+        message.retry();
+      }
     }
   },
 };

--- a/apps/proxy/wrangler.jsonc
+++ b/apps/proxy/wrangler.jsonc
@@ -45,6 +45,28 @@
   "env": {
     "local": {
       "name": "clawdentity-proxy-local",
+      "queues": {
+        "producers": [
+          {
+            "binding": "RECEIPT_QUEUE",
+            "queue": "clawdentity-receipts-local"
+          }
+        ],
+        "consumers": [
+          {
+            "queue": "clawdentity-events-local",
+            "max_batch_size": 25,
+            "max_batch_timeout": 5,
+            "dead_letter_queue": "clawdentity-events-dlq-local"
+          },
+          {
+            "queue": "clawdentity-receipts-local",
+            "max_batch_size": 25,
+            "max_batch_timeout": 5,
+            "dead_letter_queue": "clawdentity-receipts-dlq-local"
+          }
+        ]
+      },
       "durable_objects": {
         "bindings": [
           {
@@ -89,6 +111,28 @@
     },
     "dev": {
       "name": "clawdentity-proxy-dev",
+      "queues": {
+        "producers": [
+          {
+            "binding": "RECEIPT_QUEUE",
+            "queue": "clawdentity-receipts-dev"
+          }
+        ],
+        "consumers": [
+          {
+            "queue": "clawdentity-events-dev",
+            "max_batch_size": 25,
+            "max_batch_timeout": 5,
+            "dead_letter_queue": "clawdentity-events-dlq-dev"
+          },
+          {
+            "queue": "clawdentity-receipts-dev",
+            "max_batch_size": 25,
+            "max_batch_timeout": 5,
+            "dead_letter_queue": "clawdentity-receipts-dlq-dev"
+          }
+        ]
+      },
       "routes": [
         {
           "pattern": "dev.proxy.clawdentity.com",
@@ -138,6 +182,28 @@
     },
     "production": {
       "name": "clawdentity-proxy",
+      "queues": {
+        "producers": [
+          {
+            "binding": "RECEIPT_QUEUE",
+            "queue": "clawdentity-receipts"
+          }
+        ],
+        "consumers": [
+          {
+            "queue": "clawdentity-events",
+            "max_batch_size": 25,
+            "max_batch_timeout": 5,
+            "dead_letter_queue": "clawdentity-events-dlq"
+          },
+          {
+            "queue": "clawdentity-receipts",
+            "max_batch_size": 25,
+            "max_batch_timeout": 5,
+            "dead_letter_queue": "clawdentity-receipts-dlq"
+          }
+        ]
+      },
       "observability": {
         "enabled": true,
         "logs": {

--- a/crates/clawdentity-cli/src/commands/AGENTS.md
+++ b/crates/clawdentity-cli/src/commands/AGENTS.md
@@ -9,6 +9,7 @@
 - Any command that mixes blocking filesystem or blocking HTTP with async runtime must isolate the blocking work with `spawn_blocking` or an equivalent boundary.
 - Connector startup must refresh websocket auth headers on reconnect instead of caching one signed timestamp for the life of the process.
 - Connector -> OpenClaw hook payloads must send top-level `message`; keep `content` only as a compatibility alias, never as the sole field, and mirror user-visible wake text into `message` when targeting `/hooks/wake`.
+- Connector receipt notifications must also satisfy OpenClaw hook contracts: `/hooks/agent` needs `message`, `/hooks/wake` needs `text`, with structured receipt metadata preserved alongside the summary text.
 - OpenClaw peer-delivery defaults must stay aligned with visible UX: `/hooks/wake` for inbound relay traffic, with sender context rendered into `text`; reserve `/hooks/agent` for explicit isolated-hook workflows.
 - Connector inbound failure handling must not leave stale `inbound_pending` rows forever: successful redelivery must clear pending state, and retry/backoff must either reschedule or dead-letter exhausted items.
 - If inbound delivery fails but the connector successfully persists the frame for local retry, ACK the relay as accepted so only one retry path exists.

--- a/crates/clawdentity-cli/src/commands/connector.rs
+++ b/crates/clawdentity-cli/src/commands/connector.rs
@@ -28,7 +28,8 @@ use delivery::{run_inbound_loop, run_inbound_retry_loop};
 
 #[cfg(test)]
 use delivery::{
-    build_deliver_ack_reason, build_openclaw_hook_payload, should_dead_letter_after_failure,
+    build_deliver_ack_reason, build_openclaw_hook_payload, build_openclaw_receipt_payload,
+    should_dead_letter_after_failure,
 };
 
 #[derive(Debug, Subcommand)]

--- a/crates/clawdentity-cli/src/commands/connector/AGENTS.md
+++ b/crates/clawdentity-cli/src/commands/connector/AGENTS.md
@@ -8,3 +8,4 @@
 - If inbound delivery is persisted for local retry, ACK the relay as accepted so the retry path stays single-source.
 - Wake payloads must only include `sessionId` when the inbound payload explicitly carries one.
 - `/hooks/wake` remains the visible default for peer delivery; `/hooks/agent` is only for explicit isolated-hook routing.
+- Keep hook payload builders split into focused helpers so the structural 50-line non-test function rule stays green.

--- a/crates/clawdentity-cli/src/commands/connector/delivery.rs
+++ b/crates/clawdentity-cli/src/commands/connector/delivery.rs
@@ -430,46 +430,67 @@ async fn forward_receipt_to_openclaw(
 
 pub(super) fn build_openclaw_receipt_payload(hook_path: &str, receipt: &ReceiptFrame) -> Value {
     let summary = render_receipt_summary(receipt);
-    let receipt_json = json!({
-        "type": "clawdentity:receipt",
-        "originalFrameId": receipt.original_frame_id,
-        "toAgentDid": receipt.to_agent_did,
-        "status": match receipt.status {
-            ReceiptStatus::ProcessedByOpenclaw => "processed_by_openclaw",
-            ReceiptStatus::DeadLettered => "dead_lettered",
-        },
-        "reason": receipt.reason,
-        "timestamp": receipt.ts,
-    });
+    let status = receipt_status_slug(&receipt.status);
+    let receipt_json = build_receipt_metadata(receipt, status);
 
     if normalize_hook_path(hook_path) == "/hooks/wake" {
-        return json!({
-            "type": "clawdentity:receipt",
-            "originalFrameId": receipt.original_frame_id,
-            "toAgentDid": receipt.to_agent_did,
-            "status": match receipt.status {
-                ReceiptStatus::ProcessedByOpenclaw => "processed_by_openclaw",
-                ReceiptStatus::DeadLettered => "dead_lettered",
-            },
-            "reason": receipt.reason,
-            "timestamp": receipt.ts,
-            "text": summary,
-            "message": summary,
-            "mode": "now",
-            "metadata": {
-                "receipt": receipt_json,
-            },
-        });
+        return build_openclaw_wake_receipt_payload(receipt, status, &summary, &receipt_json);
     }
 
+    build_openclaw_agent_receipt_payload(receipt, status, &summary, &receipt_json)
+}
+
+fn receipt_status_slug(status: &ReceiptStatus) -> &'static str {
+    match status {
+        ReceiptStatus::ProcessedByOpenclaw => "processed_by_openclaw",
+        ReceiptStatus::DeadLettered => "dead_lettered",
+    }
+}
+
+fn build_receipt_metadata(receipt: &ReceiptFrame, status: &str) -> Value {
     json!({
         "type": "clawdentity:receipt",
         "originalFrameId": receipt.original_frame_id,
         "toAgentDid": receipt.to_agent_did,
-        "status": match receipt.status {
-            ReceiptStatus::ProcessedByOpenclaw => "processed_by_openclaw",
-            ReceiptStatus::DeadLettered => "dead_lettered",
+        "status": status,
+        "reason": receipt.reason,
+        "timestamp": receipt.ts,
+    })
+}
+
+fn build_openclaw_wake_receipt_payload(
+    receipt: &ReceiptFrame,
+    status: &str,
+    summary: &str,
+    receipt_json: &Value,
+) -> Value {
+    json!({
+        "type": "clawdentity:receipt",
+        "originalFrameId": receipt.original_frame_id,
+        "toAgentDid": receipt.to_agent_did,
+        "status": status,
+        "reason": receipt.reason,
+        "timestamp": receipt.ts,
+        "text": summary,
+        "message": summary,
+        "mode": "now",
+        "metadata": {
+            "receipt": receipt_json,
         },
+    })
+}
+
+fn build_openclaw_agent_receipt_payload(
+    receipt: &ReceiptFrame,
+    status: &str,
+    summary: &str,
+    receipt_json: &Value,
+) -> Value {
+    json!({
+        "type": "clawdentity:receipt",
+        "originalFrameId": receipt.original_frame_id,
+        "toAgentDid": receipt.to_agent_did,
+        "status": status,
         "reason": receipt.reason,
         "timestamp": receipt.ts,
         "message": summary,

--- a/crates/clawdentity-cli/src/commands/connector/delivery.rs
+++ b/crates/clawdentity-cli/src/commands/connector/delivery.rs
@@ -10,7 +10,8 @@ use clawdentity_core::http::client as create_http_client;
 use clawdentity_core::runtime_openclaw::OpenclawRuntimeConfig;
 use clawdentity_core::{
     CONNECTOR_FRAME_VERSION, ConnectorClient, ConnectorClientSender, ConnectorFrame,
-    DeliverAckFrame, DeliverFrame, EnqueueAckFrame, SqliteStore, new_frame_id, now_iso,
+    DeliverAckFrame, DeliverFrame, EnqueueAckFrame, ReceiptFrame, ReceiptStatus, SqliteStore,
+    new_frame_id, now_iso,
 };
 use serde_json::{Value, json};
 use tokio::sync::watch;
@@ -76,6 +77,19 @@ async fn handle_connector_frame(
                 deliver,
             )
             .await;
+        }
+        ConnectorFrame::Receipt(receipt) => {
+            if let Err(error) =
+                forward_receipt_to_openclaw(http_client, hook_url, openclaw_runtime, &receipt)
+                    .await
+            {
+                tracing::warn!(
+                    error = %error,
+                    request_id = %receipt.original_frame_id,
+                    status = ?receipt.status,
+                    "failed to forward receipt payload to OpenClaw hook"
+                );
+            }
         }
         ConnectorFrame::EnqueueAck(ack) => log_enqueue_ack(&ack),
         _ => {}
@@ -370,6 +384,125 @@ pub(super) fn build_openclaw_hook_payload(hook_path: &str, deliver: &DeliverFram
     }
 
     build_openclaw_agent_payload(deliver)
+}
+
+async fn forward_receipt_to_openclaw(
+    http_client: &reqwest::Client,
+    hook_url: &str,
+    openclaw_runtime: &OpenclawRuntimeConfig,
+    receipt: &ReceiptFrame,
+) -> Result<()> {
+    let mut request = http_client
+        .post(hook_url)
+        .header("content-type", "application/json")
+        .header(
+            "x-clawdentity-content-type",
+            "application/vnd.clawdentity.receipt+json",
+        )
+        .header("x-clawdentity-to-agent-did", &receipt.to_agent_did)
+        .header("x-request-id", &receipt.original_frame_id)
+        .json(&build_openclaw_receipt_payload(
+            &openclaw_runtime.hook_path,
+            receipt,
+        ));
+
+    if let Some(token) = openclaw_runtime
+        .hook_token
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        request = request.header("x-openclaw-token", token);
+    }
+
+    let response = request
+        .send()
+        .await
+        .map_err(|error| anyhow!("openclaw receipt hook request failed: {error}"))?;
+    if !response.status().is_success() {
+        return Err(anyhow!(
+            "openclaw receipt hook returned HTTP {}",
+            response.status()
+        ));
+    }
+    Ok(())
+}
+
+pub(super) fn build_openclaw_receipt_payload(hook_path: &str, receipt: &ReceiptFrame) -> Value {
+    let summary = render_receipt_summary(receipt);
+    let receipt_json = json!({
+        "type": "clawdentity:receipt",
+        "originalFrameId": receipt.original_frame_id,
+        "toAgentDid": receipt.to_agent_did,
+        "status": match receipt.status {
+            ReceiptStatus::ProcessedByOpenclaw => "processed_by_openclaw",
+            ReceiptStatus::DeadLettered => "dead_lettered",
+        },
+        "reason": receipt.reason,
+        "timestamp": receipt.ts,
+    });
+
+    if normalize_hook_path(hook_path) == "/hooks/wake" {
+        return json!({
+            "type": "clawdentity:receipt",
+            "originalFrameId": receipt.original_frame_id,
+            "toAgentDid": receipt.to_agent_did,
+            "status": match receipt.status {
+                ReceiptStatus::ProcessedByOpenclaw => "processed_by_openclaw",
+                ReceiptStatus::DeadLettered => "dead_lettered",
+            },
+            "reason": receipt.reason,
+            "timestamp": receipt.ts,
+            "text": summary,
+            "message": summary,
+            "mode": "now",
+            "metadata": {
+                "receipt": receipt_json,
+            },
+        });
+    }
+
+    json!({
+        "type": "clawdentity:receipt",
+        "originalFrameId": receipt.original_frame_id,
+        "toAgentDid": receipt.to_agent_did,
+        "status": match receipt.status {
+            ReceiptStatus::ProcessedByOpenclaw => "processed_by_openclaw",
+            ReceiptStatus::DeadLettered => "dead_lettered",
+        },
+        "reason": receipt.reason,
+        "timestamp": receipt.ts,
+        "message": summary,
+        "content": summary,
+        "metadata": {
+            "receipt": receipt_json,
+        },
+    })
+}
+
+fn render_receipt_summary(receipt: &ReceiptFrame) -> String {
+    let mut lines = vec![
+        format!(
+            "Clawdentity delivery receipt: {}",
+            match receipt.status {
+                ReceiptStatus::ProcessedByOpenclaw => "processed_by_openclaw",
+                ReceiptStatus::DeadLettered => "dead_lettered",
+            }
+        ),
+        String::new(),
+        format!("Request ID: {}", receipt.original_frame_id),
+        format!("Recipient DID: {}", receipt.to_agent_did),
+    ];
+    if let Some(reason) = receipt
+        .reason
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        lines.push(format!("Reason: {reason}"));
+    }
+    lines.push(format!("Timestamp: {}", receipt.ts));
+    lines.join("\n")
 }
 
 fn build_openclaw_agent_payload(deliver: &DeliverFrame) -> Value {

--- a/crates/clawdentity-cli/src/commands/connector/tests.rs
+++ b/crates/clawdentity-cli/src/commands/connector/tests.rs
@@ -1,12 +1,13 @@
 use anyhow::anyhow;
 use chrono::{Duration as ChronoDuration, Utc};
-use clawdentity_core::DeliverFrame;
+use clawdentity_core::{DeliverFrame, ReceiptFrame, ReceiptStatus};
 use clawdentity_core::agent::AgentAuthRecord;
 use serde_json::json;
 
 use super::runtime_config::{agent_access_requires_refresh, normalize_proxy_ws_url};
 use super::{
-    build_deliver_ack_reason, build_openclaw_hook_payload, normalize_hook_path,
+    build_deliver_ack_reason, build_openclaw_hook_payload, build_openclaw_receipt_payload,
+    normalize_hook_path,
     should_dead_letter_after_failure,
 };
 
@@ -220,6 +221,60 @@ fn openclaw_wake_payload_prefers_message_field_from_sender_transform() {
         Some(
             "Clawdentity peer message from did:cdi:test:agent:sender\n\nplain peer text\n\nRequest ID: req-5"
         )
+    );
+}
+
+#[test]
+fn openclaw_receipt_payload_uses_message_field_for_agent_hooks() {
+    let receipt = ReceiptFrame {
+        v: 1,
+        id: "receipt-1".to_string(),
+        ts: "2026-03-20T05:55:00Z".to_string(),
+        original_frame_id: "req-6".to_string(),
+        to_agent_did: "did:cdi:test:agent:recipient".to_string(),
+        status: ReceiptStatus::DeadLettered,
+        reason: Some("hook failed".to_string()),
+    };
+
+    let payload = build_openclaw_receipt_payload("/hooks/agent", &receipt);
+    assert_eq!(
+        payload.get("type").and_then(|value| value.as_str()),
+        Some("clawdentity:receipt")
+    );
+    assert_eq!(
+        payload.get("status").and_then(|value| value.as_str()),
+        Some("dead_lettered")
+    );
+    assert_eq!(
+        payload.get("message").and_then(|value| value.as_str()),
+        payload.get("content").and_then(|value| value.as_str())
+    );
+}
+
+#[test]
+fn openclaw_receipt_payload_uses_text_for_wake_hooks() {
+    let receipt = ReceiptFrame {
+        v: 1,
+        id: "receipt-2".to_string(),
+        ts: "2026-03-20T05:55:00Z".to_string(),
+        original_frame_id: "req-7".to_string(),
+        to_agent_did: "did:cdi:test:agent:recipient".to_string(),
+        status: ReceiptStatus::ProcessedByOpenclaw,
+        reason: None,
+    };
+
+    let payload = build_openclaw_receipt_payload("/hooks/wake", &receipt);
+    assert_eq!(
+        payload.get("status").and_then(|value| value.as_str()),
+        Some("processed_by_openclaw")
+    );
+    assert_eq!(
+        payload.get("mode").and_then(|value| value.as_str()),
+        Some("now")
+    );
+    assert_eq!(
+        payload.get("message").and_then(|value| value.as_str()),
+        payload.get("text").and_then(|value| value.as_str())
     );
 }
 

--- a/crates/clawdentity-core/src/connector/AGENTS.md
+++ b/crates/clawdentity-core/src/connector/AGENTS.md
@@ -10,6 +10,7 @@
 - Connector websocket reconnects must rebuild signed auth headers on every dial attempt; never reuse stale `X-Claw-Timestamp` / nonce material across reconnects.
 - OpenClaw inbound relay delivery must preserve user-visible chat behavior: prefer `/hooks/wake`-style main-session ingress for peer messages, and only use isolated `/hooks/agent` flows when the product explicitly wants a separate hook session.
 - Keep Rust connector frame contracts aligned with TypeScript: when adding frame variants (for example `receipt`), update serde tags, validation, exports, and tests in the same change.
+- Keep individual non-test functions under the structural 50-line limit by extracting frame-specific validation helpers instead of expanding central dispatch functions.
 - Keep connector helpers `clippy -D warnings` clean, especially `format!` calls that can use inline named arguments.
 - Keep connector runtime contracts backward compatible with published OpenClaw relay transform payloads unless a coordinated release updates both sides.
 - Keep websocket client dependencies compiled with TLS support; production proxy connectivity requires `wss://` and must never rely on plaintext-only websocket builds.

--- a/crates/clawdentity-core/src/connector/AGENTS.md
+++ b/crates/clawdentity-core/src/connector/AGENTS.md
@@ -9,6 +9,7 @@
 - Service install/uninstall must stay idempotent across macOS launchd and Linux systemd.
 - Connector websocket reconnects must rebuild signed auth headers on every dial attempt; never reuse stale `X-Claw-Timestamp` / nonce material across reconnects.
 - OpenClaw inbound relay delivery must preserve user-visible chat behavior: prefer `/hooks/wake`-style main-session ingress for peer messages, and only use isolated `/hooks/agent` flows when the product explicitly wants a separate hook session.
+- Keep Rust connector frame contracts aligned with TypeScript: when adding frame variants (for example `receipt`), update serde tags, validation, exports, and tests in the same change.
 - Keep connector helpers `clippy -D warnings` clean, especially `format!` calls that can use inline named arguments.
 - Keep connector runtime contracts backward compatible with published OpenClaw relay transform payloads unless a coordinated release updates both sides.
 - Keep websocket client dependencies compiled with TLS support; production proxy connectivity requires `wss://` and must never rely on plaintext-only websocket builds.

--- a/crates/clawdentity-core/src/connector/frames.rs
+++ b/crates/clawdentity-core/src/connector/frames.rs
@@ -133,60 +133,67 @@ fn validate_agent_did(value: &str, field_name: &str) -> Result<()> {
     Ok(())
 }
 
+fn validate_ack_frame(
+    version: i64,
+    id: &str,
+    ts: &str,
+    ack_id: &str,
+    label: &str,
+) -> Result<()> {
+    validate_frame_base(version, id, ts)?;
+    Ulid::from_string(ack_id)
+        .map_err(|_| CoreError::InvalidInput(format!("invalid {label} ackId: {ack_id}")))?;
+    Ok(())
+}
+
+fn validate_deliver_frame(frame: &DeliverFrame) -> Result<()> {
+    validate_frame_base(frame.v, &frame.id, &frame.ts)?;
+    validate_agent_did(&frame.from_agent_did, "fromAgentDid")?;
+    validate_agent_did(&frame.to_agent_did, "toAgentDid")?;
+    Ok(())
+}
+
+fn validate_enqueue_frame(frame: &EnqueueFrame) -> Result<()> {
+    validate_frame_base(frame.v, &frame.id, &frame.ts)?;
+    validate_agent_did(&frame.to_agent_did, "toAgentDid")?;
+    Ok(())
+}
+
+fn validate_receipt_frame(frame: &ReceiptFrame) -> Result<()> {
+    validate_frame_base(frame.v, &frame.id, &frame.ts)?;
+    Ulid::from_string(&frame.original_frame_id).map_err(|_| {
+        CoreError::InvalidInput(format!(
+            "invalid receipt originalFrameId: {}",
+            frame.original_frame_id
+        ))
+    })?;
+    validate_agent_did(&frame.to_agent_did, "toAgentDid")?;
+    if let Some(reason) = &frame.reason
+        && reason.trim().is_empty()
+    {
+        return Err(CoreError::InvalidInput(
+            "receipt reason must not be blank".to_string(),
+        ));
+    }
+    Ok(())
+}
+
 /// TODO(clawdentity): document `validate_frame`.
 pub fn validate_frame(frame: &ConnectorFrame) -> Result<()> {
     match frame {
         ConnectorFrame::Heartbeat(frame) => validate_frame_base(frame.v, &frame.id, &frame.ts),
         ConnectorFrame::HeartbeatAck(frame) => {
-            validate_frame_base(frame.v, &frame.id, &frame.ts)?;
-            Ulid::from_string(&frame.ack_id).map_err(|_| {
-                CoreError::InvalidInput(format!("invalid heartbeat ackId: {}", frame.ack_id))
-            })?;
-            Ok(())
+            validate_ack_frame(frame.v, &frame.id, &frame.ts, &frame.ack_id, "heartbeat")
         }
-        ConnectorFrame::Deliver(frame) => {
-            validate_frame_base(frame.v, &frame.id, &frame.ts)?;
-            validate_agent_did(&frame.from_agent_did, "fromAgentDid")?;
-            validate_agent_did(&frame.to_agent_did, "toAgentDid")?;
-            Ok(())
-        }
+        ConnectorFrame::Deliver(frame) => validate_deliver_frame(frame),
         ConnectorFrame::DeliverAck(frame) => {
-            validate_frame_base(frame.v, &frame.id, &frame.ts)?;
-            Ulid::from_string(&frame.ack_id).map_err(|_| {
-                CoreError::InvalidInput(format!("invalid deliver ackId: {}", frame.ack_id))
-            })?;
-            Ok(())
+            validate_ack_frame(frame.v, &frame.id, &frame.ts, &frame.ack_id, "deliver")
         }
-        ConnectorFrame::Enqueue(frame) => {
-            validate_frame_base(frame.v, &frame.id, &frame.ts)?;
-            validate_agent_did(&frame.to_agent_did, "toAgentDid")?;
-            Ok(())
-        }
+        ConnectorFrame::Enqueue(frame) => validate_enqueue_frame(frame),
         ConnectorFrame::EnqueueAck(frame) => {
-            validate_frame_base(frame.v, &frame.id, &frame.ts)?;
-            Ulid::from_string(&frame.ack_id).map_err(|_| {
-                CoreError::InvalidInput(format!("invalid enqueue ackId: {}", frame.ack_id))
-            })?;
-            Ok(())
+            validate_ack_frame(frame.v, &frame.id, &frame.ts, &frame.ack_id, "enqueue")
         }
-        ConnectorFrame::Receipt(frame) => {
-            validate_frame_base(frame.v, &frame.id, &frame.ts)?;
-            Ulid::from_string(&frame.original_frame_id).map_err(|_| {
-                CoreError::InvalidInput(format!(
-                    "invalid receipt originalFrameId: {}",
-                    frame.original_frame_id
-                ))
-            })?;
-            validate_agent_did(&frame.to_agent_did, "toAgentDid")?;
-            if let Some(reason) = &frame.reason
-                && reason.trim().is_empty()
-            {
-                return Err(CoreError::InvalidInput(
-                    "receipt reason must not be blank".to_string(),
-                ));
-            }
-            Ok(())
-        }
+        ConnectorFrame::Receipt(frame) => validate_receipt_frame(frame),
     }
 }
 

--- a/crates/clawdentity-core/src/connector/frames.rs
+++ b/crates/clawdentity-core/src/connector/frames.rs
@@ -15,6 +15,7 @@ pub enum ConnectorFrame {
     DeliverAck(DeliverAckFrame),
     Enqueue(EnqueueFrame),
     EnqueueAck(EnqueueAckFrame),
+    Receipt(ReceiptFrame),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -89,6 +90,27 @@ pub struct EnqueueAckFrame {
     pub reason: Option<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReceiptStatus {
+    ProcessedByOpenclaw,
+    DeadLettered,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReceiptFrame {
+    pub v: i64,
+    pub id: String,
+    pub ts: String,
+    #[serde(rename = "originalFrameId")]
+    pub original_frame_id: String,
+    #[serde(rename = "toAgentDid")]
+    pub to_agent_did: String,
+    pub status: ReceiptStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
 fn validate_frame_base(version: i64, id: &str, ts: &str) -> Result<()> {
     if version != CONNECTOR_FRAME_VERSION {
         return Err(CoreError::InvalidInput(format!(
@@ -147,6 +169,24 @@ pub fn validate_frame(frame: &ConnectorFrame) -> Result<()> {
             })?;
             Ok(())
         }
+        ConnectorFrame::Receipt(frame) => {
+            validate_frame_base(frame.v, &frame.id, &frame.ts)?;
+            Ulid::from_string(&frame.original_frame_id).map_err(|_| {
+                CoreError::InvalidInput(format!(
+                    "invalid receipt originalFrameId: {}",
+                    frame.original_frame_id
+                ))
+            })?;
+            validate_agent_did(&frame.to_agent_did, "toAgentDid")?;
+            if let Some(reason) = &frame.reason
+                && reason.trim().is_empty()
+            {
+                return Err(CoreError::InvalidInput(
+                    "receipt reason must not be blank".to_string(),
+                ));
+            }
+            Ok(())
+        }
     }
 }
 
@@ -181,8 +221,8 @@ pub fn new_frame_id() -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        CONNECTOR_FRAME_VERSION, ConnectorFrame, EnqueueFrame, new_frame_id, now_iso, parse_frame,
-        serialize_frame,
+        CONNECTOR_FRAME_VERSION, ConnectorFrame, EnqueueFrame, ReceiptFrame, ReceiptStatus,
+        new_frame_id, now_iso, parse_frame, serialize_frame,
     };
 
     #[test]
@@ -196,6 +236,24 @@ mod tests {
             payload: serde_json::json!({"text":"hello"}),
             conversation_id: Some("conv-1".to_string()),
             reply_to: None,
+        });
+
+        let encoded = serialize_frame(&frame).expect("serialize");
+        let decoded = parse_frame(encoded).expect("parse");
+        assert_eq!(decoded, frame);
+    }
+
+    #[test]
+    fn serialize_and_parse_receipt_frame() {
+        let frame = ConnectorFrame::Receipt(ReceiptFrame {
+            v: CONNECTOR_FRAME_VERSION,
+            id: new_frame_id(),
+            ts: now_iso(),
+            original_frame_id: new_frame_id(),
+            to_agent_did: "did:cdi:registry.clawdentity.com:agent:01HF7YAT00W6W7CM7N3W5FDXT4"
+                .to_string(),
+            status: ReceiptStatus::DeadLettered,
+            reason: Some("hook rejected".to_string()),
         });
 
         let encoded = serialize_frame(&frame).expect("serialize");

--- a/crates/clawdentity-core/src/lib.rs
+++ b/crates/clawdentity-core/src/lib.rs
@@ -67,8 +67,8 @@ pub use connector_client::{
 };
 pub use connector_frames::{
     CONNECTOR_FRAME_VERSION, ConnectorFrame, DeliverAckFrame, DeliverFrame, EnqueueAckFrame,
-    EnqueueFrame, HeartbeatAckFrame, HeartbeatFrame, new_frame_id, now_iso, parse_frame,
-    serialize_frame, validate_frame,
+    EnqueueFrame, HeartbeatAckFrame, HeartbeatFrame, ReceiptFrame, ReceiptStatus, new_frame_id,
+    now_iso, parse_frame, serialize_frame, validate_frame,
 };
 pub use crl::{
     CRL_CACHE_TTL_MS, CrlClaims, CrlRevocation, CrlVerificationKey, is_jti_revoked, load_crl_claims,

--- a/crates/tests/local/mock-proxy/src/AGENTS.md
+++ b/crates/tests/local/mock-proxy/src/AGENTS.md
@@ -10,3 +10,4 @@
 ## Relay Harness
 - Preserve simple in-memory routing/queue behavior for deterministic tests.
 - Keep websocket/session behavior minimal and explicit; avoid hidden side effects.
+- Keep `handle_client_frame` exhaustive for all `ConnectorFrame` variants so protocol additions fail fast in review, not in CI.

--- a/crates/tests/local/mock-proxy/src/relay.rs
+++ b/crates/tests/local/mock-proxy/src/relay.rs
@@ -196,6 +196,11 @@ async fn handle_client_frame(
         ConnectorFrame::HeartbeatAck(_) => {}
         ConnectorFrame::EnqueueAck(_) => {}
         ConnectorFrame::DeliverAck(_) => {}
+        ConnectorFrame::Receipt(receipt) => {
+            let target_did = receipt.to_agent_did.clone();
+            let _ =
+                route_or_queue_frame(state, &target_did, ConnectorFrame::Receipt(receipt)).await;
+        }
     }
 }
 

--- a/packages/connector/src/AGENTS.md
+++ b/packages/connector/src/AGENTS.md
@@ -5,7 +5,7 @@
 - Keep `client.ts` as the stable public surface (`ConnectorClient` + exported client types) and route internal concerns through `client/` modules:
   - `client/types.ts` for externally consumed client types.
   - `client/helpers.ts` for shared pure helpers (event parsing, sanitization, normalization).
-  - `client/inbound.ts` for parsed frame dispatch orchestration (`heartbeat`, `heartbeat_ack`, `deliver`).
+  - `client/inbound.ts` for parsed frame dispatch orchestration (`heartbeat`, `heartbeat_ack`, `deliver`, `receipt`).
   - `client/metrics.ts` for websocket uptime/reconnect and inbound ack-latency tracking.
   - `client/retry.ts` for reusable backoff math.
   - `client/heartbeat.ts` for heartbeat scheduling, ack tracking, and RTT metrics.
@@ -66,7 +66,8 @@
   - `POST /v1/inbound/dead-letter/replay`
   - `POST /v1/inbound/dead-letter/purge`
 - For dead-letter replay/purge targeting, treat omitted `requestIds` as "all", but treat `requestIds: []` (or empty after sanitization) as a no-op.
-- For replay delivery callbacks, post signed receipts to peer proxies using `replyTo` with statuses `processed_by_openclaw` and `dead_lettered`, but only when `replyTo` points to trusted peer proxy origins and the relay receipt path.
+- For replay delivery callbacks, post signed receipts directly to the validated `replyTo` target (`/v1/relay/delivery-receipts`) and enforce trusted origin checks before sending.
+- Receipt frame status values remain `processed_by_openclaw` and `dead_lettered`; do not widen status enums without coordinated proxy/runtime changes.
 
 ## WebSocket Resilience Rules
 - Keep websocket reconnect behavior centralized in `client.ts` (single cleanup path for close/error/unexpected-response/timeout).

--- a/packages/connector/src/client.test/delivery.test.ts
+++ b/packages/connector/src/client.test/delivery.test.ts
@@ -316,4 +316,49 @@ describe("ConnectorClient delivery and heartbeat frames", () => {
 
     client.disconnect();
   });
+
+  it("routes inbound receipt frames to receipt hooks", async () => {
+    const { sockets, webSocketFactory } = createMockWebSocketFactory();
+    const onReceipt = vi.fn();
+
+    const client = new ConnectorClient({
+      connectorUrl: "wss://connector.example.com/agent",
+      openclawBaseUrl: "http://127.0.0.1:18789",
+      heartbeatIntervalMs: 0,
+      hooks: {
+        onReceipt,
+      },
+      webSocketFactory,
+    });
+
+    client.connect();
+    sockets[0].open();
+
+    const receiptId = generateUlid(1700000000000);
+    const originalFrameId = generateUlid(1700000000100);
+    sockets[0].message(
+      serializeFrame({
+        v: 1,
+        type: "receipt",
+        id: receiptId,
+        ts: "2026-01-01T00:00:00.000Z",
+        originalFrameId,
+        toAgentDid: createAgentDid(1700000000200),
+        status: "processed_by_openclaw",
+      }),
+    );
+
+    await vi.waitFor(() => {
+      expect(onReceipt).toHaveBeenCalledTimes(1);
+    });
+    expect(sockets[0].sent).toHaveLength(0);
+    expect(onReceipt.mock.calls[0]?.[0]).toMatchObject({
+      type: "receipt",
+      id: receiptId,
+      originalFrameId,
+      status: "processed_by_openclaw",
+    });
+
+    client.disconnect();
+  });
 });

--- a/packages/connector/src/client/inbound-router.ts
+++ b/packages/connector/src/client/inbound-router.ts
@@ -4,6 +4,7 @@ import type {
   ConnectorFrame,
   DeliverFrame,
   HeartbeatAckFrame,
+  ReceiptFrame,
 } from "../frames.js";
 import type { LocalOpenclawDeliveryClient } from "./delivery.js";
 import type { ConnectorHeartbeatManager } from "./heartbeat.js";
@@ -61,6 +62,9 @@ export async function routeConnectorInboundMessage(options: {
           },
           recordAckLatency: options.recordAckLatency,
         });
+      },
+      onReceiptFrame: async (frame: ReceiptFrame) => {
+        await options.hooks.onReceipt?.(frame);
       },
     },
   });

--- a/packages/connector/src/client/inbound.ts
+++ b/packages/connector/src/client/inbound.ts
@@ -5,6 +5,7 @@ import {
   type HeartbeatAckFrame,
   type HeartbeatFrame,
   parseFrame,
+  type ReceiptFrame,
 } from "../frames.js";
 import { sanitizeErrorReason } from "./helpers.js";
 
@@ -13,6 +14,7 @@ type ConnectorInboundMessageHandlers = {
   onHeartbeatFrame: (frame: HeartbeatFrame) => void;
   onHeartbeatAckFrame: (frame: HeartbeatAckFrame) => void;
   onDeliverFrame: (frame: DeliverFrame) => Promise<void>;
+  onReceiptFrame: (frame: ReceiptFrame) => Promise<void>;
 };
 
 type HandleIncomingConnectorMessageInput = {
@@ -49,5 +51,10 @@ export async function handleIncomingConnectorMessage(
 
   if (frame.type === "deliver") {
     await input.handlers.onDeliverFrame(frame);
+    return;
+  }
+
+  if (frame.type === "receipt") {
+    await input.handlers.onReceiptFrame(frame);
   }
 }

--- a/packages/connector/src/client/types.ts
+++ b/packages/connector/src/client/types.ts
@@ -1,4 +1,9 @@
-import type { ConnectorFrame, DeliverFrame, EnqueueFrame } from "../frames.js";
+import type {
+  ConnectorFrame,
+  DeliverFrame,
+  EnqueueFrame,
+  ReceiptFrame,
+} from "../frames.js";
 
 export type ConnectorWebSocketEventType =
   | "open"
@@ -33,6 +38,7 @@ export type ConnectorClientHooks = {
   onFrame?: (frame: ConnectorFrame) => void;
   onDeliverSucceeded?: (frame: DeliverFrame) => void;
   onDeliverFailed?: (frame: DeliverFrame, error: unknown) => void;
+  onReceipt?: (frame: ReceiptFrame) => void | Promise<void>;
 };
 
 export type ConnectorOutboundQueuePersistence = {

--- a/packages/connector/src/frames.test.ts
+++ b/packages/connector/src/frames.test.ts
@@ -85,6 +85,24 @@ describe("connector frame parsing", () => {
     }
   });
 
+  it("roundtrips a valid receipt frame", () => {
+    const frame = {
+      v: 1 as const,
+      type: "receipt" as const,
+      id: generateUlid(1700000000000),
+      ts: "2026-01-01T00:00:00.000Z",
+      originalFrameId: generateUlid(1700000000100),
+      toAgentDid: createAgentDid(1700000000200),
+      status: "dead_lettered" as const,
+      reason: "OpenClaw hook rejected after max attempts",
+    };
+
+    const serialized = serializeFrame(frame);
+    const parsed = parseFrame(serialized);
+
+    expect(parsed).toEqual(frame);
+  });
+
   it("rejects unknown frame type", () => {
     expect(() =>
       parseFrame({
@@ -106,6 +124,20 @@ describe("connector frame parsing", () => {
         ackId: generateUlid(1700000000100),
         accepted: false,
         reason: "   ",
+      }),
+    ).toThrow(ConnectorFrameParseError);
+  });
+
+  it("rejects invalid receipt status values", () => {
+    expect(() =>
+      parseFrame({
+        v: 1,
+        type: "receipt",
+        id: generateUlid(1700000000000),
+        ts: "2026-01-01T00:00:00.000Z",
+        originalFrameId: generateUlid(1700000000100),
+        toAgentDid: createAgentDid(1700000000200),
+        status: "delivered",
       }),
     ).toThrow(ConnectorFrameParseError);
   });

--- a/packages/connector/src/frames.ts
+++ b/packages/connector/src/frames.ts
@@ -12,6 +12,7 @@ const FRAME_TYPES = [
   "deliver_ack",
   "enqueue",
   "enqueue_ack",
+  "receipt",
 ] as const;
 
 export const connectorFrameTypeSchema = z.enum(FRAME_TYPES);
@@ -113,6 +114,18 @@ export const enqueueAckFrameSchema = frameBaseSchema
   })
   .strict();
 
+const receiptStatusSchema = z.enum(["processed_by_openclaw", "dead_lettered"]);
+
+export const receiptFrameSchema = frameBaseSchema
+  .extend({
+    type: z.literal("receipt"),
+    originalFrameId: ulidStringSchema,
+    toAgentDid: agentDidSchema,
+    status: receiptStatusSchema,
+    reason: nonEmptyStringSchema.optional(),
+  })
+  .strict();
+
 export const connectorFrameSchema = z.discriminatedUnion("type", [
   heartbeatFrameSchema,
   heartbeatAckFrameSchema,
@@ -120,6 +133,7 @@ export const connectorFrameSchema = z.discriminatedUnion("type", [
   deliverAckFrameSchema,
   enqueueFrameSchema,
   enqueueAckFrameSchema,
+  receiptFrameSchema,
 ]);
 
 export type HeartbeatFrame = z.infer<typeof heartbeatFrameSchema>;
@@ -128,6 +142,7 @@ export type DeliverFrame = z.infer<typeof deliverFrameSchema>;
 export type DeliverAckFrame = z.infer<typeof deliverAckFrameSchema>;
 export type EnqueueFrame = z.infer<typeof enqueueFrameSchema>;
 export type EnqueueAckFrame = z.infer<typeof enqueueAckFrameSchema>;
+export type ReceiptFrame = z.infer<typeof receiptFrameSchema>;
 
 export type ConnectorFrame = z.infer<typeof connectorFrameSchema>;
 

--- a/packages/connector/src/index.ts
+++ b/packages/connector/src/index.ts
@@ -53,6 +53,7 @@ export type {
   EnqueueFrame,
   HeartbeatAckFrame,
   HeartbeatFrame,
+  ReceiptFrame,
 } from "./frames.js";
 export {
   ConnectorFrameParseError,
@@ -65,6 +66,7 @@ export {
   heartbeatAckFrameSchema,
   heartbeatFrameSchema,
   parseFrame,
+  receiptFrameSchema,
   serializeFrame,
 } from "./frames.js";
 export type {

--- a/packages/connector/src/runtime.receipt.test.ts
+++ b/packages/connector/src/runtime.receipt.test.ts
@@ -1,0 +1,334 @@
+import { randomBytes } from "node:crypto";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  encodeBase64url,
+  generateUlid,
+  makeAgentDid,
+  makeHumanDid,
+} from "@clawdentity/protocol";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { WebSocketServer } from "ws";
+import { serializeFrame } from "./frames.js";
+import { startConnectorRuntime } from "./runtime.js";
+
+type Sandbox = {
+  cleanup: () => void;
+  rootDir: string;
+};
+
+type WsHarness = {
+  cleanup: () => Promise<void>;
+  sendReceiptFrame: (input: {
+    requestId: string;
+    status: "processed_by_openclaw" | "dead_lettered";
+    toAgentDid?: string;
+    reason?: string;
+  }) => Promise<void>;
+  wsUrl: string;
+};
+
+const DID_AUTHORITY = "registry.example.test";
+const ENV_KEYS = [
+  "CONNECTOR_INBOUND_REPLAY_INTERVAL_MS",
+  "CONNECTOR_OPENCLAW_PROBE_INTERVAL_MS",
+  "CONNECTOR_OPENCLAW_PROBE_TIMEOUT_MS",
+] as const;
+
+function createSandbox(): Sandbox {
+  const rootDir = mkdtempSync(join(tmpdir(), "clawdentity-connector-runtime-"));
+  mkdirSync(join(rootDir, "agents", "alpha"), { recursive: true });
+
+  return {
+    rootDir,
+    cleanup: () => {
+      rmSync(rootDir, { force: true, recursive: true });
+    },
+  };
+}
+
+async function findAvailablePort(): Promise<number> {
+  return await new Promise<number>((resolve, reject) => {
+    const server = createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (address === null || typeof address === "string") {
+        reject(new Error("Unable to allocate test port"));
+        return;
+      }
+
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve(address.port);
+      });
+    });
+  });
+}
+
+async function createWsHarness(port: number): Promise<WsHarness> {
+  const wss = new WebSocketServer({
+    host: "127.0.0.1",
+    path: "/v1/relay/connect",
+    port,
+  });
+
+  let socket: import("ws").WebSocket | undefined;
+
+  const connectedPromise = new Promise<void>((resolve) => {
+    wss.on("connection", (ws) => {
+      socket = ws;
+      resolve();
+    });
+  });
+
+  const sendReceiptFrame = async (input: {
+    requestId: string;
+    status: "processed_by_openclaw" | "dead_lettered";
+    toAgentDid?: string;
+    reason?: string;
+  }): Promise<void> => {
+    await connectedPromise;
+    if (socket === undefined) {
+      throw new Error("WebSocket connection was not established");
+    }
+
+    socket.send(
+      serializeFrame({
+        v: 1,
+        type: "receipt",
+        id: generateUlid(1700000000200),
+        ts: "2026-02-20T00:00:00.000Z",
+        originalFrameId: input.requestId,
+        toAgentDid:
+          input.toAgentDid ?? makeAgentDid(DID_AUTHORITY, generateUlid(3)),
+        status: input.status,
+        reason: input.reason,
+      }),
+    );
+  };
+
+  return {
+    wsUrl: `ws://127.0.0.1:${port}/v1/relay/connect`,
+    sendReceiptFrame,
+    cleanup: async () => {
+      await new Promise<void>((resolve) => {
+        wss.close(() => resolve());
+      });
+    },
+  };
+}
+
+function createRuntimeAitToken(input: {
+  agentDid: string;
+  ownerDid: string;
+  issuer: string;
+}): string {
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  const payload = {
+    iss: input.issuer,
+    sub: input.agentDid,
+    ownerDid: input.ownerDid,
+    name: "alpha",
+    framework: "openclaw",
+    cnf: {
+      jwk: {
+        kty: "OKP" as const,
+        crv: "Ed25519" as const,
+        x: encodeBase64url(randomBytes(32)),
+      },
+    },
+    iat: nowSeconds,
+    nbf: nowSeconds,
+    exp: nowSeconds + 3600,
+    jti: generateUlid(nowSeconds * 1000),
+  };
+  const header = {
+    alg: "EdDSA",
+    typ: "AIT",
+    kid: "test-registry-kid",
+  };
+
+  return [
+    encodeBase64url(Buffer.from(JSON.stringify(header), "utf8")),
+    encodeBase64url(Buffer.from(JSON.stringify(payload), "utf8")),
+    "signature",
+  ].join(".");
+}
+
+function createRuntimeCredentials(input: { issuer?: string } = {}) {
+  const agentDid = makeAgentDid(DID_AUTHORITY, generateUlid(100));
+  const ownerDid = makeHumanDid(DID_AUTHORITY, generateUlid(101));
+
+  return {
+    agentDid,
+    ait: createRuntimeAitToken({
+      agentDid,
+      ownerDid,
+      issuer: input.issuer ?? "https://registry.example.test",
+    }),
+    secretKey: Buffer.from(randomBytes(32)).toString("base64url"),
+    accessToken: "access-token",
+    accessExpiresAt: "2100-01-01T00:00:00.000Z",
+    refreshToken: "refresh-token",
+    refreshExpiresAt: "2100-01-01T00:00:00.000Z",
+    tokenType: "Bearer" as const,
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const key of ENV_KEYS) {
+    delete process.env[key];
+  }
+});
+
+describe("startConnectorRuntime receipt forwarding", () => {
+  it("forwards receipt frames to /hooks/agent with OpenClaw-compatible payload", async () => {
+    process.env.CONNECTOR_INBOUND_REPLAY_INTERVAL_MS = "20";
+    process.env.CONNECTOR_OPENCLAW_PROBE_INTERVAL_MS = "25";
+    process.env.CONNECTOR_OPENCLAW_PROBE_TIMEOUT_MS = "20";
+
+    const sandbox = createSandbox();
+    const wsPort = await findAvailablePort();
+    const wsHarness = await createWsHarness(wsPort);
+    const outboundPort = await findAvailablePort();
+    const openclawBaseUrl = "http://127.0.0.1:39107";
+    const openclawHookUrl = `${openclawBaseUrl}/hooks/agent`;
+    const hookBodies: unknown[] = [];
+
+    const fetchMock = vi.fn<typeof fetch>(async (input, init) => {
+      const url = input instanceof URL ? input.toString() : String(input);
+      const method = init?.method ?? "GET";
+
+      if (method === "GET" && url === openclawBaseUrl) {
+        return new Response("ok", { status: 200 });
+      }
+
+      if (method === "POST" && url === openclawHookUrl) {
+        hookBodies.push(JSON.parse(String(init?.body ?? "{}")));
+        return new Response("ok", { status: 200 });
+      }
+
+      throw new Error(`Unexpected fetch call: ${method} ${url}`);
+    });
+
+    const runtime = await startConnectorRuntime({
+      agentName: "alpha",
+      configDir: sandbox.rootDir,
+      credentials: createRuntimeCredentials(),
+      fetchImpl: fetchMock,
+      openclawBaseUrl,
+      openclawHookPath: "/hooks/agent",
+      outboundBaseUrl: `http://127.0.0.1:${outboundPort}`,
+      proxyWebsocketUrl: wsHarness.wsUrl,
+    });
+
+    try {
+      const requestId = generateUlid(205);
+      await wsHarness.sendReceiptFrame({
+        requestId,
+        status: "dead_lettered",
+        reason: "hook rejected",
+      });
+
+      await vi.waitFor(() => {
+        expect(hookBodies).toHaveLength(1);
+      });
+
+      const payload = hookBodies[0] as {
+        type?: string;
+        message?: string;
+        content?: string;
+        status?: string;
+        originalFrameId?: string;
+        reason?: string;
+      };
+      expect(payload.type).toBe("clawdentity:receipt");
+      expect(payload.originalFrameId).toBe(requestId);
+      expect(payload.status).toBe("dead_lettered");
+      expect(payload.reason).toBe("hook rejected");
+      expect(payload.message).toContain("Clawdentity delivery receipt");
+      expect(payload.content).toContain("Clawdentity delivery receipt");
+    } finally {
+      await runtime.stop();
+      await wsHarness.cleanup();
+      sandbox.cleanup();
+    }
+  });
+
+  it("forwards receipt frames to /hooks/wake with required text field", async () => {
+    process.env.CONNECTOR_INBOUND_REPLAY_INTERVAL_MS = "20";
+    process.env.CONNECTOR_OPENCLAW_PROBE_INTERVAL_MS = "25";
+    process.env.CONNECTOR_OPENCLAW_PROBE_TIMEOUT_MS = "20";
+
+    const sandbox = createSandbox();
+    const wsPort = await findAvailablePort();
+    const wsHarness = await createWsHarness(wsPort);
+    const outboundPort = await findAvailablePort();
+    const openclawBaseUrl = "http://127.0.0.1:39108";
+    const openclawHookUrl = `${openclawBaseUrl}/hooks/wake`;
+    const hookBodies: unknown[] = [];
+
+    const fetchMock = vi.fn<typeof fetch>(async (input, init) => {
+      const url = input instanceof URL ? input.toString() : String(input);
+      const method = init?.method ?? "GET";
+
+      if (method === "GET" && url === openclawBaseUrl) {
+        return new Response("ok", { status: 200 });
+      }
+
+      if (method === "POST" && url === openclawHookUrl) {
+        hookBodies.push(JSON.parse(String(init?.body ?? "{}")));
+        return new Response("ok", { status: 200 });
+      }
+
+      throw new Error(`Unexpected fetch call: ${method} ${url}`);
+    });
+
+    const runtime = await startConnectorRuntime({
+      agentName: "alpha",
+      configDir: sandbox.rootDir,
+      credentials: createRuntimeCredentials(),
+      fetchImpl: fetchMock,
+      openclawBaseUrl,
+      openclawHookPath: "/hooks/wake",
+      outboundBaseUrl: `http://127.0.0.1:${outboundPort}`,
+      proxyWebsocketUrl: wsHarness.wsUrl,
+    });
+
+    try {
+      const requestId = generateUlid(206);
+      await wsHarness.sendReceiptFrame({
+        requestId,
+        status: "processed_by_openclaw",
+      });
+
+      await vi.waitFor(() => {
+        expect(hookBodies).toHaveLength(1);
+      });
+
+      const payload = hookBodies[0] as {
+        type?: string;
+        text?: string;
+        message?: string;
+        mode?: string;
+        status?: string;
+      };
+      expect(payload.type).toBe("clawdentity:receipt");
+      expect(payload.status).toBe("processed_by_openclaw");
+      expect(payload.mode).toBe("now");
+      expect(payload.text).toContain("Clawdentity delivery receipt");
+      expect(payload.message).toBe(payload.text);
+    } finally {
+      await runtime.stop();
+      await wsHarness.cleanup();
+      sandbox.cleanup();
+    }
+  });
+});

--- a/packages/connector/src/runtime.test.ts
+++ b/packages/connector/src/runtime.test.ts
@@ -28,6 +28,12 @@ type WsHarness = {
     fromAgentDid?: string;
     toAgentDid?: string;
   }) => Promise<void>;
+  sendReceiptFrame: (input: {
+    requestId: string;
+    status: "processed_by_openclaw" | "dead_lettered";
+    toAgentDid?: string;
+    reason?: string;
+  }) => Promise<void>;
   waitForDeliverAck: (requestId: string) => Promise<void>;
   wsUrl: string;
 };
@@ -145,9 +151,36 @@ async function createWsHarness(port: number): Promise<WsHarness> {
     );
   };
 
+  const sendReceiptFrame = async (input: {
+    requestId: string;
+    status: "processed_by_openclaw" | "dead_lettered";
+    toAgentDid?: string;
+    reason?: string;
+  }): Promise<void> => {
+    await connectedPromise;
+    if (socket === undefined) {
+      throw new Error("WebSocket connection was not established");
+    }
+
+    socket.send(
+      serializeFrame({
+        v: 1,
+        type: "receipt",
+        id: generateUlid(1700000000200),
+        ts: "2026-02-20T00:00:00.000Z",
+        originalFrameId: input.requestId,
+        toAgentDid:
+          input.toAgentDid ?? makeAgentDid(DID_AUTHORITY, generateUlid(3)),
+        status: input.status,
+        reason: input.reason,
+      }),
+    );
+  };
+
   return {
     wsUrl: `ws://127.0.0.1:${port}/v1/relay/connect`,
     sendDeliverFrame,
+    sendReceiptFrame,
     waitForDeliverAck,
     cleanup: async () => {
       await new Promise<void>((resolve) => {

--- a/packages/connector/src/runtime.ts
+++ b/packages/connector/src/runtime.ts
@@ -9,6 +9,7 @@ import { createConnectorInboundInbox } from "./inbound-inbox.js";
 import { createRuntimeAuthController } from "./runtime/auth-lifecycle.js";
 import { toInitialAuthBundle } from "./runtime/auth-storage.js";
 import { sanitizeErrorReason } from "./runtime/errors.js";
+import { deliverReceiptToOpenclawHook } from "./runtime/openclaw.js";
 import { createOpenclawHookTokenController } from "./runtime/openclaw-hook-token.js";
 import { createOpenclawGatewayProbeController } from "./runtime/openclaw-probe.js";
 import { createOutboundQueuePersistence } from "./runtime/outbound-queue.js";
@@ -204,6 +205,27 @@ export async function startConnectorRuntime(
               reason: sanitizeErrorReason(error),
             },
           );
+        }
+      },
+      onReceipt: async (frame) => {
+        try {
+          await deliverReceiptToOpenclawHook({
+            fetchImpl,
+            openclawHookUrl,
+            openclawHookToken:
+              openclawHookTokenController.getCurrentOpenclawHookToken(),
+            receipt: frame,
+            shutdownSignal: runtimeShutdownController.signal,
+          });
+        } catch (error) {
+          if (runtimeShutdownController.signal.aborted) {
+            return;
+          }
+          logger.warn("connector.receipt.delivery_failed", {
+            requestId: frame.originalFrameId,
+            status: frame.status,
+            reason: sanitizeErrorReason(error),
+          });
         }
       },
     },

--- a/packages/connector/src/runtime/AGENTS.md
+++ b/packages/connector/src/runtime/AGENTS.md
@@ -11,6 +11,7 @@
 - Keep gateway probe in-flight/health transitions in `openclaw-probe.ts`; avoid duplicate probe loops in `runtime.ts`.
 - Keep replay/probe policy loading and retry-delay calculations in `policy.ts`.
 - Keep replay orchestration and receipt callbacks in `replay.ts`; avoid re-embedding lane scheduling and dead-letter transitions in `runtime.ts`.
-- Keep outbound relay and receipt callbacks in `relay-service.ts`.
+- Keep outbound relay and receipt callbacks in `relay-service.ts`; receipt posts must target validated `replyTo` URLs directly and enforce trusted-origin checks.
 - Keep HTTP route handling in `server.ts` and avoid embedding route logic in helpers.
 - Keep URL/header/parse helpers focused in `url.ts`, `ws.ts`, and `parse.ts`.
+- Keep OpenClaw receipt payload shaping in `openclaw.ts` so `/hooks/agent` (`message`) and `/hooks/wake` (`text`) compatibility stays centralized.

--- a/packages/connector/src/runtime/openclaw.ts
+++ b/packages/connector/src/runtime/openclaw.ts
@@ -2,6 +2,7 @@ import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { Logger } from "@clawdentity/sdk";
 import { DEFAULT_OPENCLAW_DELIVER_TIMEOUT_MS } from "../constants.js";
+import type { ReceiptFrame } from "../frames.js";
 import { OPENCLAW_RELAY_RUNTIME_FILE_NAME } from "./constants.js";
 import { LocalOpenclawDeliveryError, sanitizeErrorReason } from "./errors.js";
 import { isRecord } from "./parse.js";
@@ -150,6 +151,131 @@ export async function deliverToOpenclawHook(input: {
       }
       throw new LocalOpenclawDeliveryError({
         message: "Local OpenClaw hook request timed out",
+        retryable: true,
+      });
+    }
+    if (error instanceof LocalOpenclawDeliveryError) {
+      throw error;
+    }
+    throw new LocalOpenclawDeliveryError({
+      message: sanitizeErrorReason(error),
+      retryable: true,
+    });
+  }
+}
+
+function renderReceiptSummary(receipt: ReceiptFrame): string {
+  const lines = [
+    `Clawdentity delivery receipt: ${receipt.status}`,
+    "",
+    `Request ID: ${receipt.originalFrameId}`,
+    `Recipient DID: ${receipt.toAgentDid}`,
+  ];
+  if (receipt.reason) {
+    lines.push(`Reason: ${receipt.reason}`);
+  }
+  lines.push(`Timestamp: ${receipt.ts}`);
+  return lines.join("\n");
+}
+
+function buildReceiptHookPayload(input: {
+  hookPathname: string;
+  receipt: ReceiptFrame;
+}): unknown {
+  const summary = renderReceiptSummary(input.receipt);
+  const payload = {
+    type: "clawdentity:receipt",
+    originalFrameId: input.receipt.originalFrameId,
+    toAgentDid: input.receipt.toAgentDid,
+    status: input.receipt.status,
+    reason: input.receipt.reason,
+    timestamp: input.receipt.ts,
+  };
+
+  if (input.hookPathname === "/hooks/wake") {
+    return {
+      ...payload,
+      text: summary,
+      message: summary,
+      mode: "now",
+      metadata: {
+        receipt: payload,
+      },
+    };
+  }
+
+  return {
+    ...payload,
+    message: summary,
+    content: summary,
+    metadata: {
+      receipt: payload,
+    },
+  };
+}
+
+export async function deliverReceiptToOpenclawHook(input: {
+  fetchImpl: typeof fetch;
+  openclawHookToken?: string;
+  openclawHookUrl: string;
+  receipt: ReceiptFrame;
+  shutdownSignal: AbortSignal;
+}): Promise<void> {
+  const timeoutSignal = AbortSignal.timeout(
+    DEFAULT_OPENCLAW_DELIVER_TIMEOUT_MS,
+  );
+  const signal = AbortSignal.any([input.shutdownSignal, timeoutSignal]);
+
+  const hookUrl = new URL(input.openclawHookUrl);
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+    "x-clawdentity-content-type": "application/vnd.clawdentity.receipt+json",
+    "x-clawdentity-to-agent-did": input.receipt.toAgentDid,
+    "x-clawdentity-verified": "true",
+    "x-request-id": input.receipt.originalFrameId,
+  };
+  if (input.openclawHookToken !== undefined) {
+    headers["x-openclaw-token"] = input.openclawHookToken;
+  }
+
+  try {
+    const response = await input.fetchImpl(input.openclawHookUrl, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(
+        buildReceiptHookPayload({
+          hookPathname: hookUrl.pathname,
+          receipt: input.receipt,
+        }),
+      ),
+      signal,
+    });
+    if (!response.ok) {
+      throw new LocalOpenclawDeliveryError({
+        message: `Local OpenClaw hook rejected receipt with status ${response.status}`,
+        retryable:
+          response.status === 401 ||
+          response.status === 403 ||
+          response.status >= 500 ||
+          response.status === 404 ||
+          response.status === 429,
+        code:
+          response.status === 401 || response.status === 403
+            ? "HOOK_AUTH_REJECTED"
+            : undefined,
+      });
+    }
+  } catch (error) {
+    if (error instanceof Error && error.name === "AbortError") {
+      if (input.shutdownSignal.aborted) {
+        throw new LocalOpenclawDeliveryError({
+          code: "RUNTIME_STOPPING",
+          message: "Connector runtime is stopping",
+          retryable: false,
+        });
+      }
+      throw new LocalOpenclawDeliveryError({
+        message: "Local OpenClaw receipt hook request timed out",
         retryable: true,
       });
     }

--- a/packages/connector/src/runtime/relay-service.ts
+++ b/packages/connector/src/runtime/relay-service.ts
@@ -136,37 +136,48 @@ export function createRelayService(input: RelayServiceInput): {
     status: OutboundDeliveryReceiptStatus;
   }): Promise<void> => {
     await input.syncAuthFromDisk();
-    const receiptUrl = new URL(inputReceipt.replyTo);
-    if (receiptUrl.pathname !== RELAY_DELIVERY_RECEIPTS_PATH) {
+    let senderReceiptUrl: URL;
+    try {
+      senderReceiptUrl = new URL(inputReceipt.replyTo);
+    } catch {
       throw new AppError({
         code: "CONNECTOR_DELIVERY_RECEIPT_INVALID_TARGET",
         message: "Delivery receipt callback target is invalid",
         status: 400,
       });
     }
-    const expectedSenderOrigin = input.trustedReceiptTargets.byAgentDid.get(
+
+    if (senderReceiptUrl.pathname !== RELAY_DELIVERY_RECEIPTS_PATH) {
+      throw new AppError({
+        code: "CONNECTOR_DELIVERY_RECEIPT_INVALID_TARGET",
+        message: "Delivery receipt callback target is invalid",
+        status: 400,
+      });
+    }
+    const trustedOriginForSender = input.trustedReceiptTargets.byAgentDid.get(
       inputReceipt.senderAgentDid,
     );
     if (
-      expectedSenderOrigin !== undefined &&
-      receiptUrl.origin !== expectedSenderOrigin
+      trustedOriginForSender !== undefined &&
+      senderReceiptUrl.origin !== trustedOriginForSender
     ) {
       throw new AppError({
-        code: "CONNECTOR_DELIVERY_RECEIPT_UNTRUSTED_TARGET",
-        message: "Delivery receipt callback target is untrusted",
+        code: "CONNECTOR_DELIVERY_RECEIPT_INVALID_TARGET",
+        message: "Delivery receipt callback target is invalid",
         status: 400,
       });
     }
     if (
-      expectedSenderOrigin === undefined &&
-      !input.trustedReceiptTargets.origins.has(receiptUrl.origin)
+      trustedOriginForSender === undefined &&
+      !input.trustedReceiptTargets.origins.has(senderReceiptUrl.origin)
     ) {
       throw new AppError({
-        code: "CONNECTOR_DELIVERY_RECEIPT_UNTRUSTED_TARGET",
-        message: "Delivery receipt callback target is untrusted",
+        code: "CONNECTOR_DELIVERY_RECEIPT_INVALID_TARGET",
+        message: "Delivery receipt callback target is invalid",
         status: 400,
       });
     }
+    const receiptUrl = senderReceiptUrl;
 
     const body = JSON.stringify({
       requestId: inputReceipt.requestId,


### PR DESCRIPTION
## Summary
- implement end-to-end receipt pipeline across connector, proxy, and rust frame handling
- add queue-based delivery receipt routing and consumer handling for delivery_receipt events
- fix queue handling so unsupported event types are not acknowledged
- fix relay receipt callback target handling to respect replyTo with strict trust/origin validation
- add OpenClaw-compatible hook payload adapters for receipt notifications

## Details
- add receipt frame contracts and routing in TypeScript and Rust
- add proxy queue consumer module and tests for receipt event processing
- update relay delivery receipt route and queue event contract to remove mixed-path sender metadata fields
- update connector relay service receipt posting logic to use validated replyTo target
- ensure unknown queue event types fail and retry instead of being dropped
- add/expand tests for connector runtime, proxy worker queue behavior, and receipt event handling

## Validation
- pnpm --filter @clawdentity/connector typecheck
- pnpm --filter @clawdentity/connector test
- pnpm --filter @clawdentity/proxy typecheck
- pnpm --filter @clawdentity/proxy test
- cargo test -p clawdentity-core connector::frames --manifest-path crates/Cargo.toml
- cargo test -p clawdentity-cli connector --manifest-path crates/Cargo.toml

Refs #203
