### PR TITLE
queue-first receipts: durable outbox + rust actor + nonce hardening

### DIFF
--- a/apps/proxy/src/AGENTS.md
+++ b/apps/proxy/src/AGENTS.md
@@ -58,6 +58,7 @@
 - Keep receipt ingestion queue-first outside `local`: in `development`/`production`, `/v1/relay/delivery-receipts` must publish to `RECEIPT_QUEUE` and fail with `503` when the binding is unavailable.
 - In `local` mode only, direct DO fallback is allowed for receipt ingestion when `RECEIPT_QUEUE` is absent, and only when `ENVIRONMENT` is explicitly set to `local`.
 - Keep receipt queue event parsing/routing isolated in `queue-consumer/receipt-events.ts`; queue handlers should route events to sender relay sessions, not embed DO RPC JSON inline in `worker.ts`.
+- Keep receipt DO routing key consistent across ingestion and lookup paths: local fallback writes and `GET /v1/relay/delivery-receipts` lookups must resolve `AGENT_RELAY_SESSION` by `senderAgentDid` so local and queue-first behavior match.
 - Keep queue-first receipt tests asserting status parity: both `processed_by_openclaw` and `dead_lettered` must remain observable end-to-end without status rewriting.
 - Keep queue failure policy explicit in `worker.ts`: unsupported/invalid queue payloads are acknowledged (not retried), and retries are reserved for transient delivery failures.
 - Keep `worker.test.ts` queue assertions aligned with `worker.ts` failure classification (`action` + `reasonCode`) so retry/ack semantics stay stable as new queue event types are added.

--- a/apps/proxy/src/AGENTS.md
+++ b/apps/proxy/src/AGENTS.md
@@ -60,6 +60,7 @@
 - Keep receipt queue event parsing/routing isolated in `queue-consumer/receipt-events.ts`; queue handlers should route events to sender relay sessions, not embed DO RPC JSON inline in `worker.ts`.
 - Keep queue-first receipt tests asserting status parity: both `processed_by_openclaw` and `dead_lettered` must remain observable end-to-end without status rewriting.
 - Keep queue failure policy explicit in `worker.ts`: unsupported/invalid queue payloads are acknowledged (not retried), and retries are reserved for transient delivery failures.
+- Keep `worker.test.ts` queue assertions aligned with `worker.ts` failure classification (`action` + `reasonCode`) so retry/ack semantics stay stable as new queue event types are added.
 - Do not import Node-only startup helpers into `worker.ts`; Worker runtime must stay free of process/port startup concerns.
 - Keep worker runtime cache keys sensitive to deploy-time version bindings so `/health` reflects fresh `APP_VERSION` after deploy.
 - Keep production request logging policy in `server.ts` restrictive (`onlyErrors` with a slow-request threshold) and keep development/local verbose for debugging.

--- a/apps/proxy/src/AGENTS.md
+++ b/apps/proxy/src/AGENTS.md
@@ -55,7 +55,10 @@
 - Keep relay websocket connect handling isolated in `relay-connect-route.ts`; `server.ts` should only compose middleware/routes.
 - Keep DO runtime behavior in `agent-relay-session.ts` (websocket accept, heartbeat alarm, connector delivery RPC).
 - Keep relay delivery-receipt HTTP handlers isolated in `relay-delivery-receipt-route.ts`; `server.ts` should only compose `POST/GET /v1/relay/delivery-receipts`.
+- Keep receipt ingestion queue-first outside `local`: in `development`/`production`, `/v1/relay/delivery-receipts` must publish to `RECEIPT_QUEUE` and fail with `503` when the binding is unavailable.
+- In `local` mode only, direct DO fallback is allowed for receipt ingestion when `RECEIPT_QUEUE` is absent, and only when `ENVIRONMENT` is explicitly set to `local`.
 - Keep receipt queue event parsing/routing isolated in `queue-consumer/receipt-events.ts`; queue handlers should route events to sender relay sessions, not embed DO RPC JSON inline in `worker.ts`.
+- Keep queue-first receipt tests asserting status parity: both `processed_by_openclaw` and `dead_lettered` must remain observable end-to-end without status rewriting.
 - Keep queue failure policy explicit in `worker.ts`: unsupported/invalid queue payloads are acknowledged (not retried), and retries are reserved for transient delivery failures.
 - Do not import Node-only startup helpers into `worker.ts`; Worker runtime must stay free of process/port startup concerns.
 - Keep worker runtime cache keys sensitive to deploy-time version bindings so `/health` reflects fresh `APP_VERSION` after deploy.

--- a/apps/proxy/src/queue-consumer/receipt-events.ts
+++ b/apps/proxy/src/queue-consumer/receipt-events.ts
@@ -61,13 +61,23 @@ export function parseReceiptQueueEvent(payload: unknown): ReceiptQueueEvent {
   };
 }
 
+function resolveSenderRelaySession(input: {
+  senderAgentDid: string;
+  relaySessionNamespace: AgentRelaySessionNamespace;
+}) {
+  return input.relaySessionNamespace.get(
+    input.relaySessionNamespace.idFromName(input.senderAgentDid),
+  );
+}
+
 export async function handleReceiptQueueEvent(input: {
   event: ReceiptQueueEvent;
   relaySessionNamespace: AgentRelaySessionNamespace;
 }): Promise<void> {
-  const relaySession = input.relaySessionNamespace.get(
-    input.relaySessionNamespace.idFromName(input.event.senderAgentDid),
-  );
+  const relaySession = resolveSenderRelaySession({
+    senderAgentDid: input.event.senderAgentDid,
+    relaySessionNamespace: input.relaySessionNamespace,
+  });
 
   await recordRelayDeliveryReceipt(relaySession, {
     requestId: input.event.requestId,

--- a/apps/proxy/src/relay-delivery-receipt-route.test.ts
+++ b/apps/proxy/src/relay-delivery-receipt-route.test.ts
@@ -198,6 +198,10 @@ describe("relay delivery receipt route", () => {
     expect(relayHarness.recordInputs).toHaveLength(1);
     expect(relayHarness.recordInputs[0]?.requestId).toBe("req-1");
     expect(relayHarness.recordInputs[0]?.status).toBe("processed_by_openclaw");
+    expect(relayHarness.namespace.idFromName).toHaveBeenCalledTimes(1);
+    expect(relayHarness.namespace.idFromName).toHaveBeenCalledWith(
+      "did:cdi:registry.clawdentity.dev:agent:01HF7YAT31JZHSMW1CG6Q6MHB7",
+    );
   });
 
   it("publishes receipt events to queue when RECEIPT_QUEUE binding is configured", async () => {
@@ -584,6 +588,10 @@ describe("relay delivery receipt route", () => {
     expect(body.receipt?.state).toBe("processed_by_openclaw");
     expect(relayHarness.lookupInputs).toHaveLength(1);
     expect(relayHarness.lookupInputs[0]?.senderAgentDid).toBe(
+      "did:cdi:registry.clawdentity.dev:agent:01HF7YAT00EXEKCZ140TBBFB97",
+    );
+    expect(relayHarness.namespace.idFromName).toHaveBeenCalledTimes(1);
+    expect(relayHarness.namespace.idFromName).toHaveBeenCalledWith(
       "did:cdi:registry.clawdentity.dev:agent:01HF7YAT00EXEKCZ140TBBFB97",
     );
   });

--- a/apps/proxy/src/relay-delivery-receipt-route.test.ts
+++ b/apps/proxy/src/relay-delivery-receipt-route.test.ts
@@ -157,7 +157,7 @@ function createReceiptQueueHarness() {
 }
 
 describe("relay delivery receipt route", () => {
-  it("accepts POST receipt updates for authenticated recipient", async () => {
+  it("accepts POST receipt updates via direct DO only when ENVIRONMENT is explicitly local", async () => {
     const relayHarness = createRelayReceiptHarness();
     const app = createApp({
       allowedPairs: [
@@ -189,6 +189,7 @@ describe("relay delivery receipt route", () => {
       },
       {
         AGENT_RELAY_SESSION: relayHarness.namespace,
+        ENVIRONMENT: "local",
       },
     );
 
@@ -238,6 +239,7 @@ describe("relay delivery receipt route", () => {
 
     expect(response.status).toBe(202);
     expect(queueHarness.sentMessages).toHaveLength(1);
+    expect(relayHarness.recordInputs).toHaveLength(0);
     const queued = JSON.parse(queueHarness.sentMessages[0] ?? "{}") as {
       type?: string;
       requestId?: string;
@@ -246,6 +248,142 @@ describe("relay delivery receipt route", () => {
     expect(queued.type).toBe("delivery_receipt");
     expect(queued.requestId).toBe("req-queue-1");
     expect(queued.status).toBe("processed_by_openclaw");
+  });
+
+  it("publishes dead_lettered receipt events to queue without direct DO writes", async () => {
+    const relayHarness = createRelayReceiptHarness();
+    const queueHarness = createReceiptQueueHarness();
+    const app = createApp({
+      allowedPairs: [
+        {
+          initiator:
+            "did:cdi:registry.clawdentity.dev:agent:01HF7YAT31JZHSMW1CG6Q6MHB7",
+          responder:
+            "did:cdi:registry.clawdentity.dev:agent:01HF7YAT00EXEKCZ140TBBFB97",
+        },
+      ],
+    });
+
+    const response = await app.request(
+      RELAY_DELIVERY_RECEIPTS_PATH,
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-claw-agent-access": "token",
+        },
+        body: JSON.stringify({
+          requestId: "req-queue-dead",
+          senderAgentDid:
+            "did:cdi:registry.clawdentity.dev:agent:01HF7YAT31JZHSMW1CG6Q6MHB7",
+          recipientAgentDid:
+            "did:cdi:registry.clawdentity.dev:agent:01HF7YAT00EXEKCZ140TBBFB97",
+          status: "dead_lettered",
+          reason: "openclaw hook failed",
+        }),
+      },
+      {
+        AGENT_RELAY_SESSION: relayHarness.namespace,
+        RECEIPT_QUEUE: queueHarness.queue,
+      },
+    );
+
+    expect(response.status).toBe(202);
+    expect(queueHarness.sentMessages).toHaveLength(1);
+    expect(relayHarness.recordInputs).toHaveLength(0);
+    const queued = JSON.parse(queueHarness.sentMessages[0] ?? "{}") as {
+      type?: string;
+      requestId?: string;
+      status?: string;
+      reason?: string;
+    };
+    expect(queued.type).toBe("delivery_receipt");
+    expect(queued.requestId).toBe("req-queue-dead");
+    expect(queued.status).toBe("dead_lettered");
+    expect(queued.reason).toBe("openclaw hook failed");
+  });
+
+  it("returns 503 when queue binding is missing outside local environment", async () => {
+    const relayHarness = createRelayReceiptHarness();
+    const app = createApp({
+      allowedPairs: [
+        {
+          initiator:
+            "did:cdi:registry.clawdentity.dev:agent:01HF7YAT31JZHSMW1CG6Q6MHB7",
+          responder:
+            "did:cdi:registry.clawdentity.dev:agent:01HF7YAT00EXEKCZ140TBBFB97",
+        },
+      ],
+    });
+
+    const response = await app.request(
+      RELAY_DELIVERY_RECEIPTS_PATH,
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-claw-agent-access": "token",
+        },
+        body: JSON.stringify({
+          requestId: "req-queue-required",
+          senderAgentDid:
+            "did:cdi:registry.clawdentity.dev:agent:01HF7YAT31JZHSMW1CG6Q6MHB7",
+          recipientAgentDid:
+            "did:cdi:registry.clawdentity.dev:agent:01HF7YAT00EXEKCZ140TBBFB97",
+          status: "processed_by_openclaw",
+        }),
+      },
+      {
+        AGENT_RELAY_SESSION: relayHarness.namespace,
+        ENVIRONMENT: "production",
+      },
+    );
+
+    expect(response.status).toBe(503);
+    const body = (await response.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("PROXY_RELAY_RECEIPT_QUEUE_UNAVAILABLE");
+    expect(relayHarness.recordInputs).toHaveLength(0);
+  });
+
+  it("returns 503 when queue binding is missing and ENVIRONMENT is not set", async () => {
+    const relayHarness = createRelayReceiptHarness();
+    const app = createApp({
+      allowedPairs: [
+        {
+          initiator:
+            "did:cdi:registry.clawdentity.dev:agent:01HF7YAT31JZHSMW1CG6Q6MHB7",
+          responder:
+            "did:cdi:registry.clawdentity.dev:agent:01HF7YAT00EXEKCZ140TBBFB97",
+        },
+      ],
+    });
+
+    const response = await app.request(
+      RELAY_DELIVERY_RECEIPTS_PATH,
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-claw-agent-access": "token",
+        },
+        body: JSON.stringify({
+          requestId: "req-queue-env-unset",
+          senderAgentDid:
+            "did:cdi:registry.clawdentity.dev:agent:01HF7YAT31JZHSMW1CG6Q6MHB7",
+          recipientAgentDid:
+            "did:cdi:registry.clawdentity.dev:agent:01HF7YAT00EXEKCZ140TBBFB97",
+          status: "processed_by_openclaw",
+        }),
+      },
+      {
+        AGENT_RELAY_SESSION: relayHarness.namespace,
+      },
+    );
+
+    expect(response.status).toBe(503);
+    const body = (await response.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("PROXY_RELAY_RECEIPT_QUEUE_UNAVAILABLE");
+    expect(relayHarness.recordInputs).toHaveLength(0);
   });
 
   it("rejects POST when recipient differs from authenticated agent DID", async () => {

--- a/apps/proxy/src/relay-delivery-receipt-route.ts
+++ b/apps/proxy/src/relay-delivery-receipt-route.ts
@@ -19,6 +19,7 @@ type ProxyContext = Context<{
   Variables: ProxyRequestVariables;
   Bindings: {
     AGENT_RELAY_SESSION?: AgentRelaySessionNamespace;
+    ENVIRONMENT?: string;
     RECEIPT_QUEUE?: Queue<string>;
   };
 }>;
@@ -91,6 +92,15 @@ function parseRequiredQuery(value: string | undefined, field: string): string {
   return value.trim();
 }
 
+function normalizeEnvironment(value: string | undefined): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  return normalized.length > 0 ? normalized : undefined;
+}
+
 function resolveSessionNamespace(c: ProxyContext): AgentRelaySessionNamespace {
   const namespace = c.env.AGENT_RELAY_SESSION;
   if (namespace === undefined) {
@@ -133,51 +143,69 @@ export function createRelayDeliveryReceiptPostHandler(
       responderAgentDid: parsedPayload.recipientAgentDid,
     });
 
-    const sessionNamespace = resolveSessionNamespace(c);
-    const relaySession = sessionNamespace.get(
-      sessionNamespace.idFromName(parsedPayload.recipientAgentDid),
-    );
-
-    try {
-      await recordRelayDeliveryReceipt(relaySession, parsedPayload);
-    } catch (error) {
-      if (error instanceof RelaySessionDeliveryError) {
-        input.logger.warn("proxy.relay.receipt_record_failed", {
-          code: error.code,
-          status: error.status,
-        });
-      }
-      throw new AppError({
-        code: "PROXY_RELAY_RECEIPT_WRITE_FAILED",
-        message: "Failed to record relay delivery receipt",
-        status: 502,
-      });
-    }
-
+    const environment = normalizeEnvironment(c.env.ENVIRONMENT);
     const receiptQueue = c.env.RECEIPT_QUEUE;
-    if (receiptQueue !== undefined) {
-      try {
-        await receiptQueue.send(
-          JSON.stringify({
-            type: DELIVERY_RECEIPT_EVENT_TYPE,
-            requestId: parsedPayload.requestId,
-            senderAgentDid: parsedPayload.senderAgentDid,
-            recipientAgentDid: parsedPayload.recipientAgentDid,
-            status: parsedPayload.status,
-            reason: parsedPayload.reason,
-            processedAt: nowIso(),
-          }),
-        );
-      } catch (error) {
-        input.logger.warn("proxy.relay.receipt_queue_publish_failed", {
-          reason: error instanceof Error ? error.message : String(error),
+    if (receiptQueue === undefined) {
+      if (environment !== "local") {
+        input.logger.warn("proxy.relay.receipt_queue_unavailable", {
+          environment: environment ?? "unset",
+          fallbackAllowed: false,
         });
         throw new AppError({
-          code: "PROXY_RELAY_RECEIPT_QUEUE_FAILED",
-          message: "Failed to queue relay delivery receipt",
+          code: "PROXY_RELAY_RECEIPT_QUEUE_UNAVAILABLE",
+          message: "Relay delivery receipt queue is unavailable",
+          status: 503,
+          details: {
+            environment: environment ?? "unset",
+            fallbackAllowed: false,
+          },
+        });
+      }
+
+      const sessionNamespace = resolveSessionNamespace(c);
+      const relaySession = sessionNamespace.get(
+        sessionNamespace.idFromName(parsedPayload.senderAgentDid),
+      );
+      try {
+        await recordRelayDeliveryReceipt(relaySession, parsedPayload);
+      } catch (error) {
+        if (error instanceof RelaySessionDeliveryError) {
+          input.logger.warn("proxy.relay.receipt_record_failed", {
+            code: error.code,
+            status: error.status,
+          });
+        }
+        throw new AppError({
+          code: "PROXY_RELAY_RECEIPT_WRITE_FAILED",
+          message: "Failed to record relay delivery receipt",
           status: 502,
         });
       }
+
+      return c.json({ accepted: true }, 202);
+    }
+
+    try {
+      await receiptQueue.send(
+        JSON.stringify({
+          type: DELIVERY_RECEIPT_EVENT_TYPE,
+          requestId: parsedPayload.requestId,
+          senderAgentDid: parsedPayload.senderAgentDid,
+          recipientAgentDid: parsedPayload.recipientAgentDid,
+          status: parsedPayload.status,
+          reason: parsedPayload.reason,
+          processedAt: nowIso(),
+        }),
+      );
+    } catch (error) {
+      input.logger.warn("proxy.relay.receipt_queue_publish_failed", {
+        reason: error instanceof Error ? error.message : String(error),
+      });
+      throw new AppError({
+        code: "PROXY_RELAY_RECEIPT_QUEUE_FAILED",
+        message: "Failed to queue relay delivery receipt",
+        status: 502,
+      });
     }
 
     return c.json({ accepted: true }, 202);

--- a/apps/proxy/src/relay-delivery-receipt-route.ts
+++ b/apps/proxy/src/relay-delivery-receipt-route.ts
@@ -225,6 +225,7 @@ export function createRelayDeliveryReceiptGetHandler(
       });
     }
 
+    const senderAgentDid = auth.agentDid;
     const requestId = parseRequiredQuery(c.req.query("requestId"), "requestId");
     const recipientAgentDid = parseRequiredQuery(
       c.req.query("recipientAgentDid"),
@@ -233,19 +234,19 @@ export function createRelayDeliveryReceiptGetHandler(
 
     await assertTrustedPair({
       trustStore: input.trustStore,
-      initiatorAgentDid: auth.agentDid,
+      initiatorAgentDid: senderAgentDid,
       responderAgentDid: recipientAgentDid,
     });
 
     const sessionNamespace = resolveSessionNamespace(c);
     const relaySession = sessionNamespace.get(
-      sessionNamespace.idFromName(recipientAgentDid),
+      sessionNamespace.idFromName(senderAgentDid),
     );
 
     try {
       const lookup = await getRelayDeliveryReceipt(relaySession, {
         requestId,
-        senderAgentDid: auth.agentDid,
+        senderAgentDid,
       });
       if (!lookup.found || lookup.receipt === undefined) {
         return c.json(

--- a/apps/proxy/src/worker.test.ts
+++ b/apps/proxy/src/worker.test.ts
@@ -280,6 +280,43 @@ describe("proxy worker", () => {
     expect(retry).not.toHaveBeenCalled();
   });
 
+  it("routes processed_by_openclaw queue events without mutating receipt status", async () => {
+    const fetchSpy = vi.fn(async (_request: Request) =>
+      Response.json({ accepted: true }, { status: 202 }),
+    );
+    const bindings = createRequiredBindings({
+      AGENT_RELAY_SESSION: createRelaySessionNamespaceWithFetchSpy(fetchSpy),
+    });
+    const ack = vi.fn();
+    const retry = vi.fn();
+    const queueBatch = {
+      messages: [
+        {
+          body: JSON.stringify({
+            type: "delivery_receipt",
+            requestId: "req-queue-processed",
+            senderAgentDid:
+              "did:cdi:registry.clawdentity.dev:agent:01HF7YAT31JZHSMW1CG6Q6MHB7",
+            recipientAgentDid:
+              "did:cdi:registry.clawdentity.dev:agent:01HF7YAT00EXEKCZ140TBBFB97",
+            status: "processed_by_openclaw",
+          }),
+          ack,
+          retry,
+        },
+      ],
+    } as unknown as MessageBatch<string>;
+
+    await worker.queue(queueBatch, bindings);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const request = fetchSpy.mock.calls[0]?.[0] as Request;
+    const body = (await request.json()) as { status?: string };
+    expect(body.status).toBe("processed_by_openclaw");
+    expect(ack).toHaveBeenCalledTimes(1);
+    expect(retry).not.toHaveBeenCalled();
+  });
+
   it("acks unsupported queue event types without retrying", async () => {
     const fetchSpy = vi.fn();
     const bindings = createRequiredBindings({

--- a/apps/proxy/src/worker.ts
+++ b/apps/proxy/src/worker.ts
@@ -210,20 +210,35 @@ function parseDeliveryReceiptEvent(payload: unknown) {
   }
 }
 
-function shouldRetryQueueError(error: unknown): boolean {
+type QueueFailureAction = "ack" | "retry";
+
+function resolveQueueFailureAction(error: unknown): {
+  action: QueueFailureAction;
+  reasonCode: string;
+} {
   if (error instanceof NonRetryableQueueError) {
-    return false;
+    return { action: "ack", reasonCode: "non_retryable_queue_error" };
   }
 
   if (error instanceof RelaySessionDeliveryError) {
-    return error.status === 429 || error.status >= 500;
+    if (error.status === 429 || error.status >= 500) {
+      return {
+        action: "retry",
+        reasonCode: "relay_session_transient_error",
+      };
+    }
+
+    return {
+      action: "ack",
+      reasonCode: "relay_session_non_retryable_error",
+    };
   }
 
   if (error instanceof TypeError) {
-    return true;
+    return { action: "retry", reasonCode: "transport_type_error" };
   }
 
-  return true;
+  return { action: "retry", reasonCode: "unknown_retryable_error" };
 }
 
 const worker = {
@@ -285,12 +300,18 @@ const worker = {
 
         message.ack();
       } catch (error) {
-        const shouldRetry = shouldRetryQueueError(error);
+        const failureAction = resolveQueueFailureAction(error);
         logger.warn("proxy.queue.message_failed", {
           reason: error instanceof Error ? error.message : String(error),
-          action: shouldRetry ? "retry" : "ack",
+          action: failureAction.action,
+          reasonCode: failureAction.reasonCode,
+          errorName: error instanceof Error ? error.name : "unknown",
+          relayStatus:
+            error instanceof RelaySessionDeliveryError ? error.status : null,
+          relayCode:
+            error instanceof RelaySessionDeliveryError ? error.code : null,
         });
-        if (shouldRetry) {
+        if (failureAction.action === "retry") {
           message.retry();
         } else {
           message.ack();

--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -304,6 +304,7 @@ dependencies = [
  "clap",
  "clawdentity-core",
  "reqwest",
+ "serde",
  "serde_json",
  "tokio",
  "tracing",

--- a/crates/clawdentity-cli/Cargo.toml
+++ b/crates/clawdentity-cli/Cargo.toml
@@ -13,6 +13,7 @@ chrono = { version = "0.4.43", default-features = false, features = ["clock"] }
 clap.workspace = true
 clawdentity-core = { version = "0.1.7", path = "../clawdentity-core" }
 reqwest = { version = "0.12.24", default-features = false, features = ["json", "rustls-tls"] }
+serde.workspace = true
 serde_json.workspace = true
 tokio = { version = "1.49.0", features = ["macros", "rt-multi-thread", "signal"] }
 tracing.workspace = true

--- a/crates/clawdentity-cli/src/commands/connector.rs
+++ b/crates/clawdentity-cli/src/commands/connector.rs
@@ -1,10 +1,12 @@
 use std::net::{IpAddr, SocketAddr};
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{Result, anyhow};
 use clap::Subcommand;
 use clawdentity_core::config::ConfigPathOptions;
+use clawdentity_core::http::client as create_http_client;
 use clawdentity_core::runtime_openclaw::OpenclawRuntimeConfig;
 use clawdentity_core::{
     ConnectorClient, ConnectorClientOptions, ConnectorClientSender, ConnectorServiceInstallInput,
@@ -23,9 +25,11 @@ const OUTBOUND_FLUSH_BATCH_SIZE: usize = 50;
 
 mod delivery;
 mod headers;
+mod receipts;
 mod runtime_config;
 
 use delivery::{run_inbound_loop, run_inbound_retry_loop};
+use receipts::{ReceiptDispatchRuntime, ReceiptOutboxHandle, start_receipt_outbox_worker};
 
 #[cfg(test)]
 use delivery::{
@@ -93,6 +97,8 @@ pub(super) struct StartConnectorInput {
 pub(super) struct ConnectorRuntimeConfig {
     agent_name: String,
     agent_did: String,
+    config_dir: PathBuf,
+    proxy_receipt_url: String,
     proxy_ws_url: String,
     openclaw_runtime: OpenclawRuntimeConfig,
     port: u16,
@@ -243,7 +249,18 @@ async fn start_connector_runtime(
         shutdown_rx.clone(),
     );
 
+    let receipt_outbox = start_receipt_outbox_worker(
+        ReceiptDispatchRuntime {
+            options: options.clone(),
+            config_dir: runtime.config_dir.clone(),
+            agent_name: runtime.agent_name.clone(),
+            proxy_receipt_url: runtime.proxy_receipt_url.clone(),
+        },
+        create_http_client()?,
+    );
+
     let mut inbound_loop_task = spawn_inbound_loop_task(
+        receipt_outbox.clone(),
         client,
         relay_sender.clone(),
         store.clone(),
@@ -252,6 +269,7 @@ async fn start_connector_runtime(
     );
 
     let mut inbound_retry_task = spawn_inbound_retry_task(
+        receipt_outbox,
         store.clone(),
         runtime.openclaw_runtime.clone(),
         shutdown_rx.clone(),
@@ -328,6 +346,7 @@ fn spawn_runtime_server_task(
 }
 
 fn spawn_inbound_loop_task(
+    receipt_outbox: ReceiptOutboxHandle,
     connector_client: ConnectorClient,
     relay_sender: ConnectorClientSender,
     store: SqliteStore,
@@ -336,6 +355,7 @@ fn spawn_inbound_loop_task(
 ) -> JoinHandle<Result<()>> {
     tokio::spawn(async move {
         run_inbound_loop(
+            receipt_outbox,
             connector_client,
             relay_sender,
             store,
@@ -355,11 +375,14 @@ fn spawn_outbound_flush_task(
 }
 
 fn spawn_inbound_retry_task(
+    receipt_outbox: ReceiptOutboxHandle,
     store: SqliteStore,
     openclaw_runtime: OpenclawRuntimeConfig,
     shutdown_rx: watch::Receiver<bool>,
 ) -> JoinHandle<Result<()>> {
-    tokio::spawn(async move { run_inbound_retry_loop(store, openclaw_runtime, shutdown_rx).await })
+    tokio::spawn(async move {
+        run_inbound_retry_loop(receipt_outbox, store, openclaw_runtime, shutdown_rx).await
+    })
 }
 
 async fn run_outbound_flush_loop(

--- a/crates/clawdentity-cli/src/commands/connector/AGENTS.md
+++ b/crates/clawdentity-cli/src/commands/connector/AGENTS.md
@@ -14,6 +14,7 @@
 - Keep OpenClaw payload/summary shaping in `delivery/openclaw_payload.rs`; `delivery.rs` should orchestrate delivery flow and persistence, not own long JSON/text render helpers.
 - Keep proxy receipt dispatch + durable outbox behavior in `receipts.rs`; do not re-embed receipt persistence/retry logic into `connector.rs` or `delivery.rs`.
 - Keep receipt outbox mutations in a single-writer command flow (enqueue/flush serialized) so disk-backed retries remain race-safe under concurrent runtime tasks.
+- Persist receipt outbox updates with atomic write-then-rename (`*.tmp-*` -> final path) so crashes cannot leave partially written JSON that drops queued receipts.
 - Receipt callback routing authority is always the runtime-owned local proxy receipt URL; do not trust inbound `reply_to` for callback destination selection.
 - Receipt PoP nonces must be cryptographically random, URL-safe, and one-time per request signing call; never derive them from timestamps/counters.
 - Keep receipt payload tests asserting status parity at top-level and metadata level so `dead_lettered` and `processed_by_openclaw` stay externally consistent for OpenClaw hooks.

--- a/crates/clawdentity-cli/src/commands/connector/AGENTS.md
+++ b/crates/clawdentity-cli/src/commands/connector/AGENTS.md
@@ -11,6 +11,7 @@
 - Keep hook payload builders split into focused helpers so the structural 50-line non-test function rule stays green.
 - Inbound OpenClaw hook requests must keep canonical identity headers (`x-clawdentity-agent-did`, `x-clawdentity-to-agent-did`, `x-clawdentity-verified`, `x-request-id`) and only add sender profile headers (`x-clawdentity-agent-name`, `x-clawdentity-human-name`) when local peer metadata exists.
 - Keep sender-profile DID lookup and header shaping in focused helpers/modules instead of expanding `delivery.rs`.
+- Keep OpenClaw payload/summary shaping in `delivery/openclaw_payload.rs`; `delivery.rs` should orchestrate delivery flow and persistence, not own long JSON/text render helpers.
 - Keep proxy receipt dispatch + durable outbox behavior in `receipts.rs`; do not re-embed receipt persistence/retry logic into `connector.rs` or `delivery.rs`.
 - Keep receipt outbox mutations in a single-writer command flow (enqueue/flush serialized) so disk-backed retries remain race-safe under concurrent runtime tasks.
 - Receipt callback routing authority is always the runtime-owned local proxy receipt URL; do not trust inbound `reply_to` for callback destination selection.

--- a/crates/clawdentity-cli/src/commands/connector/AGENTS.md
+++ b/crates/clawdentity-cli/src/commands/connector/AGENTS.md
@@ -11,3 +11,8 @@
 - Keep hook payload builders split into focused helpers so the structural 50-line non-test function rule stays green.
 - Inbound OpenClaw hook requests must keep canonical identity headers (`x-clawdentity-agent-did`, `x-clawdentity-to-agent-did`, `x-clawdentity-verified`, `x-request-id`) and only add sender profile headers (`x-clawdentity-agent-name`, `x-clawdentity-human-name`) when local peer metadata exists.
 - Keep sender-profile DID lookup and header shaping in focused helpers/modules instead of expanding `delivery.rs`.
+- Keep proxy receipt dispatch + durable outbox behavior in `receipts.rs`; do not re-embed receipt persistence/retry logic into `connector.rs` or `delivery.rs`.
+- Keep receipt outbox mutations in a single-writer command flow (enqueue/flush serialized) so disk-backed retries remain race-safe under concurrent runtime tasks.
+- Receipt callback routing authority is always the runtime-owned local proxy receipt URL; do not trust inbound `reply_to` for callback destination selection.
+- Receipt PoP nonces must be cryptographically random, URL-safe, and one-time per request signing call; never derive them from timestamps/counters.
+- Keep receipt payload tests asserting status parity at top-level and metadata level so `dead_lettered` and `processed_by_openclaw` stay externally consistent for OpenClaw hooks.

--- a/crates/clawdentity-cli/src/commands/connector/delivery.rs
+++ b/crates/clawdentity-cli/src/commands/connector/delivery.rs
@@ -20,6 +20,7 @@ use super::headers::{
     SenderProfileHeaders, build_openclaw_delivery_headers, lookup_sender_profile_headers,
 };
 use super::normalize_hook_path;
+use super::receipts::{DeliveryReceiptPayload, DeliveryReceiptStatus, ReceiptOutboxHandle};
 
 const CONNECTOR_RETRY_DELAY_MS: i64 = 5_000;
 const INBOUND_RETRY_INTERVAL: Duration = Duration::from_secs(1);
@@ -27,6 +28,7 @@ const INBOUND_RETRY_BATCH_SIZE: usize = 50;
 const INBOUND_MAX_ATTEMPTS: i64 = 3;
 
 pub(super) async fn run_inbound_loop(
+    receipt_outbox: ReceiptOutboxHandle,
     mut connector_client: ConnectorClient,
     relay_sender: ConnectorClientSender,
     store: SqliteStore,
@@ -54,6 +56,7 @@ pub(super) async fn run_inbound_loop(
                     &http_client,
                     &hook_url,
                     &openclaw_runtime,
+                    &receipt_outbox,
                 )
                 .await;
             }
@@ -68,6 +71,7 @@ async fn handle_connector_frame(
     http_client: &reqwest::Client,
     hook_url: &str,
     openclaw_runtime: &OpenclawRuntimeConfig,
+    receipt_outbox: &ReceiptOutboxHandle,
 ) {
     match frame {
         ConnectorFrame::Deliver(deliver) => {
@@ -77,6 +81,7 @@ async fn handle_connector_frame(
                 http_client,
                 hook_url,
                 openclaw_runtime,
+                receipt_outbox,
                 deliver,
             )
             .await;
@@ -113,6 +118,7 @@ fn log_enqueue_ack(ack: &EnqueueAckFrame) {
 }
 
 pub(super) async fn run_inbound_retry_loop(
+    receipt_outbox: ReceiptOutboxHandle,
     store: SqliteStore,
     openclaw_runtime: OpenclawRuntimeConfig,
     mut shutdown_rx: watch::Receiver<bool>,
@@ -130,7 +136,15 @@ pub(super) async fn run_inbound_retry_loop(
                 }
             }
             _ = interval.tick() => {
-                retry_due_inbound_deliveries(&store, &http_client, &hook_url, &openclaw_runtime).await;
+                let _ = receipt_outbox.flush_due().await;
+                retry_due_inbound_deliveries(
+                    &store,
+                    &http_client,
+                    &hook_url,
+                    &openclaw_runtime,
+                    &receipt_outbox,
+                )
+                .await;
             }
         }
     }
@@ -141,6 +155,7 @@ async fn retry_due_inbound_deliveries(
     http_client: &reqwest::Client,
     hook_url: &str,
     openclaw_runtime: &OpenclawRuntimeConfig,
+    receipt_outbox: &ReceiptOutboxHandle,
 ) {
     let due_items = match list_pending_due(store, now_utc_ms(), INBOUND_RETRY_BATCH_SIZE) {
         Ok(items) => items,
@@ -151,7 +166,15 @@ async fn retry_due_inbound_deliveries(
     };
 
     for item in due_items {
-        retry_pending_inbound_delivery(store, http_client, hook_url, openclaw_runtime, item).await;
+        retry_pending_inbound_delivery(
+            store,
+            http_client,
+            hook_url,
+            openclaw_runtime,
+            receipt_outbox,
+            item,
+        )
+        .await;
     }
 }
 
@@ -160,10 +183,11 @@ async fn retry_pending_inbound_delivery(
     http_client: &reqwest::Client,
     hook_url: &str,
     openclaw_runtime: &OpenclawRuntimeConfig,
+    receipt_outbox: &ReceiptOutboxHandle,
     item: InboundPendingItem,
 ) {
     let Ok(deliver) = build_deliver_from_pending(&item) else {
-        dead_letter_invalid_pending_payload(store, &item);
+        dead_letter_invalid_pending_payload(store, receipt_outbox, &item).await;
         return;
     };
 
@@ -177,8 +201,19 @@ async fn retry_pending_inbound_delivery(
     )
     .await
     {
-        Ok(()) => record_retry_delivery_success(store, &item),
-        Err(error) => handle_pending_retry_failure(store, &item, &error),
+        Ok(()) => {
+            record_retry_delivery_success(store, &item);
+            let _ = receipt_outbox
+                .enqueue_and_try_flush(DeliveryReceiptPayload {
+                    request_id: item.request_id.clone(),
+                    sender_agent_did: item.from_agent_did.clone(),
+                    recipient_agent_did: item.to_agent_did.clone(),
+                    status: DeliveryReceiptStatus::ProcessedByOpenclaw,
+                    reason: None,
+                })
+                .await;
+        }
+        Err(error) => handle_pending_retry_failure(store, receipt_outbox, &item, &error).await,
     }
 }
 
@@ -199,18 +234,33 @@ fn build_deliver_from_pending(item: &InboundPendingItem) -> Result<DeliverFrame>
     })
 }
 
-fn dead_letter_invalid_pending_payload(store: &SqliteStore, item: &InboundPendingItem) {
+async fn dead_letter_invalid_pending_payload(
+    store: &SqliteStore,
+    receipt_outbox: &ReceiptOutboxHandle,
+    item: &InboundPendingItem,
+) {
     let reason = build_deliver_from_pending(item)
         .err()
         .map(|error| error.to_string())
         .unwrap_or_else(|| "invalid pending payload_json".to_string());
-    if let Err(error) = move_pending_to_dead_letter(store, &item.request_id, &reason) {
+    let moved_to_dead_letter = move_pending_to_dead_letter(store, &item.request_id, &reason);
+    if let Err(error) = moved_to_dead_letter {
         tracing::warn!(
             error = %error,
             request_id = %item.request_id,
             "failed to move invalid pending payload to dead letter"
         );
+        return;
     }
+    let _ = receipt_outbox
+        .enqueue_and_try_flush(DeliveryReceiptPayload {
+            request_id: item.request_id.clone(),
+            sender_agent_did: item.from_agent_did.clone(),
+            recipient_agent_did: item.to_agent_did.clone(),
+            status: DeliveryReceiptStatus::DeadLettered,
+            reason: Some(reason),
+        })
+        .await;
 }
 
 fn record_retry_delivery_success(store: &SqliteStore, item: &InboundPendingItem) {
@@ -241,28 +291,45 @@ pub(super) fn should_dead_letter_after_failure(current_attempt_count: i64) -> bo
     current_attempt_count.saturating_add(1) >= INBOUND_MAX_ATTEMPTS
 }
 
-fn handle_pending_retry_failure(
+async fn handle_pending_retry_failure(
     store: &SqliteStore,
+    receipt_outbox: &ReceiptOutboxHandle,
     item: &InboundPendingItem,
     error: &anyhow::Error,
 ) {
     if should_dead_letter_after_failure(item.attempt_count) {
-        dead_letter_pending_retry(store, &item.request_id, error);
+        dead_letter_pending_retry(store, receipt_outbox, item, error).await;
         return;
     }
 
     schedule_pending_retry(store, item, error);
 }
 
-fn dead_letter_pending_retry(store: &SqliteStore, request_id: &str, error: &anyhow::Error) {
+async fn dead_letter_pending_retry(
+    store: &SqliteStore,
+    receipt_outbox: &ReceiptOutboxHandle,
+    item: &InboundPendingItem,
+    error: &anyhow::Error,
+) {
     let reason = format!("max retry attempts exceeded: {error}");
-    if let Err(move_error) = move_pending_to_dead_letter(store, request_id, &reason) {
+    let moved_to_dead_letter = move_pending_to_dead_letter(store, &item.request_id, &reason);
+    if let Err(move_error) = moved_to_dead_letter {
         tracing::warn!(
             error = %move_error,
-            request_id,
+            request_id = %item.request_id,
             "failed to move pending inbound delivery to dead letter"
         );
+        return;
     }
+    let _ = receipt_outbox
+        .enqueue_and_try_flush(DeliveryReceiptPayload {
+            request_id: item.request_id.clone(),
+            sender_agent_did: item.from_agent_did.clone(),
+            recipient_agent_did: item.to_agent_did.clone(),
+            status: DeliveryReceiptStatus::DeadLettered,
+            reason: Some(reason),
+        })
+        .await;
 }
 
 fn schedule_pending_retry(store: &SqliteStore, item: &InboundPendingItem, error: &anyhow::Error) {
@@ -308,6 +375,7 @@ async fn handle_deliver_frame(
     http_client: &reqwest::Client,
     hook_url: &str,
     openclaw_runtime: &OpenclawRuntimeConfig,
+    receipt_outbox: &ReceiptOutboxHandle,
     deliver: DeliverFrame,
 ) {
     let sender_profile = lookup_sender_profile_headers(store, &deliver.from_agent_did);
@@ -319,6 +387,7 @@ async fn handle_deliver_frame(
         sender_profile.as_ref(),
     )
     .await;
+    let delivery_succeeded = delivery_result.is_ok();
     let persistence_result =
         persist_inbound_delivery_result(store, &deliver, delivery_result.as_ref()).await;
     log_persist_failure(&deliver.id, persistence_result.as_ref().err());
@@ -330,6 +399,18 @@ async fn handle_deliver_frame(
     let ack_accepted = ack_reason.is_none();
     send_deliver_ack(relay_sender, &deliver.id, ack_accepted, ack_reason).await;
     log_delivery_failure(&deliver, delivery_result.err());
+
+    if delivery_succeeded {
+        let _ = receipt_outbox
+            .enqueue_and_try_flush(DeliveryReceiptPayload {
+                request_id: deliver.id.clone(),
+                sender_agent_did: deliver.from_agent_did.clone(),
+                recipient_agent_did: deliver.to_agent_did.clone(),
+                status: DeliveryReceiptStatus::ProcessedByOpenclaw,
+                reason: None,
+            })
+            .await;
+    }
 }
 
 fn log_persist_failure(request_id: &str, persistence_error: Option<&anyhow::Error>) {

--- a/crates/clawdentity-cli/src/commands/connector/delivery.rs
+++ b/crates/clawdentity-cli/src/commands/connector/delivery.rs
@@ -10,8 +10,8 @@ use clawdentity_core::http::client as create_http_client;
 use clawdentity_core::runtime_openclaw::OpenclawRuntimeConfig;
 use clawdentity_core::{
     CONNECTOR_FRAME_VERSION, ConnectorClient, ConnectorClientSender, ConnectorFrame,
-    DeliverAckFrame, DeliverFrame, EnqueueAckFrame, ReceiptFrame, ReceiptStatus, SqliteStore,
-    new_frame_id, now_iso,
+    DeliverAckFrame, DeliverFrame, EnqueueAckFrame, ReceiptFrame, SqliteStore, new_frame_id,
+    now_iso,
 };
 use serde_json::{Value, json};
 use tokio::sync::watch;
@@ -19,8 +19,10 @@ use tokio::sync::watch;
 use super::headers::{
     SenderProfileHeaders, build_openclaw_delivery_headers, lookup_sender_profile_headers,
 };
-use super::normalize_hook_path;
 use super::receipts::{DeliveryReceiptPayload, DeliveryReceiptStatus, ReceiptOutboxHandle};
+pub(super) use openclaw_payload::{build_openclaw_hook_payload, build_openclaw_receipt_payload};
+
+mod openclaw_payload;
 
 const CONNECTOR_RETRY_DELAY_MS: i64 = 5_000;
 const INBOUND_RETRY_INTERVAL: Duration = Duration::from_secs(1);
@@ -474,14 +476,6 @@ async fn forward_deliver_to_openclaw(
     Ok(())
 }
 
-pub(super) fn build_openclaw_hook_payload(hook_path: &str, deliver: &DeliverFrame) -> Value {
-    if normalize_hook_path(hook_path) == "/hooks/wake" {
-        return build_openclaw_wake_payload(deliver);
-    }
-
-    build_openclaw_agent_payload(deliver)
-}
-
 async fn forward_receipt_to_openclaw(
     http_client: &reqwest::Client,
     hook_url: &str,
@@ -523,187 +517,6 @@ async fn forward_receipt_to_openclaw(
         ));
     }
     Ok(())
-}
-
-pub(super) fn build_openclaw_receipt_payload(hook_path: &str, receipt: &ReceiptFrame) -> Value {
-    let summary = render_receipt_summary(receipt);
-    let status = receipt_status_str(&receipt.status);
-    let receipt_json = build_openclaw_receipt_metadata(receipt);
-
-    if normalize_hook_path(hook_path) == "/hooks/wake" {
-        return json!({
-            "type": "clawdentity:receipt",
-            "originalFrameId": receipt.original_frame_id,
-            "toAgentDid": receipt.to_agent_did,
-            "status": status,
-            "reason": receipt.reason,
-            "timestamp": receipt.ts,
-            "text": summary,
-            "message": summary,
-            "mode": "now",
-            "metadata": {
-                "receipt": receipt_json,
-            },
-        });
-    }
-
-    json!({
-        "type": "clawdentity:receipt",
-        "originalFrameId": receipt.original_frame_id,
-        "toAgentDid": receipt.to_agent_did,
-        "status": status,
-        "reason": receipt.reason,
-        "timestamp": receipt.ts,
-        "message": summary,
-        "content": summary,
-        "metadata": {
-            "receipt": receipt_json,
-        },
-    })
-}
-
-fn build_openclaw_receipt_metadata(receipt: &ReceiptFrame) -> Value {
-    json!({
-        "type": "clawdentity:receipt",
-        "originalFrameId": receipt.original_frame_id,
-        "toAgentDid": receipt.to_agent_did,
-        "status": receipt_status_str(&receipt.status),
-        "reason": receipt.reason,
-        "timestamp": receipt.ts,
-    })
-}
-
-fn receipt_status_str(status: &ReceiptStatus) -> &'static str {
-    match status {
-        ReceiptStatus::ProcessedByOpenclaw => "processed_by_openclaw",
-        ReceiptStatus::DeadLettered => "dead_lettered",
-    }
-}
-
-fn render_receipt_summary(receipt: &ReceiptFrame) -> String {
-    let mut lines = vec![
-        format!(
-            "Clawdentity delivery receipt: {}",
-            match receipt.status {
-                ReceiptStatus::ProcessedByOpenclaw => "processed_by_openclaw",
-                ReceiptStatus::DeadLettered => "dead_lettered",
-            }
-        ),
-        String::new(),
-        format!("Request ID: {}", receipt.original_frame_id),
-        format!("Recipient DID: {}", receipt.to_agent_did),
-    ];
-    if let Some(reason) = receipt
-        .reason
-        .as_deref()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-    {
-        lines.push(format!("Reason: {reason}"));
-    }
-    lines.push(format!("Timestamp: {}", receipt.ts));
-    lines.join("\n")
-}
-
-fn build_openclaw_agent_payload(deliver: &DeliverFrame) -> Value {
-    let message = extract_content(&deliver.payload);
-    json!({
-        "message": message,
-        "content": message,
-        "senderDid": deliver.from_agent_did,
-        "recipientDid": deliver.to_agent_did,
-        "requestId": deliver.id,
-        "metadata": {
-            "conversationId": deliver.conversation_id,
-            "replyTo": deliver.reply_to,
-            "payload": deliver.payload,
-        },
-    })
-}
-
-fn build_openclaw_wake_payload(deliver: &DeliverFrame) -> Value {
-    let wake_text = render_openclaw_wake_text(deliver);
-    let session_id = deliver
-        .payload
-        .get("sessionId")
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty());
-    let mut payload = json!({
-        "message": wake_text,
-        "text": wake_text,
-        "mode": "now",
-    });
-    if let Some(session_id) = session_id {
-        payload["sessionId"] = Value::String(session_id.to_string());
-    }
-    payload
-}
-
-fn render_openclaw_wake_text(deliver: &DeliverFrame) -> String {
-    let message = extract_content(&deliver.payload);
-    let mut lines = vec![format!(
-        "Clawdentity peer message from {}",
-        deliver.from_agent_did
-    )];
-
-    if !message.trim().is_empty() {
-        lines.push(String::new());
-        lines.push(message);
-    }
-    append_optional_line(
-        &mut lines,
-        Some(deliver.id.as_str()).filter(|value| !value.trim().is_empty()),
-        "Request ID",
-        true,
-    );
-    append_optional_line(
-        &mut lines,
-        deliver
-            .conversation_id
-            .as_deref()
-            .map(str::trim)
-            .filter(|value| !value.is_empty()),
-        "Conversation ID",
-        false,
-    );
-    append_optional_line(
-        &mut lines,
-        deliver
-            .reply_to
-            .as_deref()
-            .map(str::trim)
-            .filter(|value| !value.is_empty()),
-        "Reply To",
-        false,
-    );
-
-    lines.join("\n")
-}
-
-fn append_optional_line(lines: &mut Vec<String>, value: Option<&str>, label: &str, pad: bool) {
-    if let Some(value) = value {
-        if pad {
-            lines.push(String::new());
-        }
-        lines.push(format!("{label}: {value}"));
-    }
-}
-
-fn extract_content(payload: &Value) -> String {
-    if let Some(content) = payload.get("content").and_then(Value::as_str) {
-        return content.to_string();
-    }
-    if let Some(message) = payload.get("message").and_then(Value::as_str) {
-        return message.to_string();
-    }
-    if let Some(text) = payload.get("text").and_then(Value::as_str) {
-        return text.to_string();
-    }
-    if let Some(text) = payload.as_str() {
-        return text.to_string();
-    }
-    payload.to_string()
 }
 
 async fn persist_inbound_delivery_result(

--- a/crates/clawdentity-cli/src/commands/connector/delivery/openclaw_payload.rs
+++ b/crates/clawdentity-cli/src/commands/connector/delivery/openclaw_payload.rs
@@ -1,0 +1,194 @@
+use clawdentity_core::{DeliverFrame, ReceiptFrame, ReceiptStatus};
+use serde_json::{Value, json};
+
+use super::super::normalize_hook_path;
+
+pub(crate) fn build_openclaw_hook_payload(hook_path: &str, deliver: &DeliverFrame) -> Value {
+    if normalize_hook_path(hook_path) == "/hooks/wake" {
+        return build_openclaw_wake_payload(deliver);
+    }
+
+    build_openclaw_agent_payload(deliver)
+}
+
+pub(crate) fn build_openclaw_receipt_payload(hook_path: &str, receipt: &ReceiptFrame) -> Value {
+    let summary = render_receipt_summary(receipt);
+    let status = receipt_status_str(&receipt.status);
+    let receipt_json = build_openclaw_receipt_metadata(receipt);
+
+    if normalize_hook_path(hook_path) == "/hooks/wake" {
+        return json!({
+            "type": "clawdentity:receipt",
+            "originalFrameId": receipt.original_frame_id,
+            "toAgentDid": receipt.to_agent_did,
+            "status": status,
+            "reason": receipt.reason,
+            "timestamp": receipt.ts,
+            "text": summary,
+            "message": summary,
+            "mode": "now",
+            "metadata": {
+                "receipt": receipt_json,
+            },
+        });
+    }
+
+    json!({
+        "type": "clawdentity:receipt",
+        "originalFrameId": receipt.original_frame_id,
+        "toAgentDid": receipt.to_agent_did,
+        "status": status,
+        "reason": receipt.reason,
+        "timestamp": receipt.ts,
+        "message": summary,
+        "content": summary,
+        "metadata": {
+            "receipt": receipt_json,
+        },
+    })
+}
+
+fn build_openclaw_receipt_metadata(receipt: &ReceiptFrame) -> Value {
+    json!({
+        "type": "clawdentity:receipt",
+        "originalFrameId": receipt.original_frame_id,
+        "toAgentDid": receipt.to_agent_did,
+        "status": receipt_status_str(&receipt.status),
+        "reason": receipt.reason,
+        "timestamp": receipt.ts,
+    })
+}
+
+fn receipt_status_str(status: &ReceiptStatus) -> &'static str {
+    match status {
+        ReceiptStatus::ProcessedByOpenclaw => "processed_by_openclaw",
+        ReceiptStatus::DeadLettered => "dead_lettered",
+    }
+}
+
+fn render_receipt_summary(receipt: &ReceiptFrame) -> String {
+    let mut lines = vec![
+        format!(
+            "Clawdentity delivery receipt: {}",
+            match receipt.status {
+                ReceiptStatus::ProcessedByOpenclaw => "processed_by_openclaw",
+                ReceiptStatus::DeadLettered => "dead_lettered",
+            }
+        ),
+        String::new(),
+        format!("Request ID: {}", receipt.original_frame_id),
+        format!("Recipient DID: {}", receipt.to_agent_did),
+    ];
+
+    if let Some(reason) = receipt
+        .reason
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        lines.push(format!("Reason: {reason}"));
+    }
+    lines.push(format!("Timestamp: {}", receipt.ts));
+    lines.join("\n")
+}
+
+fn build_openclaw_agent_payload(deliver: &DeliverFrame) -> Value {
+    let message = extract_content(&deliver.payload);
+    json!({
+        "message": message,
+        "content": message,
+        "senderDid": deliver.from_agent_did,
+        "recipientDid": deliver.to_agent_did,
+        "requestId": deliver.id,
+        "metadata": {
+            "conversationId": deliver.conversation_id,
+            "replyTo": deliver.reply_to,
+            "payload": deliver.payload,
+        },
+    })
+}
+
+fn build_openclaw_wake_payload(deliver: &DeliverFrame) -> Value {
+    let wake_text = render_openclaw_wake_text(deliver);
+    let session_id = deliver
+        .payload
+        .get("sessionId")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let mut payload = json!({
+        "message": wake_text,
+        "text": wake_text,
+        "mode": "now",
+    });
+    if let Some(session_id) = session_id {
+        payload["sessionId"] = Value::String(session_id.to_string());
+    }
+    payload
+}
+
+fn render_openclaw_wake_text(deliver: &DeliverFrame) -> String {
+    let message = extract_content(&deliver.payload);
+    let mut lines = vec![format!(
+        "Clawdentity peer message from {}",
+        deliver.from_agent_did
+    )];
+
+    if !message.trim().is_empty() {
+        lines.push(String::new());
+        lines.push(message);
+    }
+    append_optional_line(
+        &mut lines,
+        Some(deliver.id.as_str()).filter(|value| !value.trim().is_empty()),
+        "Request ID",
+        true,
+    );
+    append_optional_line(
+        &mut lines,
+        deliver
+            .conversation_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty()),
+        "Conversation ID",
+        false,
+    );
+    append_optional_line(
+        &mut lines,
+        deliver
+            .reply_to
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty()),
+        "Reply To",
+        false,
+    );
+
+    lines.join("\n")
+}
+
+fn append_optional_line(lines: &mut Vec<String>, value: Option<&str>, label: &str, pad: bool) {
+    if let Some(value) = value {
+        if pad {
+            lines.push(String::new());
+        }
+        lines.push(format!("{label}: {value}"));
+    }
+}
+
+fn extract_content(payload: &Value) -> String {
+    if let Some(content) = payload.get("content").and_then(Value::as_str) {
+        return content.to_string();
+    }
+    if let Some(message) = payload.get("message").and_then(Value::as_str) {
+        return message.to_string();
+    }
+    if let Some(text) = payload.get("text").and_then(Value::as_str) {
+        return text.to_string();
+    }
+    if let Some(text) = payload.as_str() {
+        return text.to_string();
+    }
+    payload.to_string()
+}

--- a/crates/clawdentity-cli/src/commands/connector/receipts.rs
+++ b/crates/clawdentity-cli/src/commands/connector/receipts.rs
@@ -1,0 +1,304 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Result, anyhow};
+use clawdentity_core::config::ConfigPathOptions;
+use clawdentity_core::constants::AGENTS_DIR;
+use clawdentity_core::db::now_utc_ms;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use tokio::sync::{mpsc, oneshot};
+
+use super::runtime_config::load_receipt_post_headers;
+
+const RECEIPT_OUTBOX_DIR: &str = "receipt-outbox";
+const RECEIPT_OUTBOX_FILE: &str = "receipt-outbox.json";
+const RECEIPT_RETRY_INITIAL_MS: i64 = 1_000;
+const RECEIPT_RETRY_MAX_MS: i64 = 60_000;
+const RECEIPT_RETRY_BACKOFF_FACTOR: i64 = 2;
+const RECEIPT_OUTBOX_COMMAND_BUFFER: usize = 128;
+
+#[derive(Clone)]
+pub(super) struct ReceiptDispatchRuntime {
+    pub(super) options: ConfigPathOptions,
+    pub(super) config_dir: PathBuf,
+    pub(super) agent_name: String,
+    pub(super) proxy_receipt_url: String,
+}
+
+#[derive(Clone)]
+pub(super) struct ReceiptOutboxHandle {
+    command_tx: mpsc::Sender<ReceiptOutboxCommand>,
+}
+
+enum ReceiptOutboxCommand {
+    EnqueueAndFlush {
+        payload: DeliveryReceiptPayload,
+        respond_to: oneshot::Sender<Result<()>>,
+    },
+    FlushDue {
+        respond_to: oneshot::Sender<Result<()>>,
+    },
+}
+
+impl ReceiptOutboxHandle {
+    pub(super) async fn enqueue_and_try_flush(
+        &self,
+        payload: DeliveryReceiptPayload,
+    ) -> Result<()> {
+        self.request(|respond_to| ReceiptOutboxCommand::EnqueueAndFlush {
+            payload,
+            respond_to,
+        })
+        .await
+    }
+
+    pub(super) async fn flush_due(&self) -> Result<()> {
+        self.request(|respond_to| ReceiptOutboxCommand::FlushDue { respond_to })
+            .await
+    }
+
+    async fn request(
+        &self,
+        build_command: impl FnOnce(oneshot::Sender<Result<()>>) -> ReceiptOutboxCommand,
+    ) -> Result<()> {
+        let (respond_to, response_rx) = oneshot::channel();
+        self.command_tx
+            .send(build_command(respond_to))
+            .await
+            .map_err(|_| anyhow!("receipt outbox worker is unavailable"))?;
+        response_rx
+            .await
+            .map_err(|_| anyhow!("receipt outbox worker dropped command response"))?
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(super) enum DeliveryReceiptStatus {
+    #[serde(rename = "processed_by_openclaw")]
+    ProcessedByOpenclaw,
+    #[serde(rename = "dead_lettered")]
+    DeadLettered,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(super) struct DeliveryReceiptPayload {
+    pub(super) request_id: String,
+    pub(super) sender_agent_did: String,
+    pub(super) recipient_agent_did: String,
+    pub(super) status: DeliveryReceiptStatus,
+    pub(super) reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct QueuedDeliveryReceipt {
+    key: String,
+    request_id: String,
+    sender_agent_did: String,
+    recipient_agent_did: String,
+    status: DeliveryReceiptStatus,
+    reason: Option<String>,
+    attempt_count: i64,
+    next_attempt_at_ms: i64,
+    created_at_ms: i64,
+}
+
+fn outbox_path(config_dir: &Path, agent_name: &str) -> PathBuf {
+    config_dir
+        .join(AGENTS_DIR)
+        .join(agent_name)
+        .join(RECEIPT_OUTBOX_DIR)
+        .join(RECEIPT_OUTBOX_FILE)
+}
+
+fn make_receipt_key(input: &DeliveryReceiptPayload) -> String {
+    format!(
+        "{}:{}",
+        input.request_id,
+        match input.status {
+            DeliveryReceiptStatus::ProcessedByOpenclaw => "processed_by_openclaw",
+            DeliveryReceiptStatus::DeadLettered => "dead_lettered",
+        }
+    )
+}
+
+fn load_outbox(path: &Path) -> Result<Vec<QueuedDeliveryReceipt>> {
+    let raw = match fs::read_to_string(path) {
+        Ok(raw) => raw,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) => return Err(anyhow!("failed to read receipt outbox: {error}")),
+    };
+    if raw.trim().is_empty() {
+        return Ok(Vec::new());
+    }
+    let parsed = serde_json::from_str::<Vec<QueuedDeliveryReceipt>>(&raw)
+        .map_err(|error| anyhow!("failed to parse receipt outbox: {error}"))?;
+    Ok(parsed)
+}
+
+fn save_outbox(path: &Path, entries: &[QueuedDeliveryReceipt]) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|error| anyhow!("failed to create receipt outbox directory: {error}"))?;
+    }
+    let body = serde_json::to_string_pretty(entries)
+        .map_err(|error| anyhow!("failed to encode receipt outbox: {error}"))?;
+    fs::write(path, format!("{body}\n"))
+        .map_err(|error| anyhow!("failed to write receipt outbox: {error}"))?;
+    Ok(())
+}
+
+fn compute_retry_delay_ms(attempt_count: i64) -> i64 {
+    let exponent = attempt_count.saturating_sub(1).max(0) as u32;
+    let mut delay =
+        RECEIPT_RETRY_INITIAL_MS.saturating_mul(RECEIPT_RETRY_BACKOFF_FACTOR.pow(exponent));
+    if delay < 1 {
+        delay = 1;
+    }
+    delay.min(RECEIPT_RETRY_MAX_MS)
+}
+
+async fn post_receipt(
+    runtime: &ReceiptDispatchRuntime,
+    http_client: &reqwest::Client,
+    payload: &DeliveryReceiptPayload,
+) -> Result<()> {
+    let body = serde_json::to_vec(&json!({
+        "requestId": payload.request_id,
+        "senderAgentDid": payload.sender_agent_did,
+        "recipientAgentDid": payload.recipient_agent_did,
+        "status": match payload.status {
+            DeliveryReceiptStatus::ProcessedByOpenclaw => "processed_by_openclaw",
+            DeliveryReceiptStatus::DeadLettered => "dead_lettered",
+        },
+        "reason": payload.reason,
+    }))
+    .map_err(|error| anyhow!("failed to encode delivery receipt payload: {error}"))?;
+
+    let headers = load_receipt_post_headers(
+        &runtime.options,
+        &runtime.agent_name,
+        &runtime.proxy_receipt_url,
+        &body,
+    )?;
+
+    let mut request = http_client
+        .post(&runtime.proxy_receipt_url)
+        .header("content-type", "application/json")
+        .body(body);
+    for (name, value) in headers {
+        request = request.header(name, value);
+    }
+
+    let response = request
+        .send()
+        .await
+        .map_err(|error| anyhow!("delivery receipt callback request failed: {error}"))?;
+    if !response.status().is_success() {
+        return Err(anyhow!(
+            "delivery receipt callback request failed with HTTP {}",
+            response.status()
+        ));
+    }
+    Ok(())
+}
+
+fn enqueue_receipt(
+    runtime: &ReceiptDispatchRuntime,
+    payload: DeliveryReceiptPayload,
+) -> Result<()> {
+    let path = outbox_path(&runtime.config_dir, &runtime.agent_name);
+    let mut entries = load_outbox(&path)?;
+    let now_ms = now_utc_ms();
+    let key = make_receipt_key(&payload);
+    let next = QueuedDeliveryReceipt {
+        key: key.clone(),
+        request_id: payload.request_id,
+        sender_agent_did: payload.sender_agent_did,
+        recipient_agent_did: payload.recipient_agent_did,
+        status: payload.status,
+        reason: payload.reason,
+        attempt_count: 0,
+        next_attempt_at_ms: now_ms,
+        created_at_ms: now_ms,
+    };
+    if let Some(existing) = entries.iter_mut().find(|entry| entry.key == key) {
+        let created_at_ms = existing.created_at_ms;
+        *existing = QueuedDeliveryReceipt {
+            created_at_ms,
+            ..next
+        };
+    } else {
+        entries.push(next);
+    }
+    save_outbox(&path, &entries)
+}
+
+async fn flush_due_receipts(
+    runtime: &ReceiptDispatchRuntime,
+    http_client: &reqwest::Client,
+) -> Result<()> {
+    let path = outbox_path(&runtime.config_dir, &runtime.agent_name);
+    let now_ms = now_utc_ms();
+    let mut entries = load_outbox(&path)?;
+    if entries.is_empty() {
+        return Ok(());
+    }
+    entries.sort_by_key(|entry| entry.created_at_ms);
+
+    let mut retained: Vec<QueuedDeliveryReceipt> = Vec::with_capacity(entries.len());
+    for mut entry in entries {
+        if entry.next_attempt_at_ms > now_ms {
+            retained.push(entry);
+            continue;
+        }
+        let payload = DeliveryReceiptPayload {
+            request_id: entry.request_id.clone(),
+            sender_agent_did: entry.sender_agent_did.clone(),
+            recipient_agent_did: entry.recipient_agent_did.clone(),
+            status: entry.status.clone(),
+            reason: entry.reason.clone(),
+        };
+        if let Err(error) = post_receipt(runtime, http_client, &payload).await {
+            entry.attempt_count = entry.attempt_count.saturating_add(1);
+            entry.next_attempt_at_ms = now_ms + compute_retry_delay_ms(entry.attempt_count);
+            tracing::warn!(
+                error = %error,
+                request_id = %entry.request_id,
+                attempt_count = entry.attempt_count,
+                "failed to flush queued delivery receipt"
+            );
+            retained.push(entry);
+        }
+    }
+    save_outbox(&path, &retained)?;
+    Ok(())
+}
+
+pub(super) fn start_receipt_outbox_worker(
+    runtime: ReceiptDispatchRuntime,
+    http_client: reqwest::Client,
+) -> ReceiptOutboxHandle {
+    let (command_tx, mut command_rx) = mpsc::channel(RECEIPT_OUTBOX_COMMAND_BUFFER);
+    tokio::spawn(async move {
+        while let Some(command) = command_rx.recv().await {
+            match command {
+                ReceiptOutboxCommand::EnqueueAndFlush {
+                    payload,
+                    respond_to,
+                } => {
+                    let result = match enqueue_receipt(&runtime, payload) {
+                        Ok(()) => flush_due_receipts(&runtime, &http_client).await,
+                        Err(error) => Err(error),
+                    };
+                    let _ = respond_to.send(result);
+                }
+                ReceiptOutboxCommand::FlushDue { respond_to } => {
+                    let result = flush_due_receipts(&runtime, &http_client).await;
+                    let _ = respond_to.send(result);
+                }
+            }
+        }
+    });
+    ReceiptOutboxHandle { command_tx }
+}

--- a/crates/clawdentity-cli/src/commands/connector/receipts.rs
+++ b/crates/clawdentity-cli/src/commands/connector/receipts.rs
@@ -143,8 +143,15 @@ fn save_outbox(path: &Path, entries: &[QueuedDeliveryReceipt]) -> Result<()> {
     }
     let body = serde_json::to_string_pretty(entries)
         .map_err(|error| anyhow!("failed to encode receipt outbox: {error}"))?;
-    fs::write(path, format!("{body}\n"))
-        .map_err(|error| anyhow!("failed to write receipt outbox: {error}"))?;
+    let tmp_path = path.with_extension(format!(
+        "tmp-{}-{}",
+        std::process::id(),
+        now_utc_ms()
+    ));
+    fs::write(&tmp_path, format!("{body}\n"))
+        .map_err(|error| anyhow!("failed to write receipt outbox temp file: {error}"))?;
+    fs::rename(&tmp_path, path)
+        .map_err(|error| anyhow!("failed to atomically replace receipt outbox file: {error}"))?;
     Ok(())
 }
 

--- a/crates/clawdentity-cli/src/commands/connector/runtime_config.rs
+++ b/crates/clawdentity-cli/src/commands/connector/runtime_config.rs
@@ -8,8 +8,8 @@ use clawdentity_core::agent::{AgentAuthRecord, inspect_agent};
 use clawdentity_core::config::{ConfigPathOptions, get_config_dir, resolve_config};
 use clawdentity_core::constants::{AGENTS_DIR, AIT_FILE_NAME, SECRET_KEY_FILE_NAME};
 use clawdentity_core::{
-    build_relay_connect_headers, fetch_registry_metadata, refresh_agent_auth,
-    resolve_openclaw_base_url, resolve_openclaw_hook_token,
+    SignHttpRequestInput, build_relay_connect_headers, fetch_registry_metadata, new_frame_id,
+    refresh_agent_auth, resolve_openclaw_base_url, resolve_openclaw_hook_token, sign_http_request,
 };
 
 use super::{ConnectorRuntimeConfig, StartConnectorInput, env_trimmed, normalize_hook_path};
@@ -17,6 +17,7 @@ use super::{ConnectorRuntimeConfig, StartConnectorInput, env_trimmed, normalize_
 const REGISTRY_AUTH_FILE_NAME: &str = "registry-auth.json";
 const ACCESS_TOKEN_REFRESH_LEEWAY_SECONDS: i64 = 60;
 const RELAY_CONNECT_PATH: &str = "/v1/relay/connect";
+const RELAY_DELIVERY_RECEIPTS_PATH: &str = "/v1/relay/delivery-receipts";
 
 struct ConnectorRuntimeInputs {
     config: clawdentity_core::config::CliConfig,
@@ -38,10 +39,14 @@ pub(super) async fn resolve_runtime_config(
         &runtime_inputs.config.registry_url,
     )
     .await?;
+    let proxy_receipt_url = resolve_proxy_receipt_url(&proxy_ws_url)?;
+    let config_dir = runtime_inputs.config_dir.clone();
 
     Ok(ConnectorRuntimeConfig {
         agent_name: input.agent_name,
         agent_did: runtime_inputs.agent_did,
+        config_dir,
+        proxy_receipt_url,
         proxy_ws_url,
         openclaw_runtime: clawdentity_core::runtime_openclaw::OpenclawRuntimeConfig {
             base_url: resolve_openclaw_base_url(
@@ -246,4 +251,65 @@ pub(super) fn normalize_proxy_ws_url(value: &str) -> Result<String> {
         url.set_path(RELAY_CONNECT_PATH);
     }
     Ok(url.to_string())
+}
+
+pub(super) fn resolve_proxy_receipt_url(proxy_ws_url: &str) -> Result<String> {
+    let mut url = reqwest::Url::parse(proxy_ws_url)
+        .map_err(|_| anyhow!("invalid proxy websocket URL: {proxy_ws_url}"))?;
+    match url.scheme() {
+        "ws" => {
+            url.set_scheme("http")
+                .map_err(|_| anyhow!("failed to normalize receipt URL scheme"))?;
+        }
+        "wss" => {
+            url.set_scheme("https")
+                .map_err(|_| anyhow!("failed to normalize receipt URL scheme"))?;
+        }
+        "http" | "https" => {}
+        _ => return Err(anyhow!("invalid proxy websocket scheme in {proxy_ws_url}")),
+    }
+    url.set_path(RELAY_DELIVERY_RECEIPTS_PATH);
+    url.set_query(None);
+    Ok(url.to_string())
+}
+
+fn to_path_with_query(url: &reqwest::Url) -> String {
+    match url.query() {
+        Some(query) if !query.is_empty() => format!("{}?{query}", url.path()),
+        _ => url.path().to_string(),
+    }
+}
+
+pub(super) fn load_receipt_post_headers(
+    options: &ConfigPathOptions,
+    agent_name: &str,
+    receipt_url: &str,
+    body: &[u8],
+) -> Result<Vec<(String, String)>> {
+    let runtime_inputs = resolve_runtime_inputs(options, agent_name)?;
+    let signing_key = clawdentity_core::decode_secret_key(&runtime_inputs.secret_key)?;
+    let parsed_url = reqwest::Url::parse(receipt_url)
+        .map_err(|_| anyhow!("invalid proxy receipt URL: {receipt_url}"))?;
+    let timestamp = Utc::now().timestamp().to_string();
+    let nonce = new_frame_id();
+    let signed = sign_http_request(&SignHttpRequestInput {
+        method: "POST",
+        path_with_query: &to_path_with_query(&parsed_url),
+        timestamp: &timestamp,
+        nonce: &nonce,
+        body,
+        secret_key: &signing_key,
+    })?;
+
+    let mut headers = Vec::with_capacity(signed.headers.len() + 2);
+    headers.push((
+        "authorization".to_string(),
+        format!("Claw {}", runtime_inputs.ait),
+    ));
+    headers.push((
+        "x-claw-agent-access".to_string(),
+        runtime_inputs.agent_auth.access_token.clone(),
+    ));
+    headers.extend(signed.headers);
+    Ok(headers)
 }

--- a/crates/clawdentity-cli/src/commands/connector/tests.rs
+++ b/crates/clawdentity-cli/src/commands/connector/tests.rs
@@ -472,13 +472,13 @@ fn write_receipt_fixture_config(options: &ConfigPathOptions) {
             api_key: None,
             human_name: Some("Tester".to_string()),
         },
-        &options,
+        options,
     )
     .expect("write config");
 }
 
 fn write_receipt_fixture_agent_files(options: &ConfigPathOptions, agent_name: &str) {
-    let config_dir = get_config_dir(&options).expect("resolve config dir");
+    let config_dir = get_config_dir(options).expect("resolve config dir");
     let agent_dir = config_dir.join(AGENTS_DIR).join(agent_name);
     fs::create_dir_all(&agent_dir).expect("create agent dir");
 

--- a/crates/clawdentity-cli/src/commands/connector/tests.rs
+++ b/crates/clawdentity-cli/src/commands/connector/tests.rs
@@ -1,11 +1,16 @@
 use anyhow::anyhow;
 use chrono::{Duration as ChronoDuration, Utc};
 use clawdentity_core::agent::AgentAuthRecord;
+use clawdentity_core::config::{CliConfig, ConfigPathOptions, get_config_dir, write_config};
+use clawdentity_core::constants::{AGENTS_DIR, AIT_FILE_NAME, SECRET_KEY_FILE_NAME};
 use clawdentity_core::{DeliverFrame, ReceiptFrame, ReceiptStatus};
 use serde_json::json;
 use std::collections::HashMap;
+use std::fs;
 
-use super::runtime_config::{agent_access_requires_refresh, normalize_proxy_ws_url};
+use super::runtime_config::{
+    agent_access_requires_refresh, load_receipt_post_headers, normalize_proxy_ws_url,
+};
 use super::{
     SenderProfileHeaders, build_deliver_ack_reason, build_openclaw_delivery_headers,
     build_openclaw_hook_payload, build_openclaw_receipt_payload, normalize_hook_path,
@@ -335,6 +340,14 @@ fn openclaw_receipt_payload_uses_message_field_for_agent_hooks() {
         payload.get("message").and_then(|value| value.as_str()),
         payload.get("content").and_then(|value| value.as_str())
     );
+    assert_eq!(
+        payload
+            .get("metadata")
+            .and_then(|value| value.get("receipt"))
+            .and_then(|value| value.get("status"))
+            .and_then(|value| value.as_str()),
+        Some("dead_lettered")
+    );
 }
 
 #[test]
@@ -362,6 +375,14 @@ fn openclaw_receipt_payload_uses_text_for_wake_hooks() {
         payload.get("message").and_then(|value| value.as_str()),
         payload.get("text").and_then(|value| value.as_str())
     );
+    assert_eq!(
+        payload
+            .get("metadata")
+            .and_then(|value| value.get("receipt"))
+            .and_then(|value| value.get("status"))
+            .and_then(|value| value.as_str()),
+        Some("processed_by_openclaw")
+    );
 }
 
 #[test]
@@ -369,6 +390,160 @@ fn pending_retry_dead_letters_at_max_attempt_threshold() {
     assert!(!should_dead_letter_after_failure(0));
     assert!(!should_dead_letter_after_failure(1));
     assert!(should_dead_letter_after_failure(2));
+}
+
+fn encode_base64url(input: &[u8]) -> String {
+    const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+
+    let mut output = String::with_capacity((input.len() * 4).div_ceil(3));
+    let mut index = 0usize;
+    while index + 3 <= input.len() {
+        let block = ((input[index] as u32) << 16)
+            | ((input[index + 1] as u32) << 8)
+            | (input[index + 2] as u32);
+        output.push(ALPHABET[((block >> 18) & 0x3f) as usize] as char);
+        output.push(ALPHABET[((block >> 12) & 0x3f) as usize] as char);
+        output.push(ALPHABET[((block >> 6) & 0x3f) as usize] as char);
+        output.push(ALPHABET[(block & 0x3f) as usize] as char);
+        index += 3;
+    }
+
+    match input.len() - index {
+        1 => {
+            let block = (input[index] as u32) << 16;
+            output.push(ALPHABET[((block >> 18) & 0x3f) as usize] as char);
+            output.push(ALPHABET[((block >> 12) & 0x3f) as usize] as char);
+        }
+        2 => {
+            let block = ((input[index] as u32) << 16) | ((input[index + 1] as u32) << 8);
+            output.push(ALPHABET[((block >> 18) & 0x3f) as usize] as char);
+            output.push(ALPHABET[((block >> 12) & 0x3f) as usize] as char);
+            output.push(ALPHABET[((block >> 6) & 0x3f) as usize] as char);
+        }
+        _ => {}
+    }
+
+    output
+}
+
+fn fixture_ait() -> String {
+    let header = r#"{"alg":"EdDSA","kid":"key-1","typ":"JWT"}"#;
+    let payload = r#"{"sub":"did:cdi:test:agent:alpha","ownerDid":"did:cdi:test:human:owner","cnf":{"jwk":{"x":"public-key-x"}},"exp":4102444800,"framework":"openclaw"}"#;
+    format!(
+        "{}.{}.sig",
+        encode_base64url(header.as_bytes()),
+        encode_base64url(payload.as_bytes())
+    )
+}
+
+fn setup_receipt_header_fixture() -> (ConfigPathOptions, String) {
+    let root = std::env::temp_dir().join(format!(
+        "clawdentity-connector-tests-{}-{}",
+        std::process::id(),
+        Utc::now().timestamp_nanos_opt().unwrap_or(0)
+    ));
+    fs::create_dir_all(&root).expect("create test root");
+
+    let options = ConfigPathOptions {
+        home_dir: Some(root),
+        registry_url_hint: None,
+    };
+    write_config(
+        &CliConfig {
+            registry_url: "https://registry.example".to_string(),
+            proxy_url: Some("https://proxy.example".to_string()),
+            api_key: None,
+            human_name: Some("Tester".to_string()),
+        },
+        &options,
+    )
+    .expect("write config");
+
+    let agent_name = "alpha".to_string();
+    let config_dir = get_config_dir(&options).expect("resolve config dir");
+    let agent_dir = config_dir.join(AGENTS_DIR).join(&agent_name);
+    fs::create_dir_all(&agent_dir).expect("create agent dir");
+
+    fs::write(
+        agent_dir.join(AIT_FILE_NAME),
+        format!("{}\n", fixture_ait()),
+    )
+    .expect("write ait");
+    fs::write(
+        agent_dir.join(SECRET_KEY_FILE_NAME),
+        format!("{}\n", encode_base64url(&[7_u8; 32])),
+    )
+    .expect("write secret key");
+    fs::write(
+        agent_dir.join("registry-auth.json"),
+        r#"{
+  "tokenType": "Bearer",
+  "accessToken": "clw_agt_access",
+  "accessExpiresAt": "2099-01-01T00:00:00Z",
+  "refreshToken": "clw_agt_refresh",
+  "refreshExpiresAt": "2099-01-08T00:00:00Z"
+}
+"#,
+    )
+    .expect("write registry auth");
+
+    (options, agent_name)
+}
+
+#[test]
+fn receipt_post_headers_nonce_uses_random_url_safe_shape() {
+    let (options, agent_name) = setup_receipt_header_fixture();
+    let headers = load_receipt_post_headers(
+        &options,
+        &agent_name,
+        "https://proxy.example/v1/relay/delivery-receipts",
+        br#"{"requestId":"req-1"}"#,
+    )
+    .expect("receipt headers");
+    let nonce = headers
+        .iter()
+        .find(|(name, _)| name.eq_ignore_ascii_case("x-claw-nonce"))
+        .map(|(_, value)| value)
+        .expect("x-claw-nonce header is required");
+
+    assert!(!nonce.starts_with("receipt-"));
+    assert!(nonce.len() >= 22);
+    assert!(
+        nonce
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || ch == '-' || ch == '_')
+    );
+}
+
+#[test]
+fn receipt_post_headers_nonce_changes_between_calls() {
+    let (options, agent_name) = setup_receipt_header_fixture();
+    let headers_one = load_receipt_post_headers(
+        &options,
+        &agent_name,
+        "https://proxy.example/v1/relay/delivery-receipts",
+        br#"{"requestId":"req-1"}"#,
+    )
+    .expect("first receipt headers");
+    let headers_two = load_receipt_post_headers(
+        &options,
+        &agent_name,
+        "https://proxy.example/v1/relay/delivery-receipts",
+        br#"{"requestId":"req-1"}"#,
+    )
+    .expect("second receipt headers");
+    let nonce_one = headers_one
+        .into_iter()
+        .find(|(name, _)| name.eq_ignore_ascii_case("x-claw-nonce"))
+        .map(|(_, value)| value)
+        .expect("first nonce header");
+    let nonce_two = headers_two
+        .into_iter()
+        .find(|(name, _)| name.eq_ignore_ascii_case("x-claw-nonce"))
+        .map(|(_, value)| value)
+        .expect("second nonce header");
+
+    assert_ne!(nonce_one, nonce_two);
 }
 
 fn sample_auth_record(access_token: &str, expires_at: chrono::DateTime<Utc>) -> AgentAuthRecord {

--- a/crates/clawdentity-cli/src/commands/connector/tests.rs
+++ b/crates/clawdentity-cli/src/commands/connector/tests.rs
@@ -7,6 +7,8 @@ use clawdentity_core::{DeliverFrame, ReceiptFrame, ReceiptStatus};
 use serde_json::json;
 use std::collections::HashMap;
 use std::fs;
+use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use super::runtime_config::{
     agent_access_requires_refresh, load_receipt_post_headers, normalize_proxy_ws_url,
@@ -436,18 +438,33 @@ fn fixture_ait() -> String {
     )
 }
 
+static RECEIPT_FIXTURE_COUNTER: AtomicU64 = AtomicU64::new(1);
+
 fn setup_receipt_header_fixture() -> (ConfigPathOptions, String) {
+    let options = receipt_fixture_options();
+    write_receipt_fixture_config(&options);
+
+    let agent_name = "alpha".to_string();
+    write_receipt_fixture_agent_files(&options, &agent_name);
+    (options, agent_name)
+}
+
+fn receipt_fixture_options() -> ConfigPathOptions {
+    let fixture_id = RECEIPT_FIXTURE_COUNTER.fetch_add(1, Ordering::Relaxed);
     let root = std::env::temp_dir().join(format!(
-        "clawdentity-connector-tests-{}-{}",
+        "clawdentity-connector-tests-{}-{}-{fixture_id}",
         std::process::id(),
         Utc::now().timestamp_nanos_opt().unwrap_or(0)
     ));
     fs::create_dir_all(&root).expect("create test root");
 
-    let options = ConfigPathOptions {
+    ConfigPathOptions {
         home_dir: Some(root),
         registry_url_hint: None,
-    };
+    }
+}
+
+fn write_receipt_fixture_config(options: &ConfigPathOptions) {
     write_config(
         &CliConfig {
             registry_url: "https://registry.example".to_string(),
@@ -458,36 +475,51 @@ fn setup_receipt_header_fixture() -> (ConfigPathOptions, String) {
         &options,
     )
     .expect("write config");
+}
 
-    let agent_name = "alpha".to_string();
+fn write_receipt_fixture_agent_files(options: &ConfigPathOptions, agent_name: &str) {
     let config_dir = get_config_dir(&options).expect("resolve config dir");
-    let agent_dir = config_dir.join(AGENTS_DIR).join(&agent_name);
+    let agent_dir = config_dir.join(AGENTS_DIR).join(agent_name);
     fs::create_dir_all(&agent_dir).expect("create agent dir");
 
+    write_receipt_fixture_ait(&agent_dir);
+    write_receipt_fixture_secret_key(&agent_dir);
+    write_receipt_fixture_auth(&agent_dir);
+}
+
+fn write_receipt_fixture_ait(agent_dir: &Path) {
     fs::write(
         agent_dir.join(AIT_FILE_NAME),
         format!("{}\n", fixture_ait()),
     )
     .expect("write ait");
+}
+
+fn write_receipt_fixture_secret_key(agent_dir: &Path) {
     fs::write(
         agent_dir.join(SECRET_KEY_FILE_NAME),
         format!("{}\n", encode_base64url(&[7_u8; 32])),
     )
     .expect("write secret key");
+}
+
+fn write_receipt_fixture_auth(agent_dir: &Path) {
     fs::write(
         agent_dir.join("registry-auth.json"),
-        r#"{
+        receipt_fixture_registry_auth_json(),
+    )
+    .expect("write registry auth");
+}
+
+fn receipt_fixture_registry_auth_json() -> &'static str {
+    r#"{
   "tokenType": "Bearer",
   "accessToken": "clw_agt_access",
   "accessExpiresAt": "2099-01-01T00:00:00Z",
   "refreshToken": "clw_agt_refresh",
   "refreshExpiresAt": "2099-01-08T00:00:00Z"
 }
-"#,
-    )
-    .expect("write registry auth");
-
-    (options, agent_name)
+"#
 }
 
 #[test]

--- a/packages/connector/src/runtime.ts
+++ b/packages/connector/src/runtime.ts
@@ -8,6 +8,7 @@ import { ConnectorClient } from "./client.js";
 import { createConnectorInboundInbox } from "./inbound-inbox.js";
 import { createRuntimeAuthController } from "./runtime/auth-lifecycle.js";
 import { toInitialAuthBundle } from "./runtime/auth-storage.js";
+import { RECEIPT_OUTBOX_RETRY_INTERVAL_MS } from "./runtime/constants.js";
 import { sanitizeErrorReason } from "./runtime/errors.js";
 import { deliverReceiptToOpenclawHook } from "./runtime/openclaw.js";
 import { createOpenclawHookTokenController } from "./runtime/openclaw-hook-token.js";
@@ -18,11 +19,11 @@ import {
   loadInboundReplayPolicy,
   loadOpenclawProbePolicy,
 } from "./runtime/policy.js";
+import { createDeliveryReceiptOutbox } from "./runtime/receipt-outbox.js";
 import { createRelayService } from "./runtime/relay-service.js";
 import { loadSenderProfilesByDid } from "./runtime/relay-transform-peers.js";
 import { createInboundReplayController } from "./runtime/replay.js";
 import { createRuntimeRequestHandler } from "./runtime/server.js";
-import { loadTrustedReceiptTargets } from "./runtime/trusted-receipts.js";
 import type {
   ConnectorRuntimeHandle,
   OpenclawGatewayProbeStatus,
@@ -77,9 +78,6 @@ export async function startConnectorRuntime(
     RELAY_DELIVERY_RECEIPTS_PATH.slice(1),
     `${toHttpOriginFromWebSocketUrl(wsParsed)}/`,
   ).toString();
-  const defaultReceiptCallbackOrigin = new URL(defaultReceiptCallbackUrl)
-    .origin;
-
   const openclawBaseUrl = resolveOpenclawBaseUrl(input.openclawBaseUrl);
   const openclawProbeUrl = openclawBaseUrl;
   const openclawHookPath = resolveOpenclawHookPath(input.openclawHookPath);
@@ -90,12 +88,6 @@ export async function startConnectorRuntime(
 
   const inboundReplayPolicy = loadInboundReplayPolicy();
   const openclawProbePolicy = loadOpenclawProbePolicy();
-
-  const trustedReceiptTargets = await loadTrustedReceiptTargets({
-    configDir: input.configDir,
-    logger,
-  });
-  trustedReceiptTargets.origins.add(defaultReceiptCallbackOrigin);
 
   const inboundInbox = createConnectorInboundInbox({
     configDir: input.configDir,
@@ -113,6 +105,7 @@ export async function startConnectorRuntime(
   let runtimeStopping = false;
   let replayIntervalHandle: ReturnType<typeof setInterval> | undefined;
   let openclawProbeIntervalHandle: ReturnType<typeof setInterval> | undefined;
+  let receiptOutboxIntervalHandle: ReturnType<typeof setInterval> | undefined;
   const runtimeShutdownController = new AbortController();
 
   const openclawHookTokenController = createOpenclawHookTokenController({
@@ -143,11 +136,37 @@ export async function startConnectorRuntime(
     secretKey,
     ait: input.credentials.ait,
     defaultReceiptCallbackUrl,
-    trustedReceiptTargets,
     getCurrentAuth: authController.getCurrentAuth,
     setCurrentAuth: authController.persistCurrentAuth,
     syncAuthFromDisk: authController.syncAuthFromDisk,
   });
+
+  const receiptOutbox = createDeliveryReceiptOutbox({
+    configDir: input.configDir,
+    agentName: input.agentName,
+    inboundReplayPolicy,
+    logger,
+    sendReceipt: relayService.postDeliveryReceipt,
+  });
+
+  const queueReceiptAndTryFlush = async (receipt: {
+    reason?: string;
+    recipientAgentDid: string;
+    requestId: string;
+    senderAgentDid: string;
+    status: "processed_by_openclaw" | "dead_lettered";
+  }): Promise<void> => {
+    await receiptOutbox.enqueue(receipt);
+    try {
+      await receiptOutbox.flushDue();
+    } catch (error) {
+      logger.warn("connector.receipt_outbox.flush_failed", {
+        requestId: receipt.requestId,
+        status: receipt.status,
+        reason: sanitizeErrorReason(error),
+      });
+    }
+  };
 
   const replayController = createInboundReplayController({
     fetchImpl,
@@ -165,7 +184,7 @@ export async function startConnectorRuntime(
     openclawGatewayProbeStatus,
     openclawHookUrl,
     openclawProbeUrl,
-    postDeliveryReceipt: relayService.postDeliveryReceipt,
+    postDeliveryReceipt: queueReceiptAndTryFlush,
     runtimeShutdownSignal: runtimeShutdownController.signal,
     syncOpenclawHookToken: openclawHookTokenController.syncOpenclawHookToken,
   });
@@ -294,6 +313,10 @@ export async function startConnectorRuntime(
       clearInterval(openclawProbeIntervalHandle);
       openclawProbeIntervalHandle = undefined;
     }
+    if (receiptOutboxIntervalHandle !== undefined) {
+      clearInterval(receiptOutboxIntervalHandle);
+      receiptOutboxIntervalHandle = undefined;
+    }
     connectorClient.disconnect();
     await new Promise<void>((resolve, reject) => {
       server.close((error) => {
@@ -323,6 +346,7 @@ export async function startConnectorRuntime(
   await openclawProbeController.probeOpenclawGateway();
   connectorClient.connect();
   await inboundInbox.pruneDelivered();
+  await receiptOutbox.flushDue();
   void replayController.replayPendingInboundMessages();
 
   replayIntervalHandle = setInterval(() => {
@@ -332,6 +356,10 @@ export async function startConnectorRuntime(
   openclawProbeIntervalHandle = setInterval(() => {
     void openclawProbeController.probeOpenclawGateway();
   }, openclawProbePolicy.intervalMs);
+
+  receiptOutboxIntervalHandle = setInterval(() => {
+    void receiptOutbox.flushDue();
+  }, RECEIPT_OUTBOX_RETRY_INTERVAL_MS);
 
   logger.info("connector.runtime.started", {
     outboundUrl,

--- a/packages/connector/src/runtime/AGENTS.md
+++ b/packages/connector/src/runtime/AGENTS.md
@@ -11,9 +11,13 @@
 - Keep gateway probe in-flight/health transitions in `openclaw-probe.ts`; avoid duplicate probe loops in `runtime.ts`.
 - Keep replay/probe policy loading and retry-delay calculations in `policy.ts`.
 - Keep replay orchestration and receipt callbacks in `replay.ts`; avoid re-embedding lane scheduling and dead-letter transitions in `runtime.ts`.
-- Keep relay peers snapshot parsing centralized in `relay-transform-peers.ts`; reuse it for both trusted receipt targets and sender-profile enrichment.
+- Keep relay peers snapshot parsing centralized in `relay-transform-peers.ts`; reuse it for sender-profile enrichment.
 - Replay should resolve sender profile headers once per replay batch from relay peers snapshot and omit profile headers when peer metadata is unavailable.
-- Keep outbound relay and receipt callbacks in `relay-service.ts`; receipt posts must target validated `replyTo` URLs directly and enforce trusted-origin checks.
+- Keep outbound relay and receipt callbacks in `relay-service.ts`; callback routing authority is always the runtime-owned proxy receipt endpoint (`defaultReceiptCallbackUrl`), not inbound `replyTo`.
+- Keep durable receipt retry/dequeue mechanics in `receipt-outbox.ts` and wire its lifecycle in `runtime.ts`; preserve at-least-once semantics with idempotent keys (`requestId:status`).
+- Treat `receipt-outbox.ts` as a single-writer command actor: every `enqueue`/`flushDue` mutation must flow through one serialized lock so concurrent callers cannot interleave file reads/writes.
+- Keep receipt-outbox tests deterministic: use fake timers for retry backoff assertions and avoid wall-clock `setTimeout` dependency.
+- Runtime startup/shutdown must include receipt-outbox lifecycle hooks (`flushDue` on start and periodic retry loop teardown on stop) so queued receipts survive transient proxy outages.
 - Keep HTTP route handling in `server.ts` and avoid embedding route logic in helpers.
 - Keep URL/header/parse helpers focused in `url.ts`, `ws.ts`, and `parse.ts`.
 - Keep OpenClaw receipt payload shaping in `openclaw.ts` so `/hooks/agent` (`message`) and `/hooks/wake` (`text`) compatibility stays centralized.

--- a/packages/connector/src/runtime/constants.ts
+++ b/packages/connector/src/runtime/constants.ts
@@ -3,10 +3,13 @@ export const OPENCLAW_RELAY_RUNTIME_FILE_NAME = "openclaw-relay.json";
 export const AGENTS_DIR_NAME = "agents";
 export const OUTBOUND_QUEUE_DIR_NAME = "outbound-queue";
 export const OUTBOUND_QUEUE_FILENAME = "queue.json";
+export const RECEIPT_OUTBOX_DIR_NAME = "receipt-outbox";
+export const RECEIPT_OUTBOX_FILENAME = "queue.json";
 export const REFRESH_SINGLE_FLIGHT_PREFIX = "connector-runtime";
 export const NONCE_SIZE = 16;
 export const MAX_OUTBOUND_BODY_BYTES = 1024 * 1024;
 export const ACCESS_TOKEN_REFRESH_SKEW_MS = 30_000;
+export const RECEIPT_OUTBOX_RETRY_INTERVAL_MS = 1_000;
 
 export const CONNECTOR_DEAD_LETTER_PATH = "/v1/inbound/dead-letter";
 export const CONNECTOR_DEAD_LETTER_REPLAY_PATH =

--- a/packages/connector/src/runtime/receipt-outbox.test.ts
+++ b/packages/connector/src/runtime/receipt-outbox.test.ts
@@ -1,0 +1,251 @@
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import type { DeliveryReceiptInput } from "./receipt-outbox.js";
+import { createDeliveryReceiptOutbox } from "./receipt-outbox.js";
+import type { InboundReplayPolicy } from "./types.js";
+
+function createInboundReplayPolicy(): InboundReplayPolicy {
+  return {
+    batchSize: 10,
+    deadLetterNonRetryableMaxAttempts: 3,
+    eventsMaxBytes: 1024 * 1024,
+    eventsMaxFiles: 10,
+    inboxMaxBytes: 1024 * 1024,
+    inboxMaxMessages: 100,
+    replayIntervalMs: 5,
+    retryBackoffFactor: 2,
+    retryInitialDelayMs: 5,
+    retryMaxDelayMs: 100,
+    runtimeReplayMaxAttempts: 5,
+    runtimeReplayRetryBackoffFactor: 2,
+    runtimeReplayRetryInitialDelayMs: 1,
+    runtimeReplayRetryMaxDelayMs: 10,
+  };
+}
+
+function createReceiptInput(
+  overrides: Partial<DeliveryReceiptInput> = {},
+): DeliveryReceiptInput {
+  return {
+    requestId: "req-default",
+    senderAgentDid: "did:cdi:test:agent:sender",
+    recipientAgentDid: "did:cdi:test:agent:recipient",
+    status: "dead_lettered",
+    ...overrides,
+  };
+}
+
+async function waitForCallCount(
+  mockFn: { mock: { calls: unknown[][] } },
+  expected: number,
+): Promise<void> {
+  for (let index = 0; index < 50; index += 1) {
+    if (mockFn.mock.calls.length >= expected) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  throw new Error(`timed out waiting for ${expected} calls`);
+}
+
+describe("delivery receipt outbox", () => {
+  it("serializes concurrent enqueue commands and keeps the latest payload for one key", async () => {
+    const root = await mkdtemp(join(tmpdir(), "connector-receipt-outbox-"));
+    const sendReceipt = vi.fn(async (_receipt: unknown) => {});
+    const outbox = createDeliveryReceiptOutbox({
+      configDir: root,
+      agentName: "alpha",
+      inboundReplayPolicy: createInboundReplayPolicy(),
+      logger: { warn: vi.fn() },
+      sendReceipt,
+    });
+
+    await Promise.all([
+      outbox.enqueue(
+        createReceiptInput({ requestId: "req-concurrent-1", reason: "first" }),
+      ),
+      outbox.enqueue(
+        createReceiptInput({ requestId: "req-concurrent-1", reason: "second" }),
+      ),
+    ]);
+
+    await outbox.flushDue();
+
+    expect(sendReceipt).toHaveBeenCalledTimes(1);
+    expect(sendReceipt.mock.calls[0]?.at(0)).toMatchObject({
+      requestId: "req-concurrent-1",
+      status: "dead_lettered",
+      reason: "second",
+    });
+  });
+
+  it("serializes concurrent flush commands so one queued receipt is dispatched once", async () => {
+    const root = await mkdtemp(join(tmpdir(), "connector-receipt-outbox-"));
+    let releaseSend: (() => void) | undefined;
+    const sendReceipt = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseSend = resolve;
+        }),
+    );
+    const outbox = createDeliveryReceiptOutbox({
+      configDir: root,
+      agentName: "alpha",
+      inboundReplayPolicy: createInboundReplayPolicy(),
+      logger: { warn: vi.fn() },
+      sendReceipt,
+    });
+    await outbox.enqueue(createReceiptInput({ requestId: "req-concurrent-2" }));
+
+    const firstFlush = outbox.flushDue();
+    const secondFlush = outbox.flushDue();
+
+    await waitForCallCount(sendReceipt, 1);
+    expect(sendReceipt).toHaveBeenCalledTimes(1);
+    releaseSend?.();
+    await Promise.all([firstFlush, secondFlush]);
+
+    expect(sendReceipt).toHaveBeenCalledTimes(1);
+  });
+
+  it("deduplicates by requestId and status before flush", async () => {
+    const root = await mkdtemp(join(tmpdir(), "connector-receipt-outbox-"));
+    const sendReceipt = vi.fn(async (_receipt: unknown) => {});
+    const outbox = createDeliveryReceiptOutbox({
+      configDir: root,
+      agentName: "alpha",
+      inboundReplayPolicy: createInboundReplayPolicy(),
+      logger: { warn: vi.fn() },
+      sendReceipt,
+    });
+
+    await outbox.enqueue(
+      createReceiptInput({ requestId: "req-1", reason: "first" }),
+    );
+    await outbox.enqueue(
+      createReceiptInput({ requestId: "req-1", reason: "second" }),
+    );
+
+    await outbox.flushDue();
+    expect(sendReceipt).toHaveBeenCalledTimes(1);
+    expect(sendReceipt.mock.calls[0]?.at(0)).toMatchObject({
+      requestId: "req-1",
+      status: "dead_lettered",
+      reason: "second",
+    });
+
+    // Successful sends must be dequeued idempotently.
+    await outbox.flushDue();
+    expect(sendReceipt).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps separate outbox entries per status for the same requestId", async () => {
+    const root = await mkdtemp(join(tmpdir(), "connector-receipt-outbox-"));
+    const sendReceipt = vi.fn(async (_receipt: unknown) => {});
+    const outbox = createDeliveryReceiptOutbox({
+      configDir: root,
+      agentName: "alpha",
+      inboundReplayPolicy: createInboundReplayPolicy(),
+      logger: { warn: vi.fn() },
+      sendReceipt,
+    });
+
+    await outbox.enqueue(createReceiptInput({ requestId: "req-2" }));
+    await outbox.enqueue(
+      createReceiptInput({
+        requestId: "req-2",
+        status: "processed_by_openclaw",
+      }),
+    );
+
+    await outbox.flushDue();
+
+    expect(sendReceipt).toHaveBeenCalledTimes(2);
+    const sentStatuses = sendReceipt.mock.calls
+      .map((call) => call[0] as DeliveryReceiptInput)
+      .map((receipt) => receipt.status)
+      .sort();
+    expect(sentStatuses).toEqual(["dead_lettered", "processed_by_openclaw"]);
+  });
+
+  it("retries only after backoff and dequeues after success", async () => {
+    const root = await mkdtemp(join(tmpdir(), "connector-receipt-outbox-"));
+    vi.useFakeTimers();
+    let attempt = 0;
+    const sendReceipt = vi.fn(async (_receipt: unknown) => {
+      attempt += 1;
+      if (attempt === 1) {
+        throw new Error("temporary failure");
+      }
+    });
+    const outbox = createDeliveryReceiptOutbox({
+      configDir: root,
+      agentName: "alpha",
+      inboundReplayPolicy: createInboundReplayPolicy(),
+      logger: { warn: vi.fn() },
+      sendReceipt,
+    });
+
+    try {
+      await outbox.enqueue(
+        createReceiptInput({
+          requestId: "req-3",
+          status: "processed_by_openclaw",
+        }),
+      );
+
+      await outbox.flushDue();
+      expect(sendReceipt).toHaveBeenCalledTimes(1);
+
+      // No retry before retryInitialDelayMs elapses.
+      await outbox.flushDue();
+      expect(sendReceipt).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(1);
+      await outbox.flushDue();
+      expect(sendReceipt).toHaveBeenCalledTimes(2);
+
+      // Successful retry dequeues the item idempotently.
+      await outbox.flushDue();
+      expect(sendReceipt).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("persists queued receipts across outbox recreation", async () => {
+    const root = await mkdtemp(join(tmpdir(), "connector-receipt-outbox-"));
+    const sendReceipt = vi.fn(async (_receipt: unknown) => {});
+
+    const initial = createDeliveryReceiptOutbox({
+      configDir: root,
+      agentName: "alpha",
+      inboundReplayPolicy: createInboundReplayPolicy(),
+      logger: { warn: vi.fn() },
+      sendReceipt,
+    });
+    await initial.enqueue(
+      createReceiptInput({
+        requestId: "req-4",
+        status: "processed_by_openclaw",
+      }),
+    );
+
+    const restarted = createDeliveryReceiptOutbox({
+      configDir: root,
+      agentName: "alpha",
+      inboundReplayPolicy: createInboundReplayPolicy(),
+      logger: { warn: vi.fn() },
+      sendReceipt,
+    });
+    await restarted.flushDue();
+
+    expect(sendReceipt).toHaveBeenCalledTimes(1);
+    expect(sendReceipt.mock.calls[0]?.at(0)).toMatchObject({
+      requestId: "req-4",
+      status: "processed_by_openclaw",
+    });
+  });
+});

--- a/packages/connector/src/runtime/receipt-outbox.ts
+++ b/packages/connector/src/runtime/receipt-outbox.ts
@@ -1,0 +1,253 @@
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { nowUtcMs } from "@clawdentity/sdk";
+import {
+  AGENTS_DIR_NAME,
+  RECEIPT_OUTBOX_DIR_NAME,
+  RECEIPT_OUTBOX_FILENAME,
+} from "./constants.js";
+import { sanitizeErrorReason } from "./errors.js";
+import { computeRuntimeReplayRetryDelayMs } from "./policy.js";
+import type { InboundReplayPolicy } from "./types.js";
+
+export type DeliveryReceiptOutboxItem = {
+  createdAtMs: number;
+  key: string;
+  nextAttemptAtMs: number;
+  reason?: string;
+  recipientAgentDid: string;
+  requestId: string;
+  senderAgentDid: string;
+  status: "processed_by_openclaw" | "dead_lettered";
+  attemptCount: number;
+};
+
+export type DeliveryReceiptInput = {
+  reason?: string;
+  recipientAgentDid: string;
+  requestId: string;
+  senderAgentDid: string;
+  status: "processed_by_openclaw" | "dead_lettered";
+};
+
+function resolveReceiptOutboxPath(input: {
+  agentName: string;
+  configDir: string;
+}): string {
+  return join(
+    input.configDir,
+    AGENTS_DIR_NAME,
+    input.agentName,
+    RECEIPT_OUTBOX_DIR_NAME,
+    RECEIPT_OUTBOX_FILENAME,
+  );
+}
+
+function makeReceiptOutboxKey(input: DeliveryReceiptInput): string {
+  return `${input.requestId}:${input.status}`;
+}
+
+function isOutboxItem(
+  candidate: unknown,
+): candidate is DeliveryReceiptOutboxItem {
+  if (typeof candidate !== "object" || candidate === null) {
+    return false;
+  }
+  const value = candidate as Partial<DeliveryReceiptOutboxItem>;
+  return (
+    typeof value.key === "string" &&
+    typeof value.requestId === "string" &&
+    typeof value.senderAgentDid === "string" &&
+    typeof value.recipientAgentDid === "string" &&
+    (value.status === "processed_by_openclaw" ||
+      value.status === "dead_lettered") &&
+    typeof value.createdAtMs === "number" &&
+    Number.isFinite(value.createdAtMs) &&
+    typeof value.nextAttemptAtMs === "number" &&
+    Number.isFinite(value.nextAttemptAtMs) &&
+    typeof value.attemptCount === "number" &&
+    Number.isInteger(value.attemptCount) &&
+    value.attemptCount >= 0 &&
+    (value.reason === undefined || typeof value.reason === "string")
+  );
+}
+
+export function createDeliveryReceiptOutbox(input: {
+  agentName: string;
+  configDir: string;
+  inboundReplayPolicy: InboundReplayPolicy;
+  logger: {
+    warn: (event: string, payload?: Record<string, unknown>) => void;
+  };
+  sendReceipt: (receipt: DeliveryReceiptInput) => Promise<void>;
+}): {
+  enqueue: (receipt: DeliveryReceiptInput) => Promise<void>;
+  flushDue: () => Promise<void>;
+} {
+  const outboxPath = resolveReceiptOutboxPath({
+    configDir: input.configDir,
+    agentName: input.agentName,
+  });
+
+  let inFlight: Promise<void> | undefined;
+
+  const withLock = async (fn: () => Promise<void>): Promise<void> => {
+    while (inFlight !== undefined) {
+      try {
+        await inFlight;
+      } catch {
+        // Previous operation error should not permanently block the queue lock.
+      }
+    }
+    const next = fn().finally(() => {
+      inFlight = undefined;
+    });
+    inFlight = next;
+    await next;
+  };
+
+  const load = async (): Promise<DeliveryReceiptOutboxItem[]> => {
+    let raw: string;
+    try {
+      raw = await readFile(outboxPath, "utf8");
+    } catch (error) {
+      if (
+        error &&
+        typeof error === "object" &&
+        "code" in error &&
+        (error as { code?: string }).code === "ENOENT"
+      ) {
+        return [];
+      }
+
+      input.logger.warn("connector.receipt_outbox.read_failed", {
+        outboxPath,
+        reason: sanitizeErrorReason(error),
+      });
+      return [];
+    }
+
+    if (raw.trim().length === 0) {
+      return [];
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (error) {
+      input.logger.warn("connector.receipt_outbox.invalid_json", {
+        outboxPath,
+        reason: sanitizeErrorReason(error),
+      });
+      return [];
+    }
+
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    return parsed.filter(isOutboxItem);
+  };
+
+  const save = async (items: DeliveryReceiptOutboxItem[]): Promise<void> => {
+    await mkdir(dirname(outboxPath), { recursive: true });
+    const tmpPath = `${outboxPath}.tmp-${nowUtcMs()}-${Math.random().toString(16).slice(2)}`;
+    await writeFile(tmpPath, `${JSON.stringify(items, null, 2)}\n`, "utf8");
+    await rename(tmpPath, outboxPath);
+  };
+
+  const enqueue = async (receipt: DeliveryReceiptInput): Promise<void> => {
+    await withLock(async () => {
+      const nowMs = nowUtcMs();
+      const items = await load();
+      const key = makeReceiptOutboxKey(receipt);
+      const existingIndex = items.findIndex((item) => item.key === key);
+      const next: DeliveryReceiptOutboxItem = {
+        key,
+        createdAtMs: nowMs,
+        nextAttemptAtMs: nowMs,
+        requestId: receipt.requestId,
+        senderAgentDid: receipt.senderAgentDid,
+        recipientAgentDid: receipt.recipientAgentDid,
+        status: receipt.status,
+        reason: receipt.reason,
+        attemptCount: 0,
+      };
+      if (existingIndex >= 0) {
+        items[existingIndex] = {
+          ...items[existingIndex],
+          ...next,
+          createdAtMs: items[existingIndex]?.createdAtMs ?? nowMs,
+        };
+      } else {
+        items.push(next);
+      }
+      await save(items);
+    });
+  };
+
+  const flushDue = async (): Promise<void> => {
+    await withLock(async () => {
+      const nowMs = nowUtcMs();
+      const items = await load();
+      if (items.length === 0) {
+        return;
+      }
+
+      const deduped = new Map<string, DeliveryReceiptOutboxItem>();
+      for (const item of items) {
+        deduped.set(item.key, item);
+      }
+      const pending = Array.from(deduped.values()).sort(
+        (a, b) => a.createdAtMs - b.createdAtMs,
+      );
+      const retained = new Map<string, DeliveryReceiptOutboxItem>();
+
+      for (const item of pending) {
+        if (item.nextAttemptAtMs > nowMs) {
+          retained.set(item.key, item);
+          continue;
+        }
+
+        try {
+          await input.sendReceipt({
+            requestId: item.requestId,
+            senderAgentDid: item.senderAgentDid,
+            recipientAgentDid: item.recipientAgentDid,
+            status: item.status,
+            reason: item.reason,
+          });
+        } catch (error) {
+          const attemptCount = item.attemptCount + 1;
+          retained.set(item.key, {
+            ...item,
+            attemptCount,
+            nextAttemptAtMs:
+              nowMs +
+              computeRuntimeReplayRetryDelayMs({
+                attemptCount,
+                policy: input.inboundReplayPolicy,
+              }),
+          });
+          input.logger.warn("connector.receipt_outbox.retry_scheduled", {
+            requestId: item.requestId,
+            status: item.status,
+            attemptCount,
+            reason: sanitizeErrorReason(error),
+          });
+        }
+      }
+
+      await save(
+        Array.from(retained.values()).sort(
+          (a, b) => a.createdAtMs - b.createdAtMs,
+        ),
+      );
+    });
+  };
+
+  return {
+    enqueue,
+    flushDue,
+  };
+}

--- a/packages/connector/src/runtime/relay-service.test.ts
+++ b/packages/connector/src/runtime/relay-service.test.ts
@@ -1,0 +1,70 @@
+import { randomBytes } from "node:crypto";
+import {
+  RELAY_DELIVERY_RECEIPT_URL_HEADER,
+  RELAY_DELIVERY_RECEIPTS_PATH,
+} from "@clawdentity/protocol";
+import type { AgentAuthBundle } from "@clawdentity/sdk";
+import { describe, expect, it, vi } from "vitest";
+import { createRelayService } from "./relay-service.js";
+
+function createAuthBundle(): AgentAuthBundle {
+  return {
+    accessToken: "access-token",
+    accessExpiresAt: "2100-01-01T00:00:00.000Z",
+    refreshToken: "refresh-token",
+    refreshExpiresAt: "2100-01-01T00:00:00.000Z",
+    tokenType: "Bearer",
+  };
+}
+
+describe("createRelayService", () => {
+  it("uses runtime-owned callback URL for outbound and receipt posting", async () => {
+    const defaultReceiptCallbackUrl = new URL(
+      RELAY_DELIVERY_RECEIPTS_PATH.slice(1),
+      "https://proxy.self.example/",
+    ).toString();
+
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response("ok", { status: 200 }));
+    const auth = createAuthBundle();
+
+    const relayService = createRelayService({
+      agentName: "alpha",
+      ait: "test-ait",
+      configDir: "/tmp/config",
+      defaultReceiptCallbackUrl,
+      fetchImpl: fetchMock,
+      getCurrentAuth: () => auth,
+      registryUrl: "https://registry.example.test",
+      secretKey: randomBytes(32),
+      setCurrentAuth: async () => {},
+      syncAuthFromDisk: async () => {},
+    });
+
+    await relayService.relayToPeer({
+      peer: "peer",
+      peerDid: "did:cdi:registry.example.test:agent:peer",
+      peerProxyUrl: "https://peer.example.test/v1/relay/deliver",
+      payload: { message: "hello" },
+      replyTo: "https://ignored.example.test/v1/relay/delivery-receipts",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, relayInit] = fetchMock.mock.calls[0] ?? [];
+    expect(relayInit?.headers).toMatchObject({
+      [RELAY_DELIVERY_RECEIPT_URL_HEADER]: defaultReceiptCallbackUrl,
+    });
+
+    await relayService.postDeliveryReceipt({
+      requestId: "req-1",
+      senderAgentDid: "did:cdi:registry.example.test:agent:sender",
+      recipientAgentDid: "did:cdi:registry.example.test:agent:recipient",
+      status: "processed_by_openclaw",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const [receiptUrl] = fetchMock.mock.calls[1] ?? [];
+    expect(String(receiptUrl)).toBe(defaultReceiptCallbackUrl);
+  });
+});

--- a/packages/connector/src/runtime/relay-service.ts
+++ b/packages/connector/src/runtime/relay-service.ts
@@ -21,7 +21,6 @@ import { isRetryableRelayAuthError } from "./errors.js";
 import type {
   OutboundDeliveryReceiptStatus,
   OutboundRelayRequest,
-  TrustedReceiptTargets,
 } from "./types.js";
 import { toPathWithQuery } from "./url.js";
 
@@ -36,14 +35,12 @@ type RelayServiceInput = {
   secretKey: Uint8Array;
   setCurrentAuth: (nextAuth: AgentAuthBundle) => Promise<void>;
   syncAuthFromDisk: () => Promise<void>;
-  trustedReceiptTargets: TrustedReceiptTargets;
 };
 
 export function createRelayService(input: RelayServiceInput): {
   postDeliveryReceipt: (inputReceipt: {
     reason?: string;
     recipientAgentDid: string;
-    replyTo: string;
     requestId: string;
     senderAgentDid: string;
     status: OutboundDeliveryReceiptStatus;
@@ -53,13 +50,12 @@ export function createRelayService(input: RelayServiceInput): {
   const relayToPeer = async (request: OutboundRelayRequest): Promise<void> => {
     await input.syncAuthFromDisk();
     const peerUrl = new URL(request.peerProxyUrl);
-    input.trustedReceiptTargets.origins.add(peerUrl.origin);
-    input.trustedReceiptTargets.byAgentDid.set(request.peerDid, peerUrl.origin);
     const body = JSON.stringify(request.payload ?? {});
     const refreshKey = `${REFRESH_SINGLE_FLIGHT_PREFIX}:${input.configDir}:${input.agentName}`;
 
     const performRelay = async (auth: AgentAuthBundle): Promise<void> => {
-      const replyTo = request.replyTo ?? input.defaultReceiptCallbackUrl;
+      // Callback routing authority is the local runtime-owned receipt endpoint.
+      const replyTo = input.defaultReceiptCallbackUrl;
       const unixSeconds = Math.floor(nowUtcMs() / 1000).toString();
       const nonce = encodeBase64url(randomBytes(NONCE_SIZE));
       const signed = await signHttpRequest({
@@ -127,57 +123,33 @@ export function createRelayService(input: RelayServiceInput): {
     });
   };
 
+  let ownReceiptUrl: URL;
+  try {
+    ownReceiptUrl = new URL(input.defaultReceiptCallbackUrl);
+  } catch {
+    throw new AppError({
+      code: "CONNECTOR_DELIVERY_RECEIPT_INVALID_TARGET",
+      message: "Delivery receipt callback target is invalid",
+      status: 500,
+    });
+  }
+
+  if (ownReceiptUrl.pathname !== RELAY_DELIVERY_RECEIPTS_PATH) {
+    throw new AppError({
+      code: "CONNECTOR_DELIVERY_RECEIPT_INVALID_TARGET",
+      message: "Delivery receipt callback target is invalid",
+      status: 500,
+    });
+  }
+
   const postDeliveryReceipt = async (inputReceipt: {
     reason?: string;
     recipientAgentDid: string;
-    replyTo: string;
     requestId: string;
     senderAgentDid: string;
     status: OutboundDeliveryReceiptStatus;
   }): Promise<void> => {
     await input.syncAuthFromDisk();
-    let senderReceiptUrl: URL;
-    try {
-      senderReceiptUrl = new URL(inputReceipt.replyTo);
-    } catch {
-      throw new AppError({
-        code: "CONNECTOR_DELIVERY_RECEIPT_INVALID_TARGET",
-        message: "Delivery receipt callback target is invalid",
-        status: 400,
-      });
-    }
-
-    if (senderReceiptUrl.pathname !== RELAY_DELIVERY_RECEIPTS_PATH) {
-      throw new AppError({
-        code: "CONNECTOR_DELIVERY_RECEIPT_INVALID_TARGET",
-        message: "Delivery receipt callback target is invalid",
-        status: 400,
-      });
-    }
-    const trustedOriginForSender = input.trustedReceiptTargets.byAgentDid.get(
-      inputReceipt.senderAgentDid,
-    );
-    if (
-      trustedOriginForSender !== undefined &&
-      senderReceiptUrl.origin !== trustedOriginForSender
-    ) {
-      throw new AppError({
-        code: "CONNECTOR_DELIVERY_RECEIPT_INVALID_TARGET",
-        message: "Delivery receipt callback target is invalid",
-        status: 400,
-      });
-    }
-    if (
-      trustedOriginForSender === undefined &&
-      !input.trustedReceiptTargets.origins.has(senderReceiptUrl.origin)
-    ) {
-      throw new AppError({
-        code: "CONNECTOR_DELIVERY_RECEIPT_INVALID_TARGET",
-        message: "Delivery receipt callback target is invalid",
-        status: 400,
-      });
-    }
-    const receiptUrl = senderReceiptUrl;
 
     const body = JSON.stringify({
       requestId: inputReceipt.requestId,
@@ -194,14 +166,14 @@ export function createRelayService(input: RelayServiceInput): {
       const nonce = encodeBase64url(randomBytes(NONCE_SIZE));
       const signed = await signHttpRequest({
         method: "POST",
-        pathWithQuery: toPathWithQuery(receiptUrl),
+        pathWithQuery: toPathWithQuery(ownReceiptUrl),
         timestamp: unixSeconds,
         nonce,
         body: new TextEncoder().encode(body),
         secretKey: input.secretKey,
       });
 
-      const response = await input.fetchImpl(receiptUrl.toString(), {
+      const response = await input.fetchImpl(ownReceiptUrl.toString(), {
         method: "POST",
         headers: {
           Authorization: `Claw ${input.ait}`,

--- a/packages/connector/src/runtime/replay.ts
+++ b/packages/connector/src/runtime/replay.ts
@@ -22,7 +22,6 @@ import type {
 type DeliveryReceiptInput = {
   reason?: string;
   recipientAgentDid: string;
-  replyTo: string;
   requestId: string;
   senderAgentDid: string;
   status: "processed_by_openclaw" | "dead_lettered";
@@ -37,7 +36,7 @@ function groupDueItemsByLane(
     const laneKey =
       pending.conversationId !== undefined
         ? `conversation:${pending.conversationId}`
-        : "legacy-best-effort";
+        : "best-effort";
     const lane = laneByKey.get(laneKey);
     if (lane) {
       lane.push(pending);
@@ -233,25 +232,19 @@ export function createInboundReplayController(input: {
                 conversationId: pending.conversationId,
               });
 
-              if (pending.replyTo) {
-                try {
-                  await input.postDeliveryReceipt({
-                    requestId: pending.requestId,
-                    senderAgentDid: pending.fromAgentDid,
-                    recipientAgentDid: pending.toAgentDid,
-                    replyTo: pending.replyTo,
-                    status: "processed_by_openclaw",
-                  });
-                } catch (error) {
-                  input.logger.warn(
-                    "connector.inbound.delivery_receipt_failed",
-                    {
-                      requestId: pending.requestId,
-                      reason: sanitizeErrorReason(error),
-                      status: "processed_by_openclaw",
-                    },
-                  );
-                }
+              try {
+                await input.postDeliveryReceipt({
+                  requestId: pending.requestId,
+                  senderAgentDid: pending.fromAgentDid,
+                  recipientAgentDid: pending.toAgentDid,
+                  status: "processed_by_openclaw",
+                });
+              } catch (error) {
+                input.logger.warn("connector.inbound.delivery_receipt_failed", {
+                  requestId: pending.requestId,
+                  reason: sanitizeErrorReason(error),
+                  status: "processed_by_openclaw",
+                });
               }
             } catch (error) {
               if (
@@ -297,13 +290,12 @@ export function createInboundReplayController(input: {
                 reason,
               });
 
-              if (markResult.movedToDeadLetter && pending.replyTo) {
+              if (markResult.movedToDeadLetter) {
                 try {
                   await input.postDeliveryReceipt({
                     requestId: pending.requestId,
                     senderAgentDid: pending.fromAgentDid,
                     recipientAgentDid: pending.toAgentDid,
-                    replyTo: pending.replyTo,
                     status: "dead_lettered",
                     reason,
                   });


### PR DESCRIPTION
## Summary
- enforce queue-first delivery receipt ingestion in proxy (non-local requires queue)
- remove callback-routing authority from inbound `replyTo`; runtime-owned proxy receipt endpoint is authoritative
- add durable TypeScript receipt outbox with retry + idempotent dequeue (`requestId:status`)
- add Rust receipt emission parity for `processed_by_openclaw` and `dead_lettered`
- implement Rust **single-writer receipt outbox actor** (command channel) so concurrent tasks cannot race on outbox file writes
- harden Rust receipt request signing nonce generation to non-timestamp, collision-resistant values
- add/adjust proxy, connector, and Rust tests plus AGENTS guidance in touched folders

## Validation
- `pnpm -F @clawdentity/proxy test`
- `pnpm -F @clawdentity/connector test`
- `cargo test -p clawdentity-cli`
- `cargo check`

## Issue Closure
Fixes #165
Fixes #168
Fixes #169
