### PR TITLE
fix(sdk,proxy): enforce PoP freshness and add replay-safe verify path

### DIFF
--- a/apps/landing/src/content/AGENTS.md
+++ b/apps/landing/src/content/AGENTS.md
@@ -10,3 +10,4 @@
 - CLI docs must match the actual Rust binary help output. Re-check flags and subcommands before changing docs, especially `install --for`, `provider *`, and `pair *`.
 - When starter-pass behavior changes, update both user-facing docs and the landing copy in the same change.
 - Keep proxy docs aligned with runtime identity transport: header-first by default, body injection only as an explicit legacy opt-in.
+- SDK docs that mention HTTP proof verification must state that timestamp freshness is enforced by default and should recommend the replay-protected one-call verifier for nonce enforcement.

--- a/apps/landing/src/content/docs/api-reference/sdk.mdx
+++ b/apps/landing/src/content/docs/api-reference/sdk.mdx
@@ -19,7 +19,7 @@ The SDK handles AIT verification and PoP request signing:
 
 - **AIT verification** — verify registry-signed JWTs offline using cached public keys
 - **PoP signing** — generate `X-Claw-*` headers for outbound requests
-- **PoP verification** — validate inbound PoP signatures against AIT `cnf` keys
+- **PoP verification** — validate inbound PoP signatures against AIT `cnf` keys, including timestamp freshness by default
 - **CRL verification** — verify signed CRL JWTs
 
 ### CRL cache
@@ -51,6 +51,16 @@ Tracks nonces for replay protection:
 - Default TTL: 5 minutes (`DEFAULT_NONCE_TTL_MS = 300000`)
 - Per-agent nonce tracking
 - Automatic expiry purge on each `tryAcceptNonce` call
+
+### HTTP proof verification
+
+`verifyHttpRequest(input)` now enforces all of these by default:
+- body hash match
+- signature verification
+- timestamp format validation (`X-Claw-Timestamp` must be unix seconds)
+- timestamp freshness window (`maxTimestampSkewSeconds`, default 300s)
+
+Use `verifyHttpRequestWithReplayProtection(input)` when you want signature + timestamp freshness + nonce replay detection in one call.
 
 ### Agent auth client
 

--- a/apps/proxy/src/auth-middleware/AGENTS.md
+++ b/apps/proxy/src/auth-middleware/AGENTS.md
@@ -11,3 +11,5 @@
 - Shared forwarded-header and loopback-host helpers belong in `@clawdentity/common`; do not re-copy them into proxy-only files when the registry needs the same behavior.
 - Keep nonce replay checks async-safe in middleware (`await nonceCache.tryAcceptNonce(...)`) so Durable Object-backed nonce stores are fully enforced.
 - Keep nonce replay TTL tied to `maxTimestampSkewSeconds` (milliseconds) when calling nonce cache implementations.
+- Prefer `verifyHttpRequestWithReplayProtection` from `@clawdentity/sdk` for inbound proof auth so timestamp skew + signature + replay checks are enforced together in one call.
+- Keep proxy error mapping explicit when translating SDK proof errors into proxy auth error codes (`PROXY_AUTH_INVALID_TIMESTAMP`, `PROXY_AUTH_TIMESTAMP_SKEW`, `PROXY_AUTH_INVALID_NONCE`, `PROXY_AUTH_REPLAY`, `PROXY_AUTH_INVALID_PROOF`).

--- a/apps/proxy/src/auth-middleware/middleware.ts
+++ b/apps/proxy/src/auth-middleware/middleware.ts
@@ -13,7 +13,7 @@ import {
   createNonceCache,
   verifyAIT,
   verifyCRL,
-  verifyHttpRequest,
+  verifyHttpRequestWithReplayProtection,
 } from "@clawdentity/sdk";
 import { createMiddleware } from "hono/factory";
 import { assertKnownTrustedAgent } from "../trust-policy.js";
@@ -27,11 +27,8 @@ import {
   toVerificationKeys,
 } from "./registry-keys.js";
 import {
-  assertTimestampWithinSkew,
   parseAgentAccessHeader,
   parseClawAuthorizationHeader,
-  parseUnixTimestamp,
-  toProofVerificationInput,
 } from "./request-auth.js";
 import {
   DEFAULT_MAX_TIMESTAMP_SKEW_SECONDS,
@@ -52,6 +49,67 @@ import {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
+}
+
+function mapProofVerificationError(options: {
+  error: unknown;
+  maxTimestampSkewSeconds: number;
+}): AppError {
+  const { error, maxTimestampSkewSeconds } = options;
+  if (error instanceof AppError) {
+    if (
+      error.code === "HTTP_SIGNATURE_INVALID_TIMESTAMP" ||
+      (error.code === "HTTP_SIGNATURE_INVALID_INPUT" &&
+        error.details?.field === "X-Claw-Timestamp")
+    ) {
+      return unauthorizedError({
+        code: "PROXY_AUTH_INVALID_TIMESTAMP",
+        message:
+          error.code === "HTTP_SIGNATURE_INVALID_TIMESTAMP"
+            ? error.message
+            : "X-Claw-Timestamp header is required",
+      });
+    }
+
+    if (error.code === "HTTP_SIGNATURE_TIMESTAMP_SKEW") {
+      return unauthorizedError({
+        code: "PROXY_AUTH_TIMESTAMP_SKEW",
+        message: error.message,
+        details: {
+          maxSkewSeconds: maxTimestampSkewSeconds,
+        },
+      });
+    }
+
+    if (error.code === "HTTP_SIGNATURE_REPLAY_DETECTED") {
+      return unauthorizedError({
+        code: "PROXY_AUTH_REPLAY",
+        message: "Replay detected",
+      });
+    }
+
+    if (
+      error.code === "HTTP_SIGNATURE_NONCE_CHECK_FAILED" ||
+      (error.code === "HTTP_SIGNATURE_INVALID_INPUT" &&
+        error.details?.field === "X-Claw-Nonce")
+    ) {
+      return unauthorizedError({
+        code: "PROXY_AUTH_INVALID_NONCE",
+        message: "Nonce validation failed",
+        details: {
+          reason: toErrorMessage(error),
+        },
+      });
+    }
+  }
+
+  return unauthorizedError({
+    code: "PROXY_AUTH_INVALID_PROOF",
+    message: "PoP verification failed",
+    details: {
+      reason: toErrorMessage(error),
+    },
+  });
 }
 
 export function createProxyAuthMiddleware(options: ProxyAuthMiddlewareOptions) {
@@ -257,20 +315,6 @@ export function createProxyAuthMiddleware(options: ProxyAuthMiddlewareOptions) {
       const token = parseClawAuthorizationHeader(authorizationHeader);
       const claims = await verifyAitClaims(token, c.req.raw);
 
-      const timestampHeader = c.req.header("x-claw-timestamp");
-      if (typeof timestampHeader !== "string") {
-        throw unauthorizedError({
-          code: "PROXY_AUTH_INVALID_TIMESTAMP",
-          message: "X-Claw-Timestamp header is required",
-        });
-      }
-
-      assertTimestampWithinSkew({
-        clock,
-        maxSkewSeconds: maxTimestampSkewSeconds,
-        timestampSeconds: parseUnixTimestamp(timestampHeader),
-      });
-
       const bodyBytes = new Uint8Array(await c.req.raw.clone().arrayBuffer());
       const pathWithQuery = toPathWithQuery(c.req.url);
 
@@ -288,49 +332,26 @@ export function createProxyAuthMiddleware(options: ProxyAuthMiddlewareOptions) {
       }
 
       try {
-        await verifyHttpRequest(
-          toProofVerificationInput({
-            method: c.req.method,
-            pathWithQuery,
-            headers: c.req.raw.headers,
-            body: bodyBytes,
-            publicKey: cnfPublicKey,
-          }),
-        );
-      } catch (error) {
-        throw unauthorizedError({
-          code: "PROXY_AUTH_INVALID_PROOF",
-          message: "PoP verification failed",
-          details: {
-            reason: toErrorMessage(error),
+        await verifyHttpRequestWithReplayProtection({
+          method: c.req.method,
+          pathWithQuery,
+          headers: Object.fromEntries(c.req.raw.headers.entries()),
+          body: bodyBytes,
+          publicKey: cnfPublicKey,
+          nowMs: clock(),
+          maxTimestampSkewSeconds,
+          agentDid: claims.sub,
+          nonceTtlMs: maxTimestampSkewSeconds * 1000,
+          nonceChecker: {
+            tryAcceptNonce(input) {
+              return nonceCache.tryAcceptNonce(input);
+            },
           },
         });
-      }
-
-      const nonceHeader = c.req.header("x-claw-nonce");
-      const nonce = typeof nonceHeader === "string" ? nonceHeader : "";
-      const nonceResult = await (async () => {
-        try {
-          return await nonceCache.tryAcceptNonce({
-            agentDid: claims.sub,
-            nonce,
-            ttlMs: maxTimestampSkewSeconds * 1000,
-          });
-        } catch (error) {
-          throw unauthorizedError({
-            code: "PROXY_AUTH_INVALID_NONCE",
-            message: "Nonce validation failed",
-            details: {
-              reason: toErrorMessage(error),
-            },
-          });
-        }
-      })();
-
-      if (!nonceResult.accepted) {
-        throw unauthorizedError({
-          code: "PROXY_AUTH_REPLAY",
-          message: "Replay detected",
+      } catch (error) {
+        throw mapProofVerificationError({
+          error,
+          maxTimestampSkewSeconds,
         });
       }
 

--- a/apps/proxy/src/auth-middleware/request-auth.ts
+++ b/apps/proxy/src/auth-middleware/request-auth.ts
@@ -1,4 +1,3 @@
-import type { VerifyHttpRequestInput } from "@clawdentity/sdk";
 import { unauthorizedError } from "./errors.js";
 
 export function parseClawAuthorizationHeader(authorization?: string): string {
@@ -29,58 +28,4 @@ export function parseAgentAccessHeader(value: string | undefined): string {
   }
 
   return value.trim();
-}
-
-export function parseUnixTimestamp(headerValue: string): number {
-  if (!/^\d+$/.test(headerValue)) {
-    throw unauthorizedError({
-      code: "PROXY_AUTH_INVALID_TIMESTAMP",
-      message: "X-Claw-Timestamp must be a unix seconds integer",
-    });
-  }
-
-  const timestamp = Number.parseInt(headerValue, 10);
-  if (!Number.isInteger(timestamp) || timestamp < 0) {
-    throw unauthorizedError({
-      code: "PROXY_AUTH_INVALID_TIMESTAMP",
-      message: "X-Claw-Timestamp must be a unix seconds integer",
-    });
-  }
-
-  return timestamp;
-}
-
-export function assertTimestampWithinSkew(options: {
-  clock: () => number;
-  maxSkewSeconds: number;
-  timestampSeconds: number;
-}): void {
-  const nowSeconds = Math.floor(options.clock() / 1000);
-  const skew = Math.abs(nowSeconds - options.timestampSeconds);
-  if (skew > options.maxSkewSeconds) {
-    throw unauthorizedError({
-      code: "PROXY_AUTH_TIMESTAMP_SKEW",
-      message: "X-Claw-Timestamp is outside the allowed skew window",
-      details: {
-        maxSkewSeconds: options.maxSkewSeconds,
-      },
-    });
-  }
-}
-
-export function toProofVerificationInput(input: {
-  method: string;
-  pathWithQuery: string;
-  headers: Headers;
-  body: Uint8Array;
-  publicKey: Uint8Array;
-}): VerifyHttpRequestInput {
-  const headers = Object.fromEntries(input.headers.entries());
-  return {
-    method: input.method,
-    pathWithQuery: input.pathWithQuery,
-    headers,
-    body: input.body,
-    publicKey: input.publicKey,
-  };
 }

--- a/packages/sdk/AGENTS.md
+++ b/packages/sdk/AGENTS.md
@@ -14,7 +14,7 @@
 - `jwt/ait-jwt`: AIT JWS signing, verification, and header-only inspection via `decodeAIT`; both helpers reuse the same protected-header guard so alg/typ/kid invariants stay aligned even when skipping signature validation.
 - `jwt/crl-jwt`: CRL JWT helpers with EdDSA signing, header consistency checks, and tamper-detection test coverage.
 - `crl/cache`: in-memory CRL cache with periodic refresh, staleness reporting, and configurable stale behavior.
-- `http/sign` + `http/verify`: PoP request signing and verification that binds method, path+query, timestamp, nonce, and body hash.
+- `http/sign` + `http/verify`: PoP request signing and verification that binds method, path+query, timestamp, nonce, and body hash, with timestamp freshness enforced by default.
 - `security/nonce-cache`: in-memory TTL nonce replay protection keyed by `agentDid + nonce`.
 - `agent-auth-client`: shared agent auth refresh client + retry orchestration (`executeWithAgentAuthRefreshRetry`) for CLI/runtime integrations.
 - `event-bus`: shared event envelope + transport abstractions (`createInMemoryEventBus`, `createQueueEventBus`) for environment-based async delivery.
@@ -39,6 +39,8 @@
 - For HTTP signing errors, keep user-facing messages static and send extra context through `AppError.details`.
 - Enforce Ed25519 key lengths at SDK boundaries (`secretKey` 32 bytes, `publicKey` 32 bytes) so misconfiguration returns stable `AppError` codes.
 - Treat any decoded PoP proof that is not 64 bytes as `HTTP_SIGNATURE_INVALID_PROOF`.
+- Keep `verifyHttpRequest` secure-by-default: always validate `X-Claw-Timestamp` format and freshness with a bounded skew window.
+- Use `verifyHttpRequestWithReplayProtection` for inbound service auth paths so nonce replay checks stay coupled to signature + timestamp validation.
 - Nonce cache accept path must prune expired entries across all agent buckets to keep memory bounded under high-cardinality agent traffic.
 - Nonce cache must validate the top-level input shape before reading fields so invalid JS callers receive structured `AppError`s instead of runtime `TypeError`s.
 - Registry config parsing must validate `REGISTRY_SIGNING_KEYS` as JSON before runtime use so keyset endpoints fail fast with `CONFIG_VALIDATION_FAILED` on malformed key documents.
@@ -59,6 +61,8 @@
 - Crypto tests must include explicit negative verification cases (wrong message/signature/key).
 - JWT tests must include sign/verify happy path and failure paths for issuer mismatch and missing/unknown `kid`.
 - HTTP signing tests must include sign/verify happy path and explicit failures when method, path, body, or timestamp are altered.
+- HTTP verification tests must include malformed timestamp, stale/future skew rejection, and deterministic clock-injection coverage.
+- Replay wrapper tests must cover first-accept, replay rejection, and async nonce-checker support.
 - Nonce cache tests must include duplicate nonce rejection within TTL and acceptance after TTL expiry.
 - CRL cache tests must cover revoked lookup, refresh-on-stale, and stale-path behavior in both `fail-open` and `fail-closed` modes.
 - When new registry routes emit signed AITs (e.g., POST `/v1/agents`), tests should consume those tokens with the published `REGISTRY_SIGNING_KEYS` set (as returned by `/.well-known/claw-keys.json`) and assert that `verifyAIT` succeeds/fails exactly the same way the local `claw verify` workflow will, keeping the offline verification contract fully covered.

--- a/packages/sdk/src/http/types.ts
+++ b/packages/sdk/src/http/types.ts
@@ -33,9 +33,46 @@ export interface VerifyHttpRequestInput {
   headers: Record<string, string | undefined>;
   body?: Uint8Array;
   publicKey: Uint8Array;
+  nowMs?: number;
+  maxTimestampSkewSeconds?: number;
 }
 
 export interface VerifyHttpRequestResult {
   canonicalRequest: string;
   proof: string;
+}
+
+export type VerifyHttpRequestNonceCheckInput = {
+  agentDid: string;
+  nonce: string;
+  ttlMs?: number;
+  nowMs?: number;
+};
+
+export type VerifyHttpRequestNonceCheckResult =
+  | {
+      accepted: true;
+      seenAt?: number;
+      expiresAt?: number;
+    }
+  | {
+      accepted: false;
+      reason: "replay";
+      seenAt?: number;
+      expiresAt?: number;
+    };
+
+export interface VerifyHttpRequestNonceChecker {
+  tryAcceptNonce(
+    input: VerifyHttpRequestNonceCheckInput,
+  ):
+    | VerifyHttpRequestNonceCheckResult
+    | Promise<VerifyHttpRequestNonceCheckResult>;
+}
+
+export interface VerifyHttpRequestWithReplayProtectionInput
+  extends VerifyHttpRequestInput {
+  agentDid: string;
+  nonceChecker: VerifyHttpRequestNonceChecker;
+  nonceTtlMs?: number;
 }

--- a/packages/sdk/src/http/verify-replay.test.ts
+++ b/packages/sdk/src/http/verify-replay.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import { generateEd25519Keypair } from "../crypto/ed25519.js";
+import { signHttpRequest } from "./sign.js";
+import { verifyHttpRequestWithReplayProtection } from "./verify.js";
+
+const textEncoder = new TextEncoder();
+const NOW_MS = 1_739_364_000_000;
+const NOW_SECONDS = Math.floor(NOW_MS / 1000);
+
+async function makeSignedFixture(input?: {
+  timestamp?: string;
+  nonce?: string;
+  body?: Uint8Array;
+}) {
+  const keypair = await generateEd25519Keypair();
+  const body = input?.body ?? textEncoder.encode('{"hello":"world"}');
+  const timestamp = input?.timestamp ?? String(NOW_SECONDS);
+  const nonce = input?.nonce ?? "nonce_replay_test";
+  const signed = await signHttpRequest({
+    method: "POST",
+    pathWithQuery: "/v1/messages?b=2&a=1",
+    timestamp,
+    nonce,
+    body,
+    secretKey: keypair.secretKey,
+  });
+
+  return { keypair, body, signed, nonce };
+}
+
+describe("verifyHttpRequestWithReplayProtection", () => {
+  it("accepts first nonce and rejects replayed nonce", async () => {
+    const { keypair, body, signed } = await makeSignedFixture();
+    const seen = new Set<string>();
+    const nonceChecker = {
+      tryAcceptNonce(input: { agentDid: string; nonce: string }) {
+        const key = `${input.agentDid}|${input.nonce}`;
+        if (seen.has(key)) {
+          return { accepted: false as const, reason: "replay" as const };
+        }
+        seen.add(key);
+        return { accepted: true as const };
+      },
+    };
+
+    await expect(
+      verifyHttpRequestWithReplayProtection({
+        method: "POST",
+        pathWithQuery: "/v1/messages?b=2&a=1",
+        headers: signed.headers,
+        body,
+        publicKey: keypair.publicKey,
+        agentDid:
+          "did:cdi:registry.clawdentity.dev:agent:01HF7YAT00W6W7CM7N3W5FDXT4",
+        nonceChecker,
+        nowMs: NOW_MS,
+      }),
+    ).resolves.toMatchObject({
+      proof: signed.proof,
+    });
+
+    await expect(
+      verifyHttpRequestWithReplayProtection({
+        method: "POST",
+        pathWithQuery: "/v1/messages?b=2&a=1",
+        headers: signed.headers,
+        body,
+        publicKey: keypair.publicKey,
+        agentDid:
+          "did:cdi:registry.clawdentity.dev:agent:01HF7YAT00W6W7CM7N3W5FDXT4",
+        nonceChecker,
+        nowMs: NOW_MS,
+      }),
+    ).rejects.toMatchObject({
+      code: "HTTP_SIGNATURE_REPLAY_DETECTED",
+    });
+  });
+
+  it("preserves signature/body verification failures", async () => {
+    const { keypair, signed } = await makeSignedFixture();
+    const nonceChecker = {
+      tryAcceptNonce() {
+        return { accepted: true as const };
+      },
+    };
+
+    await expect(
+      verifyHttpRequestWithReplayProtection({
+        method: "POST",
+        pathWithQuery: "/v1/messages?b=2&a=1",
+        headers: signed.headers,
+        body: textEncoder.encode('{"hello":"tampered"}'),
+        publicKey: keypair.publicKey,
+        agentDid:
+          "did:cdi:registry.clawdentity.dev:agent:01HF7YAT00W6W7CM7N3W5FDXT4",
+        nonceChecker,
+        nowMs: NOW_MS,
+      }),
+    ).rejects.toMatchObject({
+      code: "HTTP_SIGNATURE_BODY_HASH_MISMATCH",
+    });
+  });
+
+  it("supports async nonce checkers", async () => {
+    const { keypair, body, signed } = await makeSignedFixture({
+      nonce: "nonce_async",
+    });
+    const nonceChecker = {
+      async tryAcceptNonce() {
+        return { accepted: true as const, seenAt: NOW_MS, expiresAt: NOW_MS };
+      },
+    };
+
+    await expect(
+      verifyHttpRequestWithReplayProtection({
+        method: "POST",
+        pathWithQuery: "/v1/messages?b=2&a=1",
+        headers: signed.headers,
+        body,
+        publicKey: keypair.publicKey,
+        agentDid:
+          "did:cdi:registry.clawdentity.dev:agent:01HF7YAT00W6W7CM7N3W5FDXT4",
+        nonceChecker,
+        nowMs: NOW_MS,
+      }),
+    ).resolves.toMatchObject({
+      proof: signed.proof,
+    });
+  });
+});

--- a/packages/sdk/src/http/verify.test.ts
+++ b/packages/sdk/src/http/verify.test.ts
@@ -4,32 +4,45 @@ import { signHttpRequest } from "./sign.js";
 import { verifyHttpRequest } from "./verify.js";
 
 const textEncoder = new TextEncoder();
+const NOW_MS = 1_739_364_000_000;
+const NOW_SECONDS = Math.floor(NOW_MS / 1000);
 
-async function makeSignedFixture() {
+async function makeSignedFixture(input?: {
+  timestamp?: string;
+  nonce?: string;
+  method?: string;
+  pathWithQuery?: string;
+}) {
   const keypair = await generateEd25519Keypair();
   const body = textEncoder.encode('{"hello":"world"}');
+  const method = input?.method ?? "POST";
+  const pathWithQuery = input?.pathWithQuery ?? "/v1/messages?b=2&a=1";
+  const timestamp = input?.timestamp ?? String(NOW_SECONDS);
+  const nonce = input?.nonce ?? "nonce_abc123";
   const signed = await signHttpRequest({
-    method: "POST",
-    pathWithQuery: "/v1/messages?b=2&a=1",
-    timestamp: "1739364000",
-    nonce: "nonce_abc123",
+    method,
+    pathWithQuery,
+    timestamp,
+    nonce,
     body,
     secretKey: keypair.secretKey,
   });
 
-  return { keypair, body, signed };
+  return { keypair, body, signed, method, pathWithQuery };
 }
 
 describe("verifyHttpRequest", () => {
   it("verifies a signed request successfully", async () => {
-    const { keypair, body, signed } = await makeSignedFixture();
+    const { keypair, body, signed, method, pathWithQuery } =
+      await makeSignedFixture();
 
     const verified = await verifyHttpRequest({
-      method: "POST",
-      pathWithQuery: "/v1/messages?b=2&a=1",
+      method,
+      pathWithQuery,
       headers: signed.headers,
       body,
       publicKey: keypair.publicKey,
+      nowMs: NOW_MS,
     });
 
     expect(verified.proof).toBe(signed.proof);
@@ -37,15 +50,16 @@ describe("verifyHttpRequest", () => {
   });
 
   it("fails verification when method is altered", async () => {
-    const { keypair, body, signed } = await makeSignedFixture();
+    const { keypair, body, signed, pathWithQuery } = await makeSignedFixture();
 
     await expect(
       verifyHttpRequest({
         method: "PATCH",
-        pathWithQuery: "/v1/messages?b=2&a=1",
+        pathWithQuery,
         headers: signed.headers,
         body,
         publicKey: keypair.publicKey,
+        nowMs: NOW_MS,
       }),
     ).rejects.toMatchObject({
       code: "HTTP_SIGNATURE_INVALID_PROOF",
@@ -62,6 +76,7 @@ describe("verifyHttpRequest", () => {
         headers: signed.headers,
         body,
         publicKey: keypair.publicKey,
+        nowMs: NOW_MS,
       }),
     ).rejects.toMatchObject({
       code: "HTTP_SIGNATURE_INVALID_PROOF",
@@ -79,17 +94,18 @@ describe("verifyHttpRequest", () => {
         headers: signed.headers,
         body: alteredBody,
         publicKey: keypair.publicKey,
+        nowMs: NOW_MS,
       }),
     ).rejects.toMatchObject({
       code: "HTTP_SIGNATURE_BODY_HASH_MISMATCH",
     });
   });
 
-  it("fails verification when timestamp header is altered", async () => {
+  it("fails verification when timestamp header is malformed", async () => {
     const { keypair, body, signed } = await makeSignedFixture();
     const tamperedHeaders = {
       ...signed.headers,
-      "X-Claw-Timestamp": "1739364999",
+      "X-Claw-Timestamp": `${NOW_SECONDS}.5`,
     };
 
     await expect(
@@ -99,9 +115,10 @@ describe("verifyHttpRequest", () => {
         headers: tamperedHeaders,
         body,
         publicKey: keypair.publicKey,
+        nowMs: NOW_MS,
       }),
     ).rejects.toMatchObject({
-      code: "HTTP_SIGNATURE_INVALID_PROOF",
+      code: "HTTP_SIGNATURE_INVALID_TIMESTAMP",
     });
   });
 
@@ -119,6 +136,7 @@ describe("verifyHttpRequest", () => {
         headers: tamperedHeaders,
         body,
         publicKey: keypair.publicKey,
+        nowMs: NOW_MS,
       }),
     ).rejects.toMatchObject({
       code: "HTTP_SIGNATURE_INVALID_PROOF",
@@ -139,6 +157,7 @@ describe("verifyHttpRequest", () => {
         headers: signed.headers,
         body,
         publicKey: new Uint8Array([1]),
+        nowMs: NOW_MS,
       }),
     ).rejects.toMatchObject({
       code: "HTTP_SIGNATURE_MISSING_PUBLIC",
@@ -146,6 +165,68 @@ describe("verifyHttpRequest", () => {
         keyLength: 1,
         expectedKeyLength: 32,
       },
+    });
+  });
+
+  it("rejects stale timestamps beyond max skew", async () => {
+    const { keypair, body, signed, method, pathWithQuery } =
+      await makeSignedFixture({
+        timestamp: String(NOW_SECONDS - 301),
+      });
+
+    await expect(
+      verifyHttpRequest({
+        method,
+        pathWithQuery,
+        headers: signed.headers,
+        body,
+        publicKey: keypair.publicKey,
+        nowMs: NOW_MS,
+      }),
+    ).rejects.toMatchObject({
+      code: "HTTP_SIGNATURE_TIMESTAMP_SKEW",
+    });
+  });
+
+  it("rejects future timestamps beyond max skew", async () => {
+    const { keypair, body, signed, method, pathWithQuery } =
+      await makeSignedFixture({
+        timestamp: String(NOW_SECONDS + 301),
+      });
+
+    await expect(
+      verifyHttpRequest({
+        method,
+        pathWithQuery,
+        headers: signed.headers,
+        body,
+        publicKey: keypair.publicKey,
+        nowMs: NOW_MS,
+      }),
+    ).rejects.toMatchObject({
+      code: "HTTP_SIGNATURE_TIMESTAMP_SKEW",
+    });
+  });
+
+  it("uses injected nowMs to keep freshness checks deterministic", async () => {
+    const deterministicNowMs = NOW_MS + 120_000;
+    const deterministicNowSeconds = Math.floor(deterministicNowMs / 1000);
+    const { keypair, body, signed, method, pathWithQuery } =
+      await makeSignedFixture({
+        timestamp: String(deterministicNowSeconds - 250),
+      });
+
+    await expect(
+      verifyHttpRequest({
+        method,
+        pathWithQuery,
+        headers: signed.headers,
+        body,
+        publicKey: keypair.publicKey,
+        nowMs: deterministicNowMs,
+      }),
+    ).resolves.toMatchObject({
+      proof: signed.proof,
     });
   });
 });

--- a/packages/sdk/src/http/verify.ts
+++ b/packages/sdk/src/http/verify.ts
@@ -142,12 +142,20 @@ export async function verifyHttpRequest(
   const method = ensureString(input.method, "method");
   const pathWithQuery = ensureString(input.pathWithQuery, "pathWithQuery");
   const headers = normalizeSignatureHeaders(input.headers);
-  const body = ensureBodyBytes(input.body);
-  const expectedBodyHash = await hashBodySha256Base64url(body);
   const nowMs = resolveNowMs(input.nowMs);
   const maxTimestampSkewSeconds = resolveMaxTimestampSkewSeconds(
     input.maxTimestampSkewSeconds,
   );
+
+  const timestampSeconds = parseUnixTimestamp(headers[X_CLAW_TIMESTAMP]);
+  assertTimestampWithinSkew({
+    nowMs,
+    maxTimestampSkewSeconds,
+    timestampSeconds,
+  });
+
+  const body = ensureBodyBytes(input.body);
+  const expectedBodyHash = await hashBodySha256Base64url(body);
 
   if (headers[X_CLAW_BODY_SHA256] !== expectedBodyHash) {
     throw new AppError({
@@ -160,13 +168,6 @@ export async function verifyHttpRequest(
       },
     });
   }
-
-  const timestampSeconds = parseUnixTimestamp(headers[X_CLAW_TIMESTAMP]);
-  assertTimestampWithinSkew({
-    nowMs,
-    maxTimestampSkewSeconds,
-    timestampSeconds,
-  });
 
   const canonicalRequest = canonicalizeRequest({
     method,

--- a/packages/sdk/src/http/verify.ts
+++ b/packages/sdk/src/http/verify.ts
@@ -12,7 +12,9 @@ import {
 } from "./constants.js";
 import type {
   VerifyHttpRequestInput,
+  VerifyHttpRequestNonceCheckResult,
   VerifyHttpRequestResult,
+  VerifyHttpRequestWithReplayProtectionInput,
 } from "./types.js";
 import {
   ensureBodyBytes,
@@ -22,6 +24,115 @@ import {
   normalizeSignatureHeaders,
   textEncoder,
 } from "./utils.js";
+
+const DEFAULT_MAX_TIMESTAMP_SKEW_SECONDS = 300;
+
+function resolveNowMs(nowMs: number | undefined): number {
+  const resolved = nowMs ?? Date.now();
+  if (!Number.isFinite(resolved) || resolved < 0) {
+    throw new AppError({
+      code: "HTTP_SIGNATURE_INVALID_INPUT",
+      message: "nowMs must be a non-negative number",
+      status: 400,
+      details: {
+        field: "nowMs",
+        value: nowMs,
+      },
+    });
+  }
+
+  return resolved;
+}
+
+function resolveMaxTimestampSkewSeconds(
+  maxTimestampSkewSeconds: number | undefined,
+): number {
+  const resolved =
+    maxTimestampSkewSeconds ?? DEFAULT_MAX_TIMESTAMP_SKEW_SECONDS;
+  if (!Number.isFinite(resolved) || resolved <= 0) {
+    throw new AppError({
+      code: "HTTP_SIGNATURE_INVALID_INPUT",
+      message: "maxTimestampSkewSeconds must be a positive number",
+      status: 400,
+      details: {
+        field: "maxTimestampSkewSeconds",
+        value: maxTimestampSkewSeconds,
+      },
+    });
+  }
+
+  return resolved;
+}
+
+function resolveNonceTtlMs(
+  nonceTtlMs: number | undefined,
+  maxTimestampSkewSeconds: number,
+): number {
+  const resolved = nonceTtlMs ?? maxTimestampSkewSeconds * 1000;
+  if (!Number.isFinite(resolved) || resolved <= 0) {
+    throw new AppError({
+      code: "HTTP_SIGNATURE_INVALID_INPUT",
+      message: "nonceTtlMs must be a positive number",
+      status: 400,
+      details: {
+        field: "nonceTtlMs",
+        value: nonceTtlMs,
+      },
+    });
+  }
+
+  return resolved;
+}
+
+function parseUnixTimestamp(timestampHeader: string): number {
+  if (!/^\d+$/.test(timestampHeader)) {
+    throw new AppError({
+      code: "HTTP_SIGNATURE_INVALID_TIMESTAMP",
+      message: "X-Claw-Timestamp must be a unix seconds integer",
+      status: 401,
+    });
+  }
+
+  const parsed = Number.parseInt(timestampHeader, 10);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new AppError({
+      code: "HTTP_SIGNATURE_INVALID_TIMESTAMP",
+      message: "X-Claw-Timestamp must be a unix seconds integer",
+      status: 401,
+    });
+  }
+
+  return parsed;
+}
+
+function assertTimestampWithinSkew(options: {
+  nowMs: number;
+  maxTimestampSkewSeconds: number;
+  timestampSeconds: number;
+}): void {
+  const nowSeconds = Math.floor(options.nowMs / 1000);
+  const skew = Math.abs(nowSeconds - options.timestampSeconds);
+  if (skew > options.maxTimestampSkewSeconds) {
+    throw new AppError({
+      code: "HTTP_SIGNATURE_TIMESTAMP_SKEW",
+      message: "X-Claw-Timestamp is outside the allowed skew window",
+      status: 401,
+      details: {
+        maxTimestampSkewSeconds: options.maxTimestampSkewSeconds,
+      },
+    });
+  }
+}
+
+function toErrorReason(error: unknown): string {
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return error.message;
+  }
+  if (typeof error === "string" && error.trim().length > 0) {
+    return error;
+  }
+  return "unknown";
+}
 
 export async function verifyHttpRequest(
   input: VerifyHttpRequestInput,
@@ -33,6 +144,10 @@ export async function verifyHttpRequest(
   const headers = normalizeSignatureHeaders(input.headers);
   const body = ensureBodyBytes(input.body);
   const expectedBodyHash = await hashBodySha256Base64url(body);
+  const nowMs = resolveNowMs(input.nowMs);
+  const maxTimestampSkewSeconds = resolveMaxTimestampSkewSeconds(
+    input.maxTimestampSkewSeconds,
+  );
 
   if (headers[X_CLAW_BODY_SHA256] !== expectedBodyHash) {
     throw new AppError({
@@ -45,6 +160,13 @@ export async function verifyHttpRequest(
       },
     });
   }
+
+  const timestampSeconds = parseUnixTimestamp(headers[X_CLAW_TIMESTAMP]);
+  assertTimestampWithinSkew({
+    nowMs,
+    maxTimestampSkewSeconds,
+    timestampSeconds,
+  });
 
   const canonicalRequest = canonicalizeRequest({
     method,
@@ -93,4 +215,52 @@ export async function verifyHttpRequest(
     canonicalRequest,
     proof: headers[X_CLAW_PROOF],
   };
+}
+
+export async function verifyHttpRequestWithReplayProtection(
+  input: VerifyHttpRequestWithReplayProtectionInput,
+): Promise<VerifyHttpRequestResult> {
+  const verified = await verifyHttpRequest(input);
+  const headers = normalizeSignatureHeaders(input.headers);
+  const agentDid = ensureString(input.agentDid, "agentDid");
+  const nowMs = resolveNowMs(input.nowMs);
+  const maxTimestampSkewSeconds = resolveMaxTimestampSkewSeconds(
+    input.maxTimestampSkewSeconds,
+  );
+  const nonceTtlMs = resolveNonceTtlMs(
+    input.nonceTtlMs,
+    maxTimestampSkewSeconds,
+  );
+
+  let nonceCheckResult: VerifyHttpRequestNonceCheckResult;
+  try {
+    nonceCheckResult = await input.nonceChecker.tryAcceptNonce({
+      agentDid,
+      nonce: headers[X_CLAW_NONCE],
+      ttlMs: nonceTtlMs,
+      nowMs,
+    });
+  } catch (error) {
+    throw new AppError({
+      code: "HTTP_SIGNATURE_NONCE_CHECK_FAILED",
+      message: "Nonce replay check failed",
+      status: 401,
+      details: {
+        reason: toErrorReason(error),
+      },
+    });
+  }
+
+  if (!nonceCheckResult.accepted) {
+    throw new AppError({
+      code: "HTTP_SIGNATURE_REPLAY_DETECTED",
+      message: "Replay detected",
+      status: 401,
+      details: {
+        reason: nonceCheckResult.reason,
+      },
+    });
+  }
+
+  return verified;
 }

--- a/packages/sdk/src/index.test.ts
+++ b/packages/sdk/src/index.test.ts
@@ -34,6 +34,7 @@ import {
   verifyCRL,
   verifyEd25519,
   verifyHttpRequest,
+  verifyHttpRequestWithReplayProtection,
 } from "./index.js";
 
 describe("sdk", () => {
@@ -246,10 +247,50 @@ describe("sdk", () => {
       headers: signed.headers,
       body,
       publicKey: keypair.publicKey,
+      nowMs: 1_739_364_000_000,
     });
 
     expect(verified.proof).toBe(signed.proof);
     expect(verified.canonicalRequest).toBe(signed.canonicalRequest);
+  });
+
+  it("exports replay-protected HTTP verification helper from package root", async () => {
+    const keypair = await generateEd25519Keypair();
+    const body = new TextEncoder().encode('{"ok":true}');
+    const signed = await signHttpRequest({
+      method: "POST",
+      pathWithQuery: "/v1/messages?b=2&a=1",
+      timestamp: "1739364000",
+      nonce: "nonce_root_http_replay",
+      body,
+      secretKey: keypair.secretKey,
+    });
+
+    const seen = new Set<string>();
+    const nonceChecker = {
+      tryAcceptNonce(input: { agentDid: string; nonce: string }) {
+        const key = `${input.agentDid}|${input.nonce}`;
+        if (seen.has(key)) {
+          return { accepted: false as const, reason: "replay" as const };
+        }
+        seen.add(key);
+        return { accepted: true as const };
+      },
+    };
+
+    const verified = await verifyHttpRequestWithReplayProtection({
+      method: "POST",
+      pathWithQuery: "/v1/messages?b=2&a=1",
+      headers: signed.headers,
+      body,
+      publicKey: keypair.publicKey,
+      nowMs: 1_739_364_000_000,
+      agentDid:
+        "did:cdi:registry.clawdentity.dev:agent:01HF7YAT00W6W7CM7N3W5FDXT4",
+      nonceChecker,
+    });
+
+    expect(verified.proof).toBe(signed.proof);
   });
 
   it("exports nonce cache helpers from package root", () => {

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -59,9 +59,16 @@ export type {
   SignHttpRequestInput,
   SignHttpRequestResult,
   VerifyHttpRequestInput,
+  VerifyHttpRequestNonceChecker,
+  VerifyHttpRequestNonceCheckInput,
+  VerifyHttpRequestNonceCheckResult,
   VerifyHttpRequestResult,
+  VerifyHttpRequestWithReplayProtectionInput,
 } from "./http/types.js";
-export { verifyHttpRequest } from "./http/verify.js";
+export {
+  verifyHttpRequest,
+  verifyHttpRequestWithReplayProtection,
+} from "./http/verify.js";
 export type {
   DecodedAit,
   DecodedAitHeader,


### PR DESCRIPTION
## Summary\n- enforce timestamp format + freshness in  (secure by default)\n- add  to verify signature + timestamp + nonce replay in one call\n- refactor proxy auth middleware to use the new one-call SDK verifier while preserving proxy error codes\n- update SDK docs and AGENTS best-practice guidance for the new verification pattern\n\n## Validation\n- 
> @clawdentity/sdk@0.0.0 test /Users/dev/Workdir/clawdentity/packages/sdk
> vitest run


 RUN  v4.0.18 /Users/dev/Workdir/clawdentity/packages/sdk

 ✓ src/logging.test.ts (5 tests) 83ms
 ✓ src/http/sign.test.ts (3 tests) 285ms
 ✓ src/crypto/ed25519.test.ts (9 tests) 530ms
 ✓ src/http/verify-replay.test.ts (3 tests) 263ms
 ✓ src/jwt/crl-jwt.test.ts (6 tests) 84ms
 ✓ src/http/verify.test.ts (10 tests) 570ms
 ✓ src/agent-auth-client.test.ts (4 tests) 429ms
     ✓ refreshes auth with claw proof  350ms
 ✓ src/jwt/ait-jwt.test.ts (8 tests) 318ms
 ✓ src/index.test.ts (10 tests) 189ms
 ✓ src/exceptions.test.ts (2 tests) 178ms
 ✓ src/request-context.test.ts (3 tests) 139ms
 ✓ src/security/nonce-cache.test.ts (6 tests) 6ms
 ✓ src/event-bus.test.ts (3 tests) 22ms
 ✓ src/testing/ait-fixtures.test.ts (2 tests) 9ms
 ✓ src/datetime.test.ts (4 tests) 14ms
 ✓ src/config.test.ts (20 tests) 14ms
 ✓ src/crl/cache.test.ts (7 tests) 6ms
 ✓ src/registry-identity-client.test.ts (4 tests) 109ms
 ✓ src/runtime-environment.test.ts (3 tests) 1ms

 Test Files  19 passed (19)
      Tests  112 passed (112)
   Start at  21:15:44
   Duration  2.06s (transform 2.39s, setup 0ms, import 8.93s, tests 3.25s, environment 2ms)\n- 
> @clawdentity/proxy@0.0.0 test /Users/dev/Workdir/clawdentity/apps/proxy
> vitest run


 RUN  v4.0.18 /Users/dev/Workdir/clawdentity/apps/proxy

 ✓ src/auth-middleware.test/url.test.ts (7 tests) 15ms
 ✓ src/proxy-trust-state.test.ts (8 tests) 123ms
stdout | src/pairing-route.test/confirm.test.ts > POST /pair/confirm > confirms local issuer tickets and enables mutual trust
{"timestamp":"2026-03-27T15:45:51.077Z","level":"info","message":"proxy.pair.confirm","service":"proxy","requestId":"bfa5f658-d2fc-45e8-8320-5187470d903f","initiatorAgentDid":"did:cdi:dev.registry.clawdentity.com:agent:01HF7YAT00YNKTFKDFNCPCDVFT","responderAgentDid":"did:cdi:dev.registry.clawdentity.com:agent:01HF7YAT344A3CZBTKX2QHWWVK","issuerProxyUrl":"http://localhost"}

stdout | src/pairing-route.test/confirm.test.ts > POST /pair/confirm > confirms local issuer tickets and enables mutual trust
{"timestamp":"2026-03-27T15:45:51.078Z","level":"info","message":"request.completed","service":"proxy","requestId":"bfa5f658-d2fc-45e8-8320-5187470d903f","method":"POST","path":"/pair/confirm","status":201,"durationMs":5}

stdout | src/pairing-route.test/confirm.test.ts > POST /pair/confirm > rejects confirm replay with 409
{"timestamp":"2026-03-27T15:45:51.086Z","level":"info","message":"proxy.pair.confirm","service":"proxy","requestId":"e25fad98-eade-4bc8-9781-dc01ee002f7c","initiatorAgentDid":"did:cdi:dev.registry.clawdentity.com:agent:01HF7YAT00YNKTFKDFNCPCDVFT","responderAgentDid":"did:cdi:dev.registry.clawdentity.com:agent:01HF7YAT344A3CZBTKX2QHWWVK","issuerProxyUrl":"http://localhost"}

stdout | src/pairing-route.test/confirm.test.ts > POST /pair/confirm > rejects confirm replay with 409
{"timestamp":"2026-03-27T15:45:51.086Z","level":"info","message":"request.completed","service":"proxy","requestId":"e25fad98-eade-4bc8-9781-dc01ee002f7c","method":"POST","path":"/pair/confirm","status":201,"durationMs":1}

stdout | src/pairing-route.test/confirm.test.ts > POST /pair/confirm > rejects confirm replay with 409
{"timestamp":"2026-03-27T15:45:51.088Z","level":"info","message":"request.completed","service":"proxy","requestId":"5ff3bf7a-10c0-4017-add0-e20da122d4e6","method":"POST","path":"/pair/confirm","status":409,"durationMs":2}

stdout | src/pairing-route.test/start.test.ts > POST /pair/start > creates a pairing ticket when caller owns initiator agent DID
{"timestamp":"2026-03-27T15:45:51.082Z","level":"info","message":"proxy.pair.start","service":"proxy","requestId":"7329b545-191d-4486-b9a0-4cb298f80046","initiatorAgentDid":"did:cdi:registry.clawdentity.com:agent:01HF7YAT00ASECAT02Q8KA0GRR","issuerProxyUrl":"http://localhost","expiresAt":"2023-11-14T22:18:20.000Z","pkid":"01HF7YAT00KBMH8J7F72MMW9VR","hasCallbackUrl":false}

stdout | src/pairing-route.test/start.test.ts > POST /pair/start > creates a pairing ticket when caller owns initiator agent DID
{"timestamp":"2026-03-27T15:45:51.083Z","level":"info","message":"request.completed","service":"proxy","requestId":"7329b545-191d-4486-b9a0-4cb298f80046","method":"POST","path":"/pair/start","status":200,"durationMs":11}

stdout | src/agent-hook-route.test.ts > POST /hooks/agent > delivers hook payload to recipient relay session
{"timestamp":"2026-03-27T15:45:51.080Z","level":"info","message":"proxy.hooks.agent.delivered_to_relay","service":"proxy","requestId":"24fef213-cbe4-4c62-84ed-197b16bddaa3","senderAgentDid":"did:cdi:dev.registry.clawdentity.com:agent:01HF7YAT00EXEKCZ140TBBFB97","recipientAgentDid":"did:cdi:dev.registry.clawdentity.com:agent:01HF7YAT31JZHSMW1CG6Q6MHB7","deliveryId":"dlv_1","state":"delivered","delivered":true,"queued":false,"queueDepth":0,"connectedSockets":1,"sentAt":"2026-02-16T20:00:00.000Z"}

stdout | src/agent-hook-route.test.ts > POST /hooks/agent > delivers hook payload to recipient relay session
{"timestamp":"2026-03-27T15:45:51.083Z","level":"info","message":"request.completed","service":"proxy","requestId":"24fef213-cbe4-4c62-84ed-197b16bddaa3","method":"POST","path":"/hooks/agent","status":202,"durationMs":6}

stdout | src/agent-hook-route.test.ts > POST /hooks/agent > delivers through DO fetch RPC
{"timestamp":"2026-03-27T15:45:51.089Z","level":"info","message":"proxy.hooks.agent.delivered_to_relay","service":"proxy","requestId":"2ba84a02-1bad-4136-a039-ea53a2d71bf9","senderAgentDid":"did:cdi:dev.registry.clawdentity.com:agent:01HF7YAT00EXEKCZ140TBBFB97","recipientAgentDid":"did:cdi:dev.registry.clawdentity.com:agent:01HF7YAT31JZHSMW1CG6Q6MHB7","deliveryId":"dlv_1","state":"delivered","delivered":true,"queued":false,"queueDepth":0,"connectedSockets":1,"sentAt":"2026-03-27T15:45:51.089Z"}

stdout | src/agent-hook-route.test.ts > POST /hooks/agent > delivers through DO fetch RPC
{"timestamp":"2026-03-27T15:45:51.090Z","level":"info","message":"request.completed","service":"proxy","requestId":"2ba84a02-1bad-4136-a039-ea53a2d71bf9","method":"POST","path":"/hooks/agent","status":202,"durationMs":2}

stdout | src/pairing-route.test/confirm.test.ts > POST /pair/confirm > rejects responder DID mismatch when allowResponderAgentDid is set
{"timestamp":"2026-03-27T15:45:51.094Z","level":"info","message":"request.completed","service":"proxy","requestId":"9fa91b6e-144c-4fdb-a97e-e09493b43d9a","method":"POST","path":"/pair/confirm","status":403,"durationMs":2}

stdout | src/pairing-route.test/start.test.ts > POST /pair/start > normalizes pairing ticket expiry to whole seconds
{"timestamp":"2026-03-27T15:45:51.093Z","level":"info","message":"proxy.pair.start","service":"proxy","requestId":"01b48175-d652-49cf-935f-daff45d884b7","initiatorAgentDid":"did:cdi:registry.clawdentity.com:agent:01HF7YAT00ASECAT02Q8KA0GRR","issuerProxyUrl":"http://localhost","expiresAt":"2023-11-14T22:18:20.000Z","pkid":"01HF7YAT3V1TPQ7TJMMHB5P5W9","hasCallbackUrl":false}

stdout | src/pairing-route.test/start.test.ts > POST /pair/start > normalizes pairing ticket expiry to whole seconds
{"timestamp":"2026-03-27T15:45:51.094Z","level":"info","message":"request.completed","service":"proxy","requestId":"01b48175-d652-49cf-935f-daff45d884b7","method":"POST","path":"/pair/start","status":200,"durationMs":7}

stdout | src/pairing-route.test/start.test.ts > POST /pair/start > returns 403 when ownership check reports caller is not owner
{"timestamp":"2026-03-27T15:45:51.118Z","level":"info","message":"request.completed","service":"proxy","requestId":"85718515-6a9a-427f-8ca3-23e455c8bc28","method":"POST","path":"/pair/start","status":403,"durationMs":1}

stdout | src/pairing-route.test/start.test.ts > POST /pair/start > keeps strict dependency failures when ownership lookup is unavailable
{"timestamp":"2026-03-27T15:45:51.120Z","level":"info","message":"request.completed","service":"proxy","requestId":"88dab328-681d-4d12-abe2-d644a2a0598e","method":"POST","path":"/pair/start","status":503,"durationMs":1}

stdout | src/pairing-route.test/start.test.ts > POST /pair/start > accepts optional allowResponderAgentDid and callbackUrl
{"timestamp":"2026-03-27T15:45:51.121Z","level":"info","message":"proxy.pair.start","service":"proxy","requestId":"5e580b69-049b-4902-a6f9-2b354ed7e189","initiatorAgentDid":"did:cdi:registry.clawdentity.com:agent:01HF7YAT00ASECAT02Q8KA0GRR","issuerProxyUrl":"http://localhost","expiresAt":"2023-11-14T22:18:20.000Z","pkid":"01HF7YAT0046C5F01CXGKPW9SF","allowResponderAgentDid":"did:cdi:registry.clawdentity.com:agent:01HF7YAT34Q698Q6BWTJNSX0RH","hasCallbackUrl":true}

stdout | src/pairing-route.test/start.test.ts > POST /pair/start > accepts optional allowResponderAgentDid and callbackUrl
{"timestamp":"2026-03-27T15:45:51.122Z","level":"info","message":"request.completed","service":"proxy","requestId":"5e580b69-049b-4902-a6f9-2b354ed7e189","method":"POST","path":"/pair/start","status":200,"durationMs":2}

stdout | src/pairing-route.test/start.test.ts > POST /pair/start > rejects invalid callbackUrl
{"timestamp":"2026-03-27T15:45:51.123Z","level":"info","message":"request.completed","service":"proxy","requestId":"7c9e5fe2-b6a9-4ba5-b923-3333ac14528c","method":"POST","path":"/pair/start","status":400,"durationMs":0}

stdout | src/pairing-route.test/start.test.ts > POST /pair/start > rejects empty allowResponderAgentDid
{"timestamp":"2026-03-27T15:45:51.125Z","level":"info","message":"request.completed","service":"proxy","requestId":"0f3d2147-8786-453f-93f5-b0c4ed979b97","method":"POST","path":"/pair/start","status":400,"durationMs":0}

stdout | src/agent-hook-route.test.ts > POST /hooks/agent > returns 403 when sender/recipient pair is not trusted
{"timestamp":"2026-03-27T15:45:51.094Z","level":"info","message":"request.completed","service":"proxy","requestId":"a3781e1d-c045-4448-b669-7a5c6328db88","method":"POST","path":"/hooks/agent","status":403,"durationMs":2}

stdout | src/agent-hook-route.test.ts > POST /hooks/agent > keeps message payload unchanged by default
{"timestamp":"2026-03-27T15:45:51.096Z","level":"info","message":"proxy.hooks.agent.delivered_to_relay","service":"proxy","requestId":"37aaab61-fe9a-4cb2-a870-0c42f24e7386","senderAgentDid":"did:cdi:dev.registry.clawdentity.com:agent:01HF7YAT00EXEKCZ140TBBFB97","recipientAgentDid":"did:cdi:dev.registry.clawdentity.com:agent:01HF7YAT31JZHSMW1CG6Q6MHB7","deliveryId":"dlv_1","state":"delivered","delivered":true,"queued":false,"queueDepth":0,"connectedSockets":1,"sentAt":"2026-03-27T15:45:51.096Z"}

stdout | src/agent-hook-route.test.ts > POST /hooks/agent > keeps message payload unchanged by default
{"timestamp":"2026-03-27T15:45:51.106Z","level":"info","message":"request.completed","service":"proxy","requestId":"37aaab61-fe9a-4cb2-a870-0c42f24e7386","method":"POST","path":"/hooks/agent","status":202,"durationMs":10}

stdout | src/agent-hook-route.test.ts > POST /hooks/agent > prepends sanitized identity block when message injection is enabled
{"timestamp":"2026-03-27T15:45:51.111Z","level":"info","message":"proxy.hooks.agent.delivered_to_relay","service":"proxy","requestId":"83db81ba-acd1-4eaa-a969-3896ebd864b1","senderAgentDid":"did:cdi:dev.registry.clawdentity.com:agent:01HF7YAT00EXEKCZ140TBBFB97","recipientAgentDid":"did:cdi:dev.registry.clawdentity.com:agent:01HF7YAT31JZHSMW1CG6Q6MHB7","deliveryId":"dlv_1","state":"delivered","delivered":true,"queued":false,"queueDepth":0,"connectedSockets":1,"sentAt":"2026-03-27T15:45:51.111Z"}

stdout | src/agent-hook-route.test.ts > POST /hooks/agent > prepends sanitized identity block when message injection is enabled
{"timestamp":"2026-03-27T15:45:51.112Z","level":"info","message":"request.completed","service":"proxy","requestId":"83db81ba-acd1-4eaa-a969-3896ebd864b1","method":"POST","path":"/hooks/agent","status":202,"durationMs":3}

stdout | src/agent-hook-route.test.ts > POST /hooks/agent > keeps payload unchanged when message injection is enabled but auth is missing
{"timestamp":"2026-03-27T15:45:51.117Z","level":"info","message":"request.completed","service":"proxy","requestId":"75c8f436-e111-470e-8248-c23771d80ac9","method":"POST","path":"/hooks/agent","status":500,"durationMs":1}

stdout | src/agent-hook-route.test.ts > POST /hooks/agent > keeps payload unchanged when message is missing or non-string
{"timestamp":"2026-03-27T15:45:51.118Z","level":"info","message":"proxy.hooks.agent.delivered_to_relay","service":"proxy","requestId":"477a5eac-42f1-402b-b84f-2a68893670b5","senderAgentDid":"did:cdi:dev.registry.clawdentity.com:agent:01HF7YAT00EXEKCZ140TBBFB97","recipientAgentDid":"did:cdi:dev.registry.clawdentity.com:agent:01HF7YAT31JZHSMW1CG6Q6MHB7","deliveryId":"dlv_1","state":"delivered","delivered":true,"queued":false,"queueDepth":0,"connectedSockets":1,"sentAt":"2026-03-27T15:45:51.118Z"}

stdout | src/agent-hook-route.test.ts > POST /hooks/agent > keeps payload unchanged when message is missing or non-string
{"timestamp":"2026-03-27T15:45:51.118Z","level":"info","message":"request.completed","service":"proxy","requestId":"477a5eac-42f1-402b-b84f-2a68893670b5","method":"POST","path":"/hooks/agent","status":202,"durationMs":0}

stdout | src/agent-hook-route.test.ts > POST /hooks/agent > keeps payload unchanged when message is missing or non-string
{"timestamp":"2026-03-27T15:45:51.119Z","level":"info","message":"proxy.hooks.agent.delivered_to_relay","service":"proxy","requestId":"84a4d38e-919b-4322-8410-bef9618adf79","senderAgentDid":"did:cdi:dev.registry.clawdentity.com:agent:01HF7YAT00EXEKCZ140TBBFB97","recipientAgentDid":"did:cdi:dev.registry.clawdentity.com:agent:01HF7YAT31JZHSMW1CG6Q6MHB7","deliveryId":"dlv_1","state":"delivered","delivered":true,"queued":false,"queueDepth":0,"connectedSockets":1,"sentAt":"2026-03-27T15:45:51.119Z"}

stdout | src/agent-hook-route.test.ts > POST /hooks/agent > keeps payload unchanged when message is missing or non-string
{"timestamp":"2026-03-27T15:45:51.119Z","level":"info","message":"request.completed","service":"proxy","requestId":"84a4d38e-919b-4322-8410-bef9618adf79","method":"POST","path":"/hooks/agent","status":202,"durationMs":1}

stdout | src/agent-hook-route.test.ts > POST /hooks/agent > sanitizes identity fields and enforces length limits
{"timestamp":"2026-03-27T15:45:51.121Z","level":"info","message":"proxy.hooks.agent.delivered_to_relay","service":"proxy","requestId":"8e344965-b52d-4cb8-8227-354bce267e52","senderAgentDid":"\u0000 did:cdi:dev.registry.clawdentity.com:agent:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \n","recipientAgentDid":"did:cdi:dev.registry.clawdentity.com:agent:01HF7YAT31JZHSMW1CG6Q6MHB7","deliveryId":"dlv_1","state":"delivered","delivered":true,"queued":false,"queueDepth":0,"connectedSockets":1,"sentAt":"2026-03-27T15:45:51.121Z"}

stdout | src/agent-hook-route.test.ts > POST /hooks/agent > sanitizes identity fields and enforces length limits
{"timestamp":"2026-03-27T15:45:51.121Z","level":"info","message":"request.completed","service":"proxy","requestId":"8e344965-b52d-4cb8-8227-354bce267e52","method":"POST","path":"/hooks/agent","status":202,"durationMs":1}

stdout | src/agent-hook-route.test.ts > POST /hooks/agent > rejects non-json content types
{"timestamp":"2026-03-27T15:45:51.125Z","level":"info","message":"request.completed","service":"proxy","requestId":"07b2a648-ac2b-4a07-b26e-76c7e3ff53e6","method":"POST","path":"/hooks/agent","status":415,"durationMs":1}

stdout | src/pairing-route.test/confirm.test.ts > POST /pair/confirm > posts callback on confirm and does not fail on callback errors
{"timestamp":"2026-03-27T15:45:51.113Z","level":"info","message":"proxy.pair.confirm","service":"proxy","requestId":"f4853c35-d0c3-4f20-9671-0ad99dcd7e7c","initiatorAgentDid":"did:cdi:dev.registry.clawdentity.com:agent:01HF7YAT00YNKTFKDFNCPCDVFT","responderAgentDid":"did:cdi:dev.registry.clawdentity.com:agent:01HF7YAT344A3CZBTKX2QHWWVK","issuerProxyUrl":"http://localhost","callbackUrl":"https://callbacks.example.com/success"}

stdout | src/pairing-route.test/confirm.test.ts > POST /pair/confirm > posts callback on confirm and does not fail on callback errors
{"timestamp":"2026-03-27T15:45:51.114Z","level":"info","message":"request.completed","service":"proxy","requestId":"f4853c35-d0c3-4f20-9671-0ad99dcd7e7c","method":"POST","path":"/pair/confirm","status":201,"durationMs":3}

stdout | src/pairing-route.test/confirm.test.ts > POST /pair/confirm > posts callback on confirm and does not fail on callback errors
{"timestamp":"2026-03-27T15:45:51.118Z","level":"info","message":"proxy.pair.confirm","service":"proxy","requestId":"dd08664b-3267-45d4-a18a-e01e7061c260","initiatorAgentDid":"did:cdi:dev.registry.clawdentity.com:agent:01HF7YAT0AAENFV8KF49XX35MS","responderAgentDid":"did:cdi:dev.registry.clawdentity.com:agent:01HF7YAT0M4JJ2M98HGEWZFQ32","issuerProxyUrl":"http://localhost","callbackUrl":"https://callbacks.example.com/failure"}

stdout | src/pairing-route.test/confirm.test.ts > POST /pair/confirm > posts callback on confirm and does not fail on callback errors
{"timestamp":"2026-03-27T15:45:51.119Z","level":"info","message":"request.completed","service":"proxy","requestId":"dd08664b-3267-45d4-a18a-e01e7061c260","method":"POST","path":"/pair/confirm","status":201,"durationMs":2}

stdout | src/pairing-route.test/confirm.test.ts > POST /pair/confirm > does not block confirm response while callback delivery is pending
{"timestamp":"2026-03-27T15:45:51.123Z","level":"info","message":"proxy.pair.confirm","service":"proxy","requestId":"1c108d56-dafe-49b1-98ab-36a541336bd0","initiatorAgentDid":"did:cdi:dev.registry.clawdentity.com:agent:01HF7YAT00YNKTFKDFNCPCDVFT","responderAgentDid":"did:cdi:dev.registry.clawdentity.com:agent:01HF7YAT344A3CZBTKX2QHWWVK","issuerProxyUrl":"http://localhost","callbackUrl":"https://callbacks.example.com/pending"}

stdout | src/pairing-route.test/confirm.test.ts > POST /pair/confirm > does not block confirm response while callback delivery is pending
{"timestamp":"2026-03-27T15:45:51.123Z","level":"info","message":"request.completed","service":"proxy","requestId":"1c108d56-dafe-49b1-98ab-36a541336bd0","method":"POST","path":"/pair/confirm","status":201,"durationMs":1}

 ✓ src/pairing-route.test/start.test.ts (7 tests) 66ms
 ✓ src/agent-relay-session.delivery.test.ts (9 tests) 191ms
stdout | src/auth-middleware.test/robustness.test.ts > proxy auth middleware > rejects non-health route when Authorization scheme is not Claw
{"timestamp":"2026-03-27T15:45:51.138Z","level":"info","message":"request.completed","service":"proxy","requestId":"63b15486-d627-4ec1-8c20-69c2b0cdbfa0","method":"POST","path":"/protected","status":401,"durationMs":3}

stdout | src/auth-middleware.test/robustness.test.ts > proxy auth middleware > rejects Authorization headers with extra segments
{"timestamp":"2026-03-27T15:45:51.151Z","level":"info","message":"request.completed","service":"proxy","requestId":"93431390-4682-48ba-a3ce-9ac7eb6d1126","method":"POST","path":"/protected","status":401,"durationMs":1}

stdout | src/agent-hook-route.test.ts > POST /hooks/agent > rejects invalid JSON payloads
{"timestamp":"2026-03-27T15:45:51.159Z","level":"info","message":"request.completed","service":"proxy","requestId":"7f605cf6-f623-4430-9058-ad8b58b81146","method":"POST","path":"/hooks/agent","status":400,"durationMs":18}

stdout | src/agent-hook-route.test.ts > POST /hooks/agent > rejects missing recipient DID header
{"timestamp":"2026-03-27T15:45:51.160Z","level":"info","message":"request.completed","service":"proxy","requestId":"c8c4f7a3-21fa-4993-a308-bf7dc93cc112","method":"POST","path":"/hooks/agent","status":400,"durationMs":0}

stdout | src/agent-hook-route.test.ts > POST /hooks/agent > rejects invalid recipient DID header
{"timestamp":"2026-03-27T15:45:51.164Z","level":"info","message":"request.completed","service":"proxy","requestId":"2f8bb232-cdc2-4e9a-ae7b-83226fd81f1d","method":"POST","path":"/hooks/agent","status":400,"durationMs":3}

stdout | src/agent-hook-route.test.ts > POST /hooks/agent > returns 503 when relay session namespace is unavailable
{"timestamp":"2026-03-27T15:45:51.166Z","level":"info","message":"request.completed","service":"proxy","requestId":"42085e10-186c-45ea-b01c-6bfcb129892d","method":"POST","path":"/hooks/agent","status":503,"durationMs":0}

stdout | src/auth-middleware.test/agent-access.test.ts > proxy auth middleware > requires x-claw-agent-access for /hooks/agent
{"timestamp":"2026-03-27T15:45:51.167Z","level":"info","message":"request.completed","service":"proxy","requestId":"0e809dda-1483-4247-bfd7-5eb0be8ed46a","method":"POST","path":"/hooks/agent","status":401,"durationMs":13}

stdout | src/auth-middleware.test/robustness.test.ts > proxy auth middleware > rejects replayed nonce for the same agent
{"timestamp":"2026-03-27T15:45:51.169Z","level":"info","message":"proxy.auth.verified","service":"proxy","agentDid":"did:cdi:registry.clawdentity.com:agent:01KMQZJ9YH4EZF62EJNC7KB47K","ownerDid":"did:cdi:registry.clawdentity.com:human:01KMQZJ9YV8XXQFKSS47CAB7AR","jti":"01KMQZJ9Z5G7NQ0SG68TJMMMAY"}

stdout | src/auth-middleware.test/robustness.test.ts > proxy auth middleware > rejects replayed nonce for the same agent
{"timestamp":"2026-03-27T15:45:51.169Z","level":"info","message":"request.completed","service":"proxy","requestId":"15f930cb-ff0e-47a8-a19b-0c26520741e0","method":"POST","path":"/protected","status":200,"durationMs":10}

stdout | src/agent-hook-route.test.ts > POST /hooks/agent > maps relay delivery failures to 502
{"timestamp":"2026-03-27T15:45:51.169Z","level":"info","message":"request.completed","service":"proxy","requestId":"0d69c66c-f473-4452-aa3f-7cf82b4bc694","method":"POST","path":"/hooks/agent","status":502,"durationMs":2}

stdout | src/agent-hook-route.test.ts > POST /hooks/agent > returns queued state when target connector is offline
{"timestamp":"2026-03-27T15:45:51.171Z","level":"info","message":"proxy.hooks.agent.delivered_to_relay","service":"proxy","requestId":"10e026ba-9118-4ed2-a435-ae3c9990cc4b","senderAgentDid":"did:cdi:dev.registry.clawdentity.com:agent:01HF7YAT00EXEKCZ140TBBFB97","recipientAgentDid":"did:cdi:dev.registry.clawdentity.com:agent:01HF7YAT31JZHSMW1CG6Q6MHB7","deliveryId":"dlv_queued","state":"queued","delivered":false,"queued":true,"queueDepth":1,"connectedSockets":0,"sentAt":"2026-03-27T15:45:51.171Z"}

stdout | src/agent-hook-route.test.ts > POST /hooks/agent > returns queued state when target connector is offline
{"timestamp":"2026-03-27T15:45:51.172Z","level":"info","message":"request.completed","service":"proxy","requestId":"10e026ba-9118-4ed2-a435-ae3c9990cc4b","method":"POST","path":"/hooks/agent","status":202,"durationMs":1}

stdout | src/agent-hook-route.test.ts > POST /hooks/agent > returns 507 when relay queue is full
{"timestamp":"2026-03-27T15:45:51.173Z","level":"info","message":"request.completed","service":"proxy","requestId":"b5b08988-d58d-49ca-a9d8-7f3155dff4b1","method":"POST","path":"/hooks/agent","status":507,"durationMs":0}

stdout | src/pairing-route.test/confirm.test.ts > POST /pair/confirm > rejects confirm when signature does not match persisted publicKeyX
{"timestamp":"2026-03-27T15:45:51.175Z","level":"info","message":"request.completed","service":"proxy","requestId":"8245c0e3-8945-4cfd-8ab1-bcf2900d1234","method":"POST","path":"/pair/confirm","status":400,"durationMs":0}

stdout | src/auth-middleware.test/robustness.test.ts > proxy auth middleware > rejects replayed nonce for the same agent
{"timestamp":"2026-03-27T15:45:51.175Z","level":"info","message":"request.completed","service":"proxy","requestId":"26b6ede7-1272-45c2-b5eb-872f70647481","method":"POST","path":"/protected","status":401,"durationMs":5}

 ✓ src/pairing-route.test/confirm.test.ts (6 tests) 120ms
stdout | src/auth-middleware.test/basic.test.ts > proxy auth middleware > keeps /health open without auth headers
{"timestamp":"2026-03-27T15:45:51.143Z","level":"info","message":"request.completed","service":"proxy","requestId":"2ffad70a-e1d5-454d-954c-81c7164846b7","method":"GET","path":"/health","status":200,"durationMs":11}

stdout | src/auth-middleware.test/rotation.test.ts > proxy auth middleware > refreshes keyset and accepts valid AIT after registry key rotation
{"timestamp":"2026-03-27T15:45:51.188Z","level":"info","message":"proxy.auth.verified","service":"proxy","agentDid":"did:cdi:registry.clawdentity.com:agent:01KMQZJ9YTAF1FYRK4Q9XEMBMH","ownerDid":"did:cdi:registry.clawdentity.com:human:01KMQZJ9Z4MAX2FPXQW2FXD5BB","jti":"01KMQZJ9ZE4B8YGHC76WG471D4"}

stdout | src/auth-middleware.test/rotation.test.ts > proxy auth middleware > refreshes keyset and accepts valid AIT after registry key rotation
{"timestamp":"2026-03-27T15:45:51.192Z","level":"info","message":"request.completed","service":"proxy","requestId":"bd3ca7a5-ee61-48f4-92c1-0833d62adbaa","method":"POST","path":"/protected","status":200,"durationMs":47}

stdout | src/auth-middleware.test/basic.test.ts > proxy auth middleware > verifies inbound auth and exposes auth context to downstream handlers
{"timestamp":"2026-03-27T15:45:51.204Z","level":"info","message":"proxy.auth.verified","service":"proxy","agentDid":"did:cdi:registry.clawdentity.com:agent:01KMQZJ9YQT18JYV5SRG07CKX2","ownerDid":"did:cdi:registry.clawdentity.com:human:01KMQZJ9Z1R0DFV85RN8XPQ5V2","jti":"01KMQZJ9ZBAYC13VPCEN9C4QQF"}

stdout | src/auth-middleware.test/basic.test.ts > proxy auth middleware > verifies inbound auth and exposes auth context to downstream handlers
{"timestamp":"2026-03-27T15:45:51.204Z","level":"info","message":"request.completed","service":"proxy","requestId":"cbfdad15-e196-43b8-bd57-178dcb8d7d44","method":"POST","path":"/protected","status":200,"durationMs":10}

stdout | src/auth-middleware.test/rotation.test.ts > proxy auth middleware > refreshes keyset and verifies CRL after registry CRL key rotation
{"timestamp":"2026-03-27T15:45:51.206Z","level":"info","message":"proxy.auth.verified","service":"proxy","agentDid":"did:cdi:registry.clawdentity.com:agent:01KMQZJ9YTE4HXP70JQSG0W244","ownerDid":"did:cdi:registry.clawdentity.com:human:01KMQZJ9Z4PPD6NXTSMB3NJQY5","jti":"01KMQZJ9ZE7XVF8156PKMHJEH2"}

stdout | src/auth-middleware.test/rotation.test.ts > proxy auth middleware > refreshes keyset and verifies CRL after registry CRL key rotation
{"timestamp":"2026-03-27T15:45:51.207Z","level":"info","message":"request.completed","service":"proxy","requestId":"4cbed8fc-2283-479c-8993-0bafb72567e9","method":"POST","path":"/protected","status":200,"durationMs":7}

 ✓ src/auth-middleware.test/rotation.test.ts (2 tests) 146ms
 ✓ src/agent-hook-route.test.ts (16 tests) 118ms
stdout | src/auth-middleware.test/basic.test.ts > proxy auth middleware > returns 403 when a verified caller is not trusted by agent DID
{"timestamp":"2026-03-27T15:45:51.219Z","level":"info","message":"request.completed","service":"proxy","requestId":"a029b238-7578-40fe-9172-36a0bd8729bc","method":"POST","path":"/protected","status":403,"durationMs":7}

stdout | src/auth-middleware.test/agent-access.test.ts > proxy auth middleware > rejects /hooks/agent when registry access-token validation fails
{"timestamp":"2026-03-27T15:45:51.229Z","level":"info","message":"request.completed","service":"proxy","requestId":"c1120c6a-52e2-4deb-979c-7813ead6a3cf","method":"POST","path":"/hooks/agent","status":401,"durationMs":56}

stdout | src/auth-middleware.test/basic.test.ts > proxy auth middleware > allows unknown agents to reach /pair/confirm for pairing bootstrap
{"timestamp":"2026-03-27T15:45:51.234Z","level":"info","message":"proxy.auth.verified","service":"proxy","agentDid":"did:cdi:registry.clawdentity.com:agent:01KMQZJ9YQ2GZCW31EKJNVWHZ4","ownerDid":"did:cdi:registry.clawdentity.com:human:01KMQZJ9Z1936KNSBZTYCYTPHM","jti":"01KMQZJ9ZBF2KZ1J3646T6H91C"}

stdout | src/auth-middleware.test/basic.test.ts > proxy auth middleware > allows unknown agents to reach /pair/confirm for pairing bootstrap
{"timestamp":"2026-03-27T15:45:51.234Z","level":"info","message":"request.completed","service":"proxy","requestId":"92712e7d-b546-42e5-a69a-dd86033a9a18","method":"POST","path":"/pair/confirm","status":400,"durationMs":8}

stdout | src/auth-middleware.test/agent-access.test.ts > proxy auth middleware > accepts /hooks/agent when x-claw-agent-access validates
{"timestamp":"2026-03-27T15:45:51.241Z","level":"info","message":"proxy.auth.verified","service":"proxy","agentDid":"did:cdi:registry.clawdentity.com:agent:01KMQZJ9YHG2JGGS5T3CNN96BA","ownerDid":"did:cdi:registry.clawdentity.com:human:01KMQZJ9YVVB2SD4TWCE2A3FDW","jti":"01KMQZJ9Z5DKPFRE98EF78D3GE"}

stdout | src/auth-middleware.test/agent-access.test.ts > proxy auth middleware > accepts /hooks/agent when x-claw-agent-access validates
{"timestamp":"2026-03-27T15:45:51.243Z","level":"info","message":"proxy.hooks.agent.delivered_to_relay","service":"proxy","requestId":"57d41b34-f8fe-4655-9d53-db992dbc4a25","senderAgentDid":"did:cdi:registry.clawdentity.com:agent:01KMQZJ9YHG2JGGS5T3CNN96BA","recipientAgentDid":"did:cdi:registry.clawdentity.com:agent:01KMQZJ9YHG2JGGS5T3CNN96BA","deliveryId":"57d41b34-f8fe-4655-9d53-db992dbc4a25","state":"delivered","delivered":true,"queued":false,"queueDepth":0,"connectedSockets":1,"sentAt":"2026-03-27T15:45:51.047Z"}

stdout | src/auth-middleware.test/agent-access.test.ts > proxy auth middleware > accepts /hooks/agent when x-claw-agent-access validates
{"timestamp":"2026-03-27T15:45:51.243Z","level":"info","message":"request.completed","service":"proxy","requestId":"57d41b34-f8fe-4655-9d53-db992dbc4a25","method":"POST","path":"/hooks/agent","status":202,"durationMs":9}

stdout | src/auth-middleware.test/basic.test.ts > proxy auth middleware > allows unknown agents to reach /pair/status for initiator polling bootstrap
{"timestamp":"2026-03-27T15:45:51.253Z","level":"info","message":"proxy.auth.verified","service":"proxy","agentDid":"did:cdi:registry.clawdentity.com:agent:01KMQZJ9YQQ5HQ7GHTKERN3JPZ","ownerDid":"did:cdi:registry.clawdentity.com:human:01KMQZJ9Z1YFA0NPR62BEKSB9M","jti":"01KMQZJ9ZBS859P28PRXM37KQX"}

stdout | src/auth-middleware.test/basic.test.ts > proxy auth middleware > allows unknown agents to reach /pair/status for initiator polling bootstrap
{"timestamp":"2026-03-27T15:45:51.254Z","level":"info","message":"request.completed","service":"proxy","requestId":"8664706f-f0b9-4a3d-8611-70edfaca3719","method":"POST","path":"/pair/status","status":400,"durationMs":10}

stdout | src/auth-middleware.test/agent-access.test.ts > proxy auth middleware > requires x-claw-agent-access for relay websocket connect
{"timestamp":"2026-03-27T15:45:51.255Z","level":"info","message":"request.completed","service":"proxy","requestId":"8b51c475-99a0-4885-b9f0-addeaf3b809b","method":"GET","path":"/v1/relay/connect","status":401,"durationMs":6}

stdout | src/auth-middleware.test/basic.test.ts > proxy auth middleware > rejects /pair/confirm without Authorization
{"timestamp":"2026-03-27T15:45:51.260Z","level":"info","message":"request.completed","service":"proxy","requestId":"f4e581e2-4405-4ad2-be9a-529c09a72e00","method":"POST","path":"/pair/confirm","status":401,"durationMs":1}

 ✓ src/auth-middleware.test/basic.test.ts (6 tests) 199ms
stdout | src/auth-middleware.test/robustness.test.ts > proxy auth middleware > rejects replayed nonce across app instances when durable nonce store is shared
{"timestamp":"2026-03-27T15:45:51.287Z","level":"info","message":"proxy.auth.verified","service":"proxy","agentDid":"did:cdi:registry.clawdentity.com:agent:01KMQZJ9YHE019YDSTZS4X16NT","ownerDid":"did:cdi:registry.clawdentity.com:human:01KMQZJ9YVDMB0F168V7NJ43F3","jti":"01KMQZJ9Z52JAEZWZSVHVTGCT1"}

stdout | src/auth-middleware.test/robustness.test.ts > proxy auth middleware > rejects replayed nonce across app instances when durable nonce store is shared
{"timestamp":"2026-03-27T15:45:51.287Z","level":"info","message":"request.completed","service":"proxy","requestId":"f6092ca5-bc02-4631-8f38-d328c1957f6a","method":"POST","path":"/protected","status":200,"durationMs":7}

stdout | src/auth-middleware.test/robustness.test.ts > proxy auth middleware > rejects replayed nonce across app instances when durable nonce store is shared
{"timestamp":"2026-03-27T15:45:51.293Z","level":"info","message":"request.completed","service":"proxy","requestId":"fa7be045-ce65-4e43-b7ac-1352ce72290e","method":"POST","path":"/protected","status":401,"durationMs":5}

stdout | src/auth-middleware.test/robustness.test.ts > proxy auth middleware > rejects requests outside the timestamp skew window
{"timestamp":"2026-03-27T15:45:51.346Z","level":"info","message":"request.completed","service":"proxy","requestId":"a7ac153d-70a9-4ecc-9075-73ed90da665c","method":"POST","path":"/protected","status":401,"durationMs":45}

stdout | src/auth-middleware.test/agent-access.test.ts > proxy auth middleware > accepts relay websocket connect when x-claw-agent-access validates
{"timestamp":"2026-03-27T15:45:51.355Z","level":"info","message":"proxy.auth.verified","service":"proxy","agentDid":"did:cdi:registry.clawdentity.com:agent:01KMQZJ9YHHMYR96VC85BRKMDA","ownerDid":"did:cdi:registry.clawdentity.com:human:01KMQZJ9YVR8J2XRF4A8X4WZS6","jti":"01KMQZJ9Z511ZKNVMDYWRYVEJN"}

stdout | src/auth-middleware.test/robustness.test.ts > proxy auth middleware > rejects malformed X-Claw-Timestamp header: 1774626351abc
{"timestamp":"2026-03-27T15:45:51.366Z","level":"info","message":"request.completed","service":"proxy","requestId":"04150d33-9453-49e6-abc6-afc89b13f418","method":"POST","path":"/protected","status":401,"durationMs":4}

stdout | src/auth-middleware.test/agent-access.test.ts > proxy auth middleware > accepts relay websocket connect when x-claw-agent-access validates
{"timestamp":"2026-03-27T15:45:51.367Z","level":"info","message":"proxy.relay.connect","service":"proxy","requestId":"24e1e8be-e672-4a30-b604-e6dc97003606","agentDid":"did:cdi:registry.clawdentity.com:agent:01KMQZJ9YHHMYR96VC85BRKMDA","status":204}

stdout | src/auth-middleware.test/agent-access.test.ts > proxy auth middleware > accepts relay websocket connect when x-claw-agent-access validates
{"timestamp":"2026-03-27T15:45:51.367Z","level":"info","message":"request.completed","service":"proxy","requestId":"24e1e8be-e672-4a30-b604-e6dc97003606","method":"GET","path":"/v1/relay/connect","status":204,"durationMs":105}

stdout | src/auth-middleware.test/robustness.test.ts > proxy auth middleware > rejects malformed X-Claw-Timestamp header: 1774626351.5
{"timestamp":"2026-03-27T15:45:51.374Z","level":"info","message":"request.completed","service":"proxy","requestId":"1224a39e-9f00-4266-9b70-30339c6ee17c","method":"POST","path":"/protected","status":401,"durationMs":2}

stdout | src/auth-middleware.test/robustness.test.ts > proxy auth middleware > rejects proof mismatches when body is tampered
{"timestamp":"2026-03-27T15:45:51.384Z","level":"info","message":"request.completed","service":"proxy","requestId":"ea585832-9918-4ca0-bbb2-9761b4fd1c1a","method":"POST","path":"/protected","status":401,"durationMs":5}

stdout | src/auth-middleware.test/robustness.test.ts > proxy auth middleware > rejects revoked AITs
{"timestamp":"2026-03-27T15:45:51.392Z","level":"info","message":"request.completed","service":"proxy","requestId":"7433999a-e58a-438f-885b-993863b3835f","method":"POST","path":"/protected","status":401,"durationMs":4}

stdout | src/auth-middleware.test/robustness.test.ts > proxy auth middleware > rejects expired AITs
{"timestamp":"2026-03-27T15:45:51.400Z","level":"info","message":"request.completed","service":"proxy","requestId":"bdf08f23-9f8f-4f22-ab98-bdaab65ea94d","method":"POST","path":"/protected","status":401,"durationMs":2}

stdout | src/auth-middleware.test/robustness.test.ts > proxy auth middleware > returns 503 when registry signing keys are unavailable
{"timestamp":"2026-03-27T15:45:51.405Z","level":"info","message":"request.completed","service":"proxy","requestId":"c55a27c5-f4d8-4000-956f-a43e22285947","method":"POST","path":"/protected","status":503,"durationMs":1}

stdout | src/auth-middleware.test/agent-access.test.ts > proxy auth middleware > allows unknown agents to connect relay websocket when auth validates
{"timestamp":"2026-03-27T15:45:51.407Z","level":"info","message":"proxy.auth.verified","service":"proxy","agentDid":"did:cdi:registry.clawdentity.com:agent:01KMQZJ9YHM1JAJ5RGW4QCB5T4","ownerDid":"did:cdi:registry.clawdentity.com:human:01KMQZJ9YVGWXQN3H90Q8H43XD","jti":"01KMQZJ9Z5BYS0DFT7Z3VE5AS3"}

stdout | src/auth-middleware.test/agent-access.test.ts > proxy auth middleware > allows unknown agents to connect relay websocket when auth validates
{"timestamp":"2026-03-27T15:45:51.407Z","level":"info","message":"proxy.relay.connect","service":"proxy","requestId":"b6688113-5d71-4dbe-b9ae-637fc8d278c5","agentDid":"did:cdi:registry.clawdentity.com:agent:01KMQZJ9YHM1JAJ5RGW4QCB5T4","status":204}

stdout | src/auth-middleware.test/agent-access.test.ts > proxy auth middleware > allows unknown agents to connect relay websocket when auth validates
{"timestamp":"2026-03-27T15:45:51.407Z","level":"info","message":"request.completed","service":"proxy","requestId":"b6688113-5d71-4dbe-b9ae-637fc8d278c5","method":"GET","path":"/v1/relay/connect","status":204,"durationMs":4}

 ✓ src/auth-middleware.test/agent-access.test.ts (6 tests) 352ms
stdout | src/auth-middleware.test/robustness.test.ts > proxy auth middleware > returns 503 when CRL is unavailable in fail-closed mode
{"timestamp":"2026-03-27T15:45:51.420Z","level":"info","message":"request.completed","service":"proxy","requestId":"7a4f96d3-5eda-4c73-9762-d787032ccea8","method":"POST","path":"/protected","status":503,"durationMs":6}

 ✓ src/auth-middleware.test/robustness.test.ts (12 tests) 365ms
 ✓ src/config.test.ts (21 tests) 18ms
 ✓ src/nonce-replay-guard.test.ts (5 tests) 96ms
 ✓ src/agent-rate-limit-middleware.test.ts (4 tests) 22ms
 ✓ src/agent-relay-session.connect.test.ts (6 tests) 37ms
 ✓ src/proxy-trust-store.test.ts (9 tests) 23ms
stdout | src/relay-delivery-receipt-route.test.ts > relay delivery receipt route > accepts POST receipt updates via direct DO only when ENVIRONMENT is explicitly local
{"timestamp":"2026-03-27T15:45:52.137Z","level":"info","message":"request.completed","service":"proxy","requestId":"996164fa-0d07-4c58-885b-4dcf100b38eb","method":"POST","path":"/v1/relay/delivery-receipts","status":202,"durationMs":15}

stdout | src/relay-delivery-receipt-route.test.ts > relay delivery receipt route > publishes receipt events to queue when RECEIPT_QUEUE binding is configured
{"timestamp":"2026-03-27T15:45:52.143Z","level":"info","message":"request.completed","service":"proxy","requestId":"41f19417-c2a2-46a6-860f-1f8d07ef47a3","method":"POST","path":"/v1/relay/delivery-receipts","status":202,"durationMs":0}

stdout | src/relay-delivery-receipt-route.test.ts > relay delivery receipt route > publishes dead_lettered receipt events to queue without direct DO writes
{"timestamp":"2026-03-27T15:45:52.144Z","level":"info","message":"request.completed","service":"proxy","requestId":"a0da95b9-6e5d-469d-a0f2-72d3d6b6b0af","method":"POST","path":"/v1/relay/delivery-receipts","status":202,"durationMs":0}

stdout | src/relay-delivery-receipt-route.test.ts > relay delivery receipt route > returns 503 when queue binding is missing outside local environment
{"timestamp":"2026-03-27T15:45:52.145Z","level":"info","message":"request.completed","service":"proxy","requestId":"5cba55c7-7abc-4c1c-bacf-fdf1eb982806","method":"POST","path":"/v1/relay/delivery-receipts","status":503,"durationMs":0}

stdout | src/relay-delivery-receipt-route.test.ts > relay delivery receipt route > returns 503 when queue binding is missing and ENVIRONMENT is not set
{"timestamp":"2026-03-27T15:45:52.146Z","level":"info","message":"request.completed","service":"proxy","requestId":"b20d2af3-232f-4392-9052-67d03a53bbb2","method":"POST","path":"/v1/relay/delivery-receipts","status":503,"durationMs":0}

stdout | src/relay-delivery-receipt-route.test.ts > relay delivery receipt route > rejects POST when recipient differs from authenticated agent DID
{"timestamp":"2026-03-27T15:45:52.149Z","level":"info","message":"request.completed","service":"proxy","requestId":"99f1d428-de89-47c4-8660-09f81c4f29ac","method":"POST","path":"/v1/relay/delivery-receipts","status":403,"durationMs":1}

stdout | src/relay-delivery-receipt-route.test.ts > relay delivery receipt route > rejects POST when requestId is whitespace only
{"timestamp":"2026-03-27T15:45:52.151Z","level":"info","message":"request.completed","service":"proxy","requestId":"0312e14a-f65b-4a18-affc-452b86bba730","method":"POST","path":"/v1/relay/delivery-receipts","status":400,"durationMs":0}

stdout | src/relay-delivery-receipt-route.test.ts > relay delivery receipt route > rejects POST when senderAgentDid is whitespace only
{"timestamp":"2026-03-27T15:45:52.153Z","level":"info","message":"request.completed","service":"proxy","requestId":"33f94576-9682-46dd-8fd2-08268ff728ae","method":"POST","path":"/v1/relay/delivery-receipts","status":400,"durationMs":0}

stdout | src/relay-delivery-receipt-route.test.ts > relay delivery receipt route > rejects POST when recipientAgentDid is whitespace only
{"timestamp":"2026-03-27T15:45:52.156Z","level":"info","message":"request.completed","service":"proxy","requestId":"67040677-2f05-4392-8a9d-ee97d8fab62b","method":"POST","path":"/v1/relay/delivery-receipts","status":400,"durationMs":1}

stdout | src/pairing-route.test/status.test.ts > POST /pair/status > returns pending status to initiator before ticket is confirmed
{"timestamp":"2026-03-27T15:45:52.163Z","level":"info","message":"proxy.pair.status","service":"proxy","requestId":"e765b6fa-4c28-4dcd-a610-d4f997d6e14d","status":"pending","initiatorAgentDid":"did:cdi:registry.clawdentity.com:agent:01HF7YAT00GKZ2WWFYNGYJSJ67","initiatorAgentName":"alpha","initiatorHumanName":"Ravi","expiresAt":"2023-11-14T22:28:20.000Z"}

stdout | src/pairing-route.test/status.test.ts > POST /pair/status > returns pending status to initiator before ticket is confirmed
{"timestamp":"2026-03-27T15:45:52.164Z","level":"info","message":"request.completed","service":"proxy","requestId":"e765b6fa-4c28-4dcd-a610-d4f997d6e14d","method":"POST","path":"/pair/status","status":200,"durationMs":5}

stdout | src/relay-delivery-receipt-route.test.ts > relay delivery receipt route > returns receipt on GET when trusted pair exists
{"timestamp":"2026-03-27T15:45:52.186Z","level":"info","message":"request.completed","service":"proxy","requestId":"41957b41-5a0d-46bb-a02c-ef9c1b0a275f","method":"GET","path":"/v1/relay/delivery-receipts","status":200,"durationMs":2}

stdout | src/relay-delivery-receipt-route.test.ts > relay delivery receipt route > returns 404 on GET when receipt is not found
{"timestamp":"2026-03-27T15:45:52.209Z","level":"info","message":"request.completed","service":"proxy","requestId":"66a88586-10e1-4045-b9d9-6d92ebf67cf3","method":"GET","path":"/v1/relay/delivery-receipts","status":404,"durationMs":5}

stdout | src/relay-delivery-receipt-route.test.ts > relay delivery receipt route > returns 502 on GET when relay receipt lookup RPC fails
{"timestamp":"2026-03-27T15:45:52.210Z","level":"info","message":"request.completed","service":"proxy","requestId":"27543db5-19f8-4433-877d-e839615202b3","method":"GET","path":"/v1/relay/delivery-receipts","status":502,"durationMs":1}

 ✓ src/relay-delivery-receipt-route.test.ts (12 tests) 97ms
stdout | src/server.test.ts > proxy server > returns health response with status, version, and environment
{"timestamp":"2026-03-27T15:45:52.233Z","level":"info","message":"request.completed","service":"proxy","requestId":"4f073f7b-4e7a-4b4e-8198-fd7907d6319c","method":"GET","path":"/health","status":200,"durationMs":23}

stdout | src/server.test.ts > proxy server > uses ENVIRONMENT from config for health payload
{"timestamp":"2026-03-27T15:45:52.245Z","level":"info","message":"request.completed","service":"proxy","requestId":"0190ceab-4266-4f0f-934b-d1b6b69244ff","method":"GET","path":"/health","status":200,"durationMs":0}

stdout | src/server.test.ts > proxy server > uses provided app version when supplied by runtime
{"timestamp":"2026-03-27T15:45:52.246Z","level":"info","message":"request.completed","service":"proxy","requestId":"6895f167-e7d5-4408-a64e-5af1ab940143","method":"GET","path":"/health","status":200,"durationMs":0}

stdout | src/pairing-route.test/status.test.ts > POST /pair/status > returns confirmed status to initiator after responder confirms ticket
{"timestamp":"2026-03-27T15:45:52.254Z","level":"info","message":"proxy.pair.status","service":"proxy","requestId":"d2629873-989b-4a96-bad0-2b3a26d2059e","status":"confirmed","initiatorAgentDid":"did:cdi:registry.clawdentity.com:agent:01HF7YAT00GKZ2WWFYNGYJSJ67","initiatorAgentName":"alpha","initiatorHumanName":"Ravi","responderAgentDid":"did:cdi:registry.clawdentity.com:agent:01HF7YAT34PPYB8ZDATWYYRXDM","responderAgentName":"beta","responderHumanName":"Ira","expiresAt":"2023-11-14T22:28:20.000Z","confirmedAt":"2023-11-14T22:13:20.000Z"}

stdout | src/pairing-route.test/status.test.ts > POST /pair/status > returns confirmed status to initiator after responder confirms ticket
{"timestamp":"2026-03-27T15:45:52.254Z","level":"info","message":"request.completed","service":"proxy","requestId":"d2629873-989b-4a96-bad0-2b3a26d2059e","method":"POST","path":"/pair/status","status":200,"durationMs":0}

stdout | src/server.test.ts > proxy server > returns 429 for repeated unauthenticated probes on /hooks/agent from same IP
{"timestamp":"2026-03-27T15:45:52.256Z","level":"info","message":"request.completed","service":"proxy","requestId":"35b9a44c-868a-4fc6-acc7-6f3a6801cf37","method":"POST","path":"/hooks/agent","status":401,"durationMs":0}

stdout | src/server.test.ts > proxy server > returns 429 for repeated unauthenticated probes on /hooks/agent from same IP
{"timestamp":"2026-03-27T15:45:52.259Z","level":"info","message":"request.completed","service":"proxy","requestId":"e3f0ff4e-537a-45a9-af11-87ef512bd2d8","method":"POST","path":"/hooks/agent","status":401,"durationMs":1}

stdout | src/server.test.ts > proxy server > returns 429 for repeated unauthenticated probes on /hooks/agent from same IP
{"timestamp":"2026-03-27T15:45:52.262Z","level":"info","message":"request.completed","service":"proxy","requestId":"ce1ca86d-ef03-4bc3-adbc-61e103939be1","method":"POST","path":"/hooks/agent","status":429,"durationMs":2}

stdout | src/server.test.ts > proxy server > returns 429 for repeated unauthenticated probes on relay connect from same IP
{"timestamp":"2026-03-27T15:45:52.265Z","level":"info","message":"request.completed","service":"proxy","requestId":"0e884573-c0e1-41f7-866a-7486df948d61","method":"GET","path":"/v1/relay/connect","status":401,"durationMs":1}

stdout | src/server.test.ts > proxy server > returns 429 for repeated unauthenticated probes on relay connect from same IP
{"timestamp":"2026-03-27T15:45:52.269Z","level":"info","message":"request.completed","service":"proxy","requestId":"fc40611b-34ac-4aab-a6b3-9e404679b037","method":"GET","path":"/v1/relay/connect","status":401,"durationMs":4}

stdout | src/server.test.ts > proxy server > returns 429 for repeated unauthenticated probes on relay connect from same IP
{"timestamp":"2026-03-27T15:45:52.270Z","level":"info","message":"request.completed","service":"proxy","requestId":"17b5acfc-786a-45ad-8a9d-75045de8b182","method":"GET","path":"/v1/relay/connect","status":429,"durationMs":0}

stdout | src/pairing-route.test/status.test.ts > POST /pair/status > rejects status lookups from non-participant agents
{"timestamp":"2026-03-27T15:45:52.278Z","level":"info","message":"request.completed","service":"proxy","requestId":"fb979eb4-3588-4e3f-80d1-01fdd75cf246","method":"POST","path":"/pair/status","status":403,"durationMs":1}

 ✓ src/pairing-route.test/status.test.ts (3 tests) 134ms
 ✓ src/server.test.ts (10 tests) 76ms
stdout | src/worker.test.ts > proxy worker > serves /health with parsed runtime config from bindings
{"timestamp":"2026-03-27T15:45:52.326Z","level":"info","message":"request.completed","service":"proxy","requestId":"dd60435a-cdd8-4782-b02a-78939750e293","method":"GET","path":"/health","status":200,"durationMs":1}

 ✓ src/index.test.ts (7 tests) 17ms
stdout | src/worker.test.ts > proxy worker > allows local startup without trust DO binding
{"timestamp":"2026-03-27T15:45:52.337Z","level":"info","message":"request.completed","service":"proxy","requestId":"d0690ae4-41a9-490f-b47b-e7db26c741b6","method":"GET","path":"/health","status":200,"durationMs":0}

stdout | src/worker.test.ts > proxy worker > allows development startup when trust DO binding exists
{"timestamp":"2026-03-27T15:45:52.339Z","level":"info","message":"request.completed","service":"proxy","requestId":"2d57682a-d373-4c41-87e6-4f4df23a240d","method":"GET","path":"/health","status":200,"durationMs":0}

 ✓ src/worker.test.ts (13 tests) 34ms
 ✓ src/agent-relay-session.rpc.test.ts (2 tests) 10ms
stdout | src/relay-connect-route.test.ts > GET /v1/relay/connect > forwards websocket connect requests to DO session keyed by authenticated connector DID
{"timestamp":"2026-03-27T15:45:52.427Z","level":"info","message":"proxy.relay.connect","service":"proxy","requestId":"c00d3fd0-2c94-4b91-a843-6074f66d191a","agentDid":"did:cdi:registry.clawdentity.dev:agent:01HF7YAT7NQWWJ9ZXM8P9J8H4C","status":204}

stdout | src/relay-connect-route.test.ts > GET /v1/relay/connect > forwards websocket connect requests to DO session keyed by authenticated connector DID
{"timestamp":"2026-03-27T15:45:52.428Z","level":"info","message":"request.completed","service":"proxy","requestId":"c00d3fd0-2c94-4b91-a843-6074f66d191a","method":"GET","path":"/v1/relay/connect","status":204,"durationMs":1}

stdout | src/relay-connect-route.test.ts > GET /v1/relay/connect > requires websocket upgrade header
{"timestamp":"2026-03-27T15:45:52.431Z","level":"info","message":"request.completed","service":"proxy","requestId":"e5c0599a-60a5-4330-9e3f-7c1f4f6e0c44","method":"GET","path":"/v1/relay/connect","status":426,"durationMs":1}

stdout | src/relay-connect-route.test.ts > GET /v1/relay/connect > returns 503 when relay session namespace is unavailable
{"timestamp":"2026-03-27T15:45:52.434Z","level":"info","message":"request.completed","service":"proxy","requestId":"b00ed893-e8b7-4a9e-9091-3487a1600aef","method":"GET","path":"/v1/relay/connect","status":503,"durationMs":1}

 ✓ src/relay-connect-route.test.ts (3 tests) 13ms
 ✓ src/queue-consumer/receipt-events.test.ts (3 tests) 4ms

 Test Files  23 passed (23)
      Tests  177 passed (177)
   Start at  21:15:48
   Duration  4.00s (transform 10.52s, setup 0ms, import 25.99s, tests 2.28s, environment 23ms)\n- 
> @clawdentity/sdk@0.0.0 typecheck /Users/dev/Workdir/clawdentity/packages/sdk
> tsc --noEmit\n- 
> @clawdentity/proxy@0.0.0 typecheck /Users/dev/Workdir/clawdentity/apps/proxy
> tsc --noEmit\n- 
> @clawdentity/sdk@0.0.0 lint /Users/dev/Workdir/clawdentity/packages/sdk
> biome lint .

Checked 45 files in 22ms. No fixes applied.\n- 
> @clawdentity/proxy@0.0.0 lint /Users/dev/Workdir/clawdentity/apps/proxy
> biome lint .

Checked 91 files in 19ms. No fixes applied.\n\nFixes #114