### PR TITLE
feat(openclaw): route inbound /hooks/agent payloads using configured openclawAgentId

### DIFF
--- a/apps/landing/src/content/AGENTS.md
+++ b/apps/landing/src/content/AGENTS.md
@@ -8,6 +8,8 @@
 - `/getting-started/github/` is the hosted prompt surface. Keep prompt generation there, driven by the GitHub redirect payload.
 - `/skill.md` remains the canonical skill artifact for private, self-hosted, operator, or advanced/manual paths. Label those paths clearly so they are not confused with hosted onboarding.
 - CLI docs must match the actual Rust binary help output. Re-check flags and subcommands before changing docs, especially `install --for`, `provider *`, and `pair *`.
+- Connector docs must keep `/hooks/wake` as the default inbound path unless runtime defaults change in Rust; if `/hooks/agent` is documented, call out that it is explicit/opt-in.
+- OpenClaw setup docs must describe `--openclaw-agent-id` routing behavior accurately: mapping persists in connector assignment state, applies to `/hooks/agent`, and does not change `/hooks/wake` defaults.
 - When starter-pass behavior changes, update both user-facing docs and the landing copy in the same change.
 - Keep proxy docs aligned with runtime identity transport: header-first by default, body injection only as an explicit legacy opt-in.
 - SDK docs that mention HTTP proof verification must state that timestamp freshness is enforced by default and should recommend the replay-protected one-call verifier for nonce enforcement.

--- a/apps/landing/src/content/docs/api-reference/cli.mdx
+++ b/apps/landing/src/content/docs/api-reference/cli.mdx
@@ -202,6 +202,7 @@ Configures provider runtime integration (paths, webhook settings, connector opti
 clawdentity provider setup \
   --for <platform> \
   [--agent-name <name>] \
+  [--openclaw-agent-id <id>] \
   [--platform-base-url <url>] \
   [--webhook-host <host>] \
   [--webhook-port <port>] \
@@ -211,6 +212,10 @@ clawdentity provider setup \
   [--relay-transform-peers-path <path>] \
   [--json]
 ```
+
+OpenClaw-specific setup options:
+- `--openclaw-agent-id <id>` — target OpenClaw agent ID used for connector delivery when you run with `/hooks/agent`; defaults to `main` and is validated against OpenClaw config during setup
+- Default delivery still targets `/hooks/wake`; the `openclawAgentId` mapping is dormant until you explicitly run the connector with `--openclaw-hook-path /hooks/agent` (or `OPENCLAW_HOOK_PATH=/hooks/agent`)
 
 ### `provider doctor`
 
@@ -293,7 +298,7 @@ clawdentity connector start <agentName> \
 Options:
 - `--proxy-ws-url <url>` — proxy websocket URL (or `CLAWDENTITY_PROXY_WS_URL` env)
 - `--openclaw-base-url <url>` — OpenClaw base URL (default `OPENCLAW_BASE_URL` env or `http://127.0.0.1:18789`)
-- `--openclaw-hook-path <path>` — OpenClaw hooks path (default `OPENCLAW_HOOK_PATH` env or `/hooks/agent`)
+- `--openclaw-hook-path <path>` — OpenClaw hooks path (default `OPENCLAW_HOOK_PATH` env or `/hooks/wake`)
 - `--openclaw-hook-token <token>` — OpenClaw hooks token (default `OPENCLAW_HOOK_TOKEN` env)
 
 ### `connector service install`

--- a/apps/landing/src/content/docs/guides/connector.mdx
+++ b/apps/landing/src/content/docs/guides/connector.mdx
@@ -20,7 +20,7 @@ agent: Agent Machine {
     style.fill: "#f8e8f8"
     label: |md
       **OpenClaw**
-      /hooks/agent
+      /hooks/wake (default)
     |
   }
 
@@ -106,6 +106,12 @@ Messages arrive through a durable inbox model that ensures reliable delivery:
 5. Non-retryable failure after 5 attempts → move to dead-letter queue, send receipt (`dead_lettered`)
 
 The optional `x-openclaw-token` header is included when configured, authenticating the connector to OpenClaw.
+
+Hook routing behavior:
+
+- Default mode targets `/hooks/wake` and keeps wake-style payloads (`text` + `message`) for visible chat delivery.
+- If you explicitly set `/hooks/agent` (`--openclaw-hook-path /hooks/agent` or `OPENCLAW_HOOK_PATH=/hooks/agent`), the connector sends agent-hook payloads and injects `agentId` only when `provider setup --for openclaw` has persisted an `openclawAgentId` mapping for the active Clawdentity agent.
+- If no mapping exists, `/hooks/agent` payloads remain backward-compatible and omit `agentId`.
 
 ## Inbound inbox
 
@@ -275,7 +281,7 @@ The connector manages its own access token lifecycle:
 | `CLAWDENTITY_CONNECTOR_BASE_URL` | `http://127.0.0.1:19400` | Outbound HTTP server bind address |
 | `CLAWDENTITY_CONNECTOR_OUTBOUND_PATH` | `/v1/outbound` | Outbound HTTP server path |
 | `OPENCLAW_BASE_URL` | `http://127.0.0.1:18789` | Local OpenClaw base URL |
-| `OPENCLAW_HOOK_PATH` | `/hooks/agent` | OpenClaw hook delivery path |
+| `OPENCLAW_HOOK_PATH` | `/hooks/wake` | OpenClaw hook delivery path (`/hooks/agent` enables isolated agent-hook routing) |
 | `OPENCLAW_HOOK_TOKEN` | — | Optional OpenClaw hook auth token |
 
 ### Connector constants

--- a/apps/landing/src/content/docs/guides/openclaw-skill.mdx
+++ b/apps/landing/src/content/docs/guides/openclaw-skill.mdx
@@ -105,9 +105,9 @@ After installing the skill, set up the agent for peer communication:
 
 3. **Set up OpenClaw integration**:
    ```bash
-   clawdentity provider setup --for openclaw --agent-name my-agent
+   clawdentity provider setup --for openclaw --agent-name my-agent [--openclaw-agent-id <openclawAgentId>]
    ```
-   This provisions the connector runtime, wires hooks, stabilizes gateway auth, and runs readiness checks.
+   This provisions the connector runtime, wires hooks, stabilizes gateway auth, and runs readiness checks. If `--openclaw-agent-id` is omitted, setup persists `main` as the default routed OpenClaw agent ID.
 
 4. **Run diagnostics** to verify everything is healthy:
    ```bash
@@ -193,6 +193,24 @@ After `provider setup --for openclaw`, the relay runtime config is stored at `~/
 ```
 
 `openclawBaseUrl` is the local OpenClaw gateway URL, not the Clawdentity registry or proxy URL. In the normal local OpenClaw flow this should stay at `http://127.0.0.1:18789` unless the operator intentionally moved the OpenClaw gateway elsewhere.
+
+### Connector assignment state
+
+Provider setup also persists per-agent connector assignment state in `~/.clawdentity/openclaw-connectors.json`:
+
+```json
+{
+  "agents": {
+    "my-agent": {
+      "connectorBaseUrl": "http://127.0.0.1:19400/",
+      "openclawAgentId": "main",
+      "updatedAt": "2025-01-01T00:00:00.000Z"
+    }
+  }
+}
+```
+
+`openclawAgentId` is used only for `/hooks/agent` delivery. Default `/hooks/wake` behavior remains unchanged.
 
 ## Provider doctor
 

--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -309,6 +309,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "wiremock",
 ]
 
 [[package]]

--- a/crates/clawdentity-cli/Cargo.toml
+++ b/crates/clawdentity-cli/Cargo.toml
@@ -18,3 +18,6 @@ serde_json.workspace = true
 tokio = { version = "1.49.0", features = ["macros", "rt-multi-thread", "signal"] }
 tracing.workspace = true
 tracing-subscriber.workspace = true
+
+[dev-dependencies]
+wiremock = "0.6.5"

--- a/crates/clawdentity-cli/src/commands/AGENTS.md
+++ b/crates/clawdentity-cli/src/commands/AGENTS.md
@@ -11,6 +11,8 @@
 - Connector -> OpenClaw hook payloads must send top-level `message`; keep `content` only as a compatibility alias, never as the sole field, and mirror user-visible wake text into `message` when targeting `/hooks/wake`.
 - Connector receipt notifications must also satisfy OpenClaw hook contracts: `/hooks/agent` needs `message`, `/hooks/wake` needs `text`, with structured receipt metadata preserved alongside the summary text.
 - OpenClaw peer-delivery defaults must stay aligned with visible UX: `/hooks/wake` for inbound relay traffic, with sender context rendered into `text`; reserve `/hooks/agent` for explicit isolated-hook workflows.
+- Keep `provider setup --for openclaw --openclaw-agent-id <id>` wired end-to-end into core setup options; default mapping remains `main` when omitted.
+- OpenClaw agent routing is opt-in behavior tied to `/hooks/agent`; CLI defaults and docs must continue treating `/hooks/wake` as the default inbound hook path.
 - Connector inbound failure handling must not leave stale `inbound_pending` rows forever: successful redelivery must clear pending state, and retry/backoff must either reschedule or dead-letter exhausted items.
 - If inbound delivery fails but the connector successfully persists the frame for local retry, ACK the relay as accepted so only one retry path exists.
 - Wake payloads must not force `sessionId: "main"`; only send `sessionId` when the inbound payload explicitly carries one so OpenClaw's configured default session stays in control.

--- a/crates/clawdentity-cli/src/commands/connector.rs
+++ b/crates/clawdentity-cli/src/commands/connector.rs
@@ -34,7 +34,7 @@ use receipts::{ReceiptDispatchRuntime, ReceiptOutboxHandle, start_receipt_outbox
 #[cfg(test)]
 use delivery::{
     build_deliver_ack_reason, build_openclaw_hook_payload, build_openclaw_receipt_payload,
-    should_dead_letter_after_failure,
+    forward_deliver_to_openclaw, should_dead_letter_after_failure,
 };
 #[cfg(test)]
 use headers::{SenderProfileHeaders, build_openclaw_delivery_headers};

--- a/crates/clawdentity-cli/src/commands/connector/AGENTS.md
+++ b/crates/clawdentity-cli/src/commands/connector/AGENTS.md
@@ -9,6 +9,7 @@
 - Wake payloads must only include `sessionId` when the inbound payload explicitly carries one.
 - `/hooks/wake` remains the visible default for peer delivery; `/hooks/agent` is only for explicit isolated-hook routing.
 - Inject `agentId` into OpenClaw payloads only when delivering to `/hooks/agent` and a non-empty mapped `openclawAgentId` exists for the active Clawdentity agent.
+- Keep `/hooks/agent` routing symmetric for deliveries and receipts: when a mapped `openclawAgentId` exists, both payload types must include `agentId`.
 - Never inject `agentId` for `/hooks/wake`; wake-mode payload shape must stay stable for backward compatibility and visible chat delivery.
 - Runtime config resolution for OpenClaw routing must read per-agent `openclawAgentId` from connector assignment state and gracefully return `None` when mapping data is absent.
 - Keep hook payload builders split into focused helpers so the structural 50-line non-test function rule stays green.

--- a/crates/clawdentity-cli/src/commands/connector/AGENTS.md
+++ b/crates/clawdentity-cli/src/commands/connector/AGENTS.md
@@ -8,6 +8,9 @@
 - If inbound delivery is persisted for local retry, ACK the relay as accepted so the retry path stays single-source.
 - Wake payloads must only include `sessionId` when the inbound payload explicitly carries one.
 - `/hooks/wake` remains the visible default for peer delivery; `/hooks/agent` is only for explicit isolated-hook routing.
+- Inject `agentId` into OpenClaw payloads only when delivering to `/hooks/agent` and a non-empty mapped `openclawAgentId` exists for the active Clawdentity agent.
+- Never inject `agentId` for `/hooks/wake`; wake-mode payload shape must stay stable for backward compatibility and visible chat delivery.
+- Runtime config resolution for OpenClaw routing must read per-agent `openclawAgentId` from connector assignment state and gracefully return `None` when mapping data is absent.
 - Keep hook payload builders split into focused helpers so the structural 50-line non-test function rule stays green.
 - Inbound OpenClaw hook requests must keep canonical identity headers (`x-clawdentity-agent-did`, `x-clawdentity-to-agent-did`, `x-clawdentity-verified`, `x-request-id`) and only add sender profile headers (`x-clawdentity-agent-name`, `x-clawdentity-human-name`) when local peer metadata exists.
 - Keep sender-profile DID lookup and header shaping in focused helpers/modules instead of expanding `delivery.rs`.

--- a/crates/clawdentity-cli/src/commands/connector/delivery.rs
+++ b/crates/clawdentity-cli/src/commands/connector/delivery.rs
@@ -444,7 +444,7 @@ pub(super) fn build_deliver_ack_reason(
     }
 }
 
-async fn forward_deliver_to_openclaw(
+pub(super) async fn forward_deliver_to_openclaw(
     http_client: &reqwest::Client,
     hook_url: &str,
     openclaw_runtime: &OpenclawRuntimeConfig,
@@ -496,6 +496,7 @@ async fn forward_receipt_to_openclaw(
         .json(&build_openclaw_receipt_payload(
             &openclaw_runtime.hook_path,
             receipt,
+            openclaw_runtime.target_agent_id.as_deref(),
         ));
 
     if let Some(token) = openclaw_runtime

--- a/crates/clawdentity-cli/src/commands/connector/delivery.rs
+++ b/crates/clawdentity-cli/src/commands/connector/delivery.rs
@@ -456,6 +456,7 @@ async fn forward_deliver_to_openclaw(
         .json(&build_openclaw_hook_payload(
             &openclaw_runtime.hook_path,
             deliver,
+            openclaw_runtime.target_agent_id.as_deref(),
         ));
 
     for (name, value) in build_openclaw_delivery_headers(

--- a/crates/clawdentity-cli/src/commands/connector/delivery/openclaw_payload.rs
+++ b/crates/clawdentity-cli/src/commands/connector/delivery/openclaw_payload.rs
@@ -3,12 +3,16 @@ use serde_json::{Value, json};
 
 use super::super::normalize_hook_path;
 
-pub(crate) fn build_openclaw_hook_payload(hook_path: &str, deliver: &DeliverFrame) -> Value {
+pub(crate) fn build_openclaw_hook_payload(
+    hook_path: &str,
+    deliver: &DeliverFrame,
+    openclaw_target_agent_id: Option<&str>,
+) -> Value {
     if normalize_hook_path(hook_path) == "/hooks/wake" {
         return build_openclaw_wake_payload(deliver);
     }
 
-    build_openclaw_agent_payload(deliver)
+    build_openclaw_agent_payload(deliver, openclaw_target_agent_id)
 }
 
 pub(crate) fn build_openclaw_receipt_payload(hook_path: &str, receipt: &ReceiptFrame) -> Value {
@@ -92,9 +96,12 @@ fn render_receipt_summary(receipt: &ReceiptFrame) -> String {
     lines.join("\n")
 }
 
-fn build_openclaw_agent_payload(deliver: &DeliverFrame) -> Value {
+fn build_openclaw_agent_payload(
+    deliver: &DeliverFrame,
+    openclaw_target_agent_id: Option<&str>,
+) -> Value {
     let message = extract_content(&deliver.payload);
-    json!({
+    let mut payload = json!({
         "message": message,
         "content": message,
         "senderDid": deliver.from_agent_did,
@@ -105,7 +112,14 @@ fn build_openclaw_agent_payload(deliver: &DeliverFrame) -> Value {
             "replyTo": deliver.reply_to,
             "payload": deliver.payload,
         },
-    })
+    });
+    if let Some(agent_id) = openclaw_target_agent_id
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        payload["agentId"] = Value::String(agent_id.to_string());
+    }
+    payload
 }
 
 fn build_openclaw_wake_payload(deliver: &DeliverFrame) -> Value {

--- a/crates/clawdentity-cli/src/commands/connector/delivery/openclaw_payload.rs
+++ b/crates/clawdentity-cli/src/commands/connector/delivery/openclaw_payload.rs
@@ -15,7 +15,11 @@ pub(crate) fn build_openclaw_hook_payload(
     build_openclaw_agent_payload(deliver, openclaw_target_agent_id)
 }
 
-pub(crate) fn build_openclaw_receipt_payload(hook_path: &str, receipt: &ReceiptFrame) -> Value {
+pub(crate) fn build_openclaw_receipt_payload(
+    hook_path: &str,
+    receipt: &ReceiptFrame,
+    openclaw_target_agent_id: Option<&str>,
+) -> Value {
     let summary = render_receipt_summary(receipt);
     let status = receipt_status_str(&receipt.status);
     let receipt_json = build_openclaw_receipt_metadata(receipt);
@@ -37,7 +41,7 @@ pub(crate) fn build_openclaw_receipt_payload(hook_path: &str, receipt: &ReceiptF
         });
     }
 
-    json!({
+    let mut payload = json!({
         "type": "clawdentity:receipt",
         "originalFrameId": receipt.original_frame_id,
         "toAgentDid": receipt.to_agent_did,
@@ -49,7 +53,14 @@ pub(crate) fn build_openclaw_receipt_payload(hook_path: &str, receipt: &ReceiptF
         "metadata": {
             "receipt": receipt_json,
         },
-    })
+    });
+    if let Some(agent_id) = openclaw_target_agent_id
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        payload["agentId"] = Value::String(agent_id.to_string());
+    }
+    payload
 }
 
 fn build_openclaw_receipt_metadata(receipt: &ReceiptFrame) -> Value {

--- a/crates/clawdentity-cli/src/commands/connector/runtime_config.rs
+++ b/crates/clawdentity-cli/src/commands/connector/runtime_config.rs
@@ -9,7 +9,8 @@ use clawdentity_core::config::{ConfigPathOptions, get_config_dir, resolve_config
 use clawdentity_core::constants::{AGENTS_DIR, AIT_FILE_NAME, SECRET_KEY_FILE_NAME};
 use clawdentity_core::{
     SignHttpRequestInput, build_relay_connect_headers, fetch_registry_metadata, new_frame_id,
-    refresh_agent_auth, resolve_openclaw_base_url, resolve_openclaw_hook_token, sign_http_request,
+    load_connector_assignments, refresh_agent_auth, resolve_openclaw_base_url,
+    resolve_openclaw_hook_token, sign_http_request,
 };
 
 use super::{ConnectorRuntimeConfig, StartConnectorInput, env_trimmed, normalize_hook_path};
@@ -41,6 +42,8 @@ pub(super) async fn resolve_runtime_config(
     .await?;
     let proxy_receipt_url = resolve_proxy_receipt_url(&proxy_ws_url)?;
     let config_dir = runtime_inputs.config_dir.clone();
+    let target_agent_id =
+        resolve_openclaw_target_agent_id(&runtime_inputs.config_dir, &input.agent_name)?;
 
     Ok(ConnectorRuntimeConfig {
         agent_name: input.agent_name,
@@ -58,10 +61,25 @@ pub(super) async fn resolve_runtime_config(
                 &runtime_inputs.config_dir,
                 input.openclaw_hook_token.as_deref(),
             )?,
+            target_agent_id,
         },
         port: input.port,
         bind: input.bind,
     })
+}
+
+pub(super) fn resolve_openclaw_target_agent_id(
+    config_dir: &Path,
+    agent_name: &str,
+) -> Result<Option<String>> {
+    let assignments = load_connector_assignments(config_dir)?;
+    Ok(assignments
+        .agents
+        .get(agent_name)
+        .and_then(|assignment| assignment.openclaw_agent_id.as_deref())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned))
 }
 
 pub(super) fn load_connector_headers(

--- a/crates/clawdentity-cli/src/commands/connector/tests.rs
+++ b/crates/clawdentity-cli/src/commands/connector/tests.rs
@@ -3,6 +3,7 @@ use chrono::{Duration as ChronoDuration, Utc};
 use clawdentity_core::agent::AgentAuthRecord;
 use clawdentity_core::config::{CliConfig, ConfigPathOptions, get_config_dir, write_config};
 use clawdentity_core::constants::{AGENTS_DIR, AIT_FILE_NAME, SECRET_KEY_FILE_NAME};
+use clawdentity_core::runtime_openclaw::OpenclawRuntimeConfig;
 use clawdentity_core::{DeliverFrame, ReceiptFrame, ReceiptStatus};
 use serde_json::json;
 use std::collections::HashMap;
@@ -16,9 +17,11 @@ use super::runtime_config::{
 };
 use super::{
     SenderProfileHeaders, build_deliver_ack_reason, build_openclaw_delivery_headers,
-    build_openclaw_hook_payload, build_openclaw_receipt_payload, normalize_hook_path,
-    should_dead_letter_after_failure,
+    build_openclaw_hook_payload, build_openclaw_receipt_payload, forward_deliver_to_openclaw,
+    normalize_hook_path, should_dead_letter_after_failure,
 };
+use wiremock::matchers::{body_json, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
 
 #[test]
 fn normalizes_hook_path_with_leading_slash() {
@@ -394,7 +397,7 @@ fn openclaw_receipt_payload_uses_message_field_for_agent_hooks() {
         reason: Some("hook failed".to_string()),
     };
 
-    let payload = build_openclaw_receipt_payload("/hooks/agent", &receipt);
+    let payload = build_openclaw_receipt_payload("/hooks/agent", &receipt, Some("coder"));
     assert_eq!(
         payload.get("type").and_then(|value| value.as_str()),
         Some("clawdentity:receipt")
@@ -415,6 +418,26 @@ fn openclaw_receipt_payload_uses_message_field_for_agent_hooks() {
             .and_then(|value| value.as_str()),
         Some("dead_lettered")
     );
+    assert_eq!(
+        payload.get("agentId").and_then(|value| value.as_str()),
+        Some("coder")
+    );
+}
+
+#[test]
+fn openclaw_receipt_payload_omits_agent_id_when_mapping_missing() {
+    let receipt = ReceiptFrame {
+        v: 1,
+        id: "receipt-1b".to_string(),
+        ts: "2026-03-20T05:55:00Z".to_string(),
+        original_frame_id: "req-6b".to_string(),
+        to_agent_did: "did:cdi:test:agent:recipient".to_string(),
+        status: ReceiptStatus::DeadLettered,
+        reason: Some("hook failed".to_string()),
+    };
+
+    let payload = build_openclaw_receipt_payload("/hooks/agent", &receipt, None);
+    assert!(payload.get("agentId").is_none());
 }
 
 #[test]
@@ -429,7 +452,7 @@ fn openclaw_receipt_payload_uses_text_for_wake_hooks() {
         reason: None,
     };
 
-    let payload = build_openclaw_receipt_payload("/hooks/wake", &receipt);
+    let payload = build_openclaw_receipt_payload("/hooks/wake", &receipt, Some("coder"));
     assert_eq!(
         payload.get("status").and_then(|value| value.as_str()),
         Some("processed_by_openclaw")
@@ -450,6 +473,57 @@ fn openclaw_receipt_payload_uses_text_for_wake_hooks() {
             .and_then(|value| value.as_str()),
         Some("processed_by_openclaw")
     );
+    assert!(payload.get("agentId").is_none());
+}
+
+#[tokio::test]
+async fn forward_delivery_posts_agent_id_for_agent_hook_path() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/hooks/agent"))
+        .and(body_json(json!({
+            "message": "hello over relay",
+            "content": "hello over relay",
+            "senderDid": "did:cdi:test:agent:sender",
+            "recipientDid": "did:cdi:test:agent:recipient",
+            "requestId": "req-e2e-1",
+            "agentId": "coder",
+            "metadata": {
+                "conversationId": serde_json::Value::Null,
+                "replyTo": serde_json::Value::Null,
+                "payload": {
+                    "message": "hello over relay"
+                }
+            }
+        })))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let runtime = OpenclawRuntimeConfig {
+        base_url: server.uri(),
+        hook_path: "/hooks/agent".to_string(),
+        hook_token: None,
+        target_agent_id: Some("coder".to_string()),
+    };
+    let deliver = DeliverFrame {
+        v: 1,
+        id: "req-e2e-1".to_string(),
+        ts: "2026-03-20T05:55:00Z".to_string(),
+        from_agent_did: "did:cdi:test:agent:sender".to_string(),
+        to_agent_did: "did:cdi:test:agent:recipient".to_string(),
+        payload: json!({ "message": "hello over relay" }),
+        content_type: Some("application/json".to_string()),
+        conversation_id: None,
+        reply_to: None,
+    };
+    let hook_url = runtime.hook_url().expect("hook url");
+    let client = reqwest::Client::new();
+
+    forward_deliver_to_openclaw(&client, &hook_url, &runtime, &deliver, None)
+        .await
+        .expect("forward delivery should succeed");
 }
 
 #[test]

--- a/crates/clawdentity-cli/src/commands/connector/tests.rs
+++ b/crates/clawdentity-cli/src/commands/connector/tests.rs
@@ -12,6 +12,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use super::runtime_config::{
     agent_access_requires_refresh, load_receipt_post_headers, normalize_proxy_ws_url,
+    resolve_openclaw_target_agent_id,
 };
 use super::{
     SenderProfileHeaders, build_deliver_ack_reason, build_openclaw_delivery_headers,
@@ -175,7 +176,7 @@ fn openclaw_hook_payload_uses_message_field() {
         reply_to: Some("reply-1".to_string()),
     };
 
-    let payload = build_openclaw_hook_payload("/hooks/agent", &deliver);
+    let payload = build_openclaw_hook_payload("/hooks/agent", &deliver, None);
     assert_eq!(
         payload.get("message").and_then(|value| value.as_str()),
         Some("hello from alpha")
@@ -209,11 +210,55 @@ fn openclaw_hook_payload_stringifies_non_string_payloads() {
         reply_to: None,
     };
 
-    let payload = build_openclaw_hook_payload("/hooks/agent", &deliver);
+    let payload = build_openclaw_hook_payload("/hooks/agent", &deliver, None);
     assert_eq!(
         payload.get("message").and_then(|value| value.as_str()),
         Some("{\"count\":2,\"structured\":true}")
     );
+    assert!(payload.get("agentId").is_none());
+}
+
+#[test]
+fn openclaw_agent_hook_payload_includes_agent_id_when_mapping_exists() {
+    let deliver = DeliverFrame {
+        v: 1,
+        id: "req-2b".to_string(),
+        ts: "2026-03-20T05:55:00Z".to_string(),
+        from_agent_did: "did:cdi:test:agent:sender".to_string(),
+        to_agent_did: "did:cdi:test:agent:recipient".to_string(),
+        payload: json!({
+            "message": "hello",
+        }),
+        content_type: Some("application/json".to_string()),
+        conversation_id: None,
+        reply_to: None,
+    };
+
+    let payload = build_openclaw_hook_payload("/hooks/agent", &deliver, Some("alpha"));
+    assert_eq!(
+        payload.get("agentId").and_then(|value| value.as_str()),
+        Some("alpha")
+    );
+}
+
+#[test]
+fn openclaw_agent_hook_payload_omits_agent_id_when_mapping_missing() {
+    let deliver = DeliverFrame {
+        v: 1,
+        id: "req-2c".to_string(),
+        ts: "2026-03-20T05:55:00Z".to_string(),
+        from_agent_did: "did:cdi:test:agent:sender".to_string(),
+        to_agent_did: "did:cdi:test:agent:recipient".to_string(),
+        payload: json!({
+            "message": "hello",
+        }),
+        content_type: Some("application/json".to_string()),
+        conversation_id: None,
+        reply_to: None,
+    };
+
+    let payload = build_openclaw_hook_payload("/hooks/agent", &deliver, None);
+    assert!(payload.get("agentId").is_none());
 }
 
 #[test]
@@ -233,7 +278,7 @@ fn openclaw_wake_payload_preserves_explicit_session_id() {
         reply_to: Some("reply-1".to_string()),
     };
 
-    let payload = build_openclaw_hook_payload("/hooks/wake", &deliver);
+    let payload = build_openclaw_hook_payload("/hooks/wake", &deliver, None);
     assert_eq!(
         payload.get("mode").and_then(|value| value.as_str()),
         Some("now")
@@ -273,7 +318,7 @@ fn openclaw_wake_payload_omits_default_session_override() {
         reply_to: None,
     };
 
-    let payload = build_openclaw_hook_payload("/hooks/wake", &deliver);
+    let payload = build_openclaw_hook_payload("/hooks/wake", &deliver, None);
     assert!(payload.get("sessionId").is_none());
     assert_eq!(
         payload.get("message").and_then(|value| value.as_str()),
@@ -303,7 +348,7 @@ fn openclaw_wake_payload_prefers_message_field_from_sender_transform() {
         reply_to: None,
     };
 
-    let payload = build_openclaw_hook_payload("/hooks/wake", &deliver);
+    let payload = build_openclaw_hook_payload("/hooks/wake", &deliver, None);
     assert!(payload.get("sessionId").is_none());
     assert_eq!(
         payload.get("message").and_then(|value| value.as_str()),
@@ -315,6 +360,26 @@ fn openclaw_wake_payload_prefers_message_field_from_sender_transform() {
             "Clawdentity peer message from did:cdi:test:agent:sender\n\nplain peer text\n\nRequest ID: req-5"
         )
     );
+}
+
+#[test]
+fn openclaw_wake_payload_ignores_agent_mapping() {
+    let deliver = DeliverFrame {
+        v: 1,
+        id: "req-5b".to_string(),
+        ts: "2026-03-20T05:55:00Z".to_string(),
+        from_agent_did: "did:cdi:test:agent:sender".to_string(),
+        to_agent_did: "did:cdi:test:agent:recipient".to_string(),
+        payload: json!({
+            "message": "wake test",
+        }),
+        content_type: Some("application/json".to_string()),
+        conversation_id: None,
+        reply_to: None,
+    };
+
+    let payload = build_openclaw_hook_payload("/hooks/wake", &deliver, Some("alpha"));
+    assert!(payload.get("agentId").is_none());
 }
 
 #[test]
@@ -576,6 +641,35 @@ fn receipt_post_headers_nonce_changes_between_calls() {
         .expect("second nonce header");
 
     assert_ne!(nonce_one, nonce_two);
+}
+
+#[test]
+fn runtime_config_resolves_mapped_openclaw_target_agent_id() {
+    let options = receipt_fixture_options();
+    let config_dir = get_config_dir(&options).expect("resolve config dir");
+    fs::create_dir_all(&config_dir).expect("create config dir");
+    clawdentity_core::save_connector_assignment(
+        &config_dir,
+        "alpha",
+        "http://127.0.0.1:13372",
+        Some("beta"),
+    )
+    .expect("save connector assignment");
+
+    let target_agent_id =
+        resolve_openclaw_target_agent_id(&config_dir, "alpha").expect("resolve target agent id");
+    assert_eq!(target_agent_id.as_deref(), Some("beta"));
+}
+
+#[test]
+fn runtime_config_omits_openclaw_target_agent_id_when_assignment_missing() {
+    let options = receipt_fixture_options();
+    let config_dir = get_config_dir(&options).expect("resolve config dir");
+    fs::create_dir_all(&config_dir).expect("create config dir");
+
+    let target_agent_id =
+        resolve_openclaw_target_agent_id(&config_dir, "alpha").expect("resolve target agent id");
+    assert!(target_agent_id.is_none());
 }
 
 fn sample_auth_record(access_token: &str, expires_at: chrono::DateTime<Utc>) -> AgentAuthRecord {

--- a/crates/clawdentity-cli/src/commands/mod.rs
+++ b/crates/clawdentity-cli/src/commands/mod.rs
@@ -185,6 +185,8 @@ pub enum ProviderCommand {
         #[arg(long)]
         agent_name: Option<String>,
         #[arg(long)]
+        openclaw_agent_id: Option<String>,
+        #[arg(long)]
         platform_base_url: Option<String>,
         #[arg(long)]
         webhook_host: Option<String>,

--- a/crates/clawdentity-cli/src/commands/provider.rs
+++ b/crates/clawdentity-cli/src/commands/provider.rs
@@ -54,6 +54,7 @@ pub(crate) fn execute_provider_command(
         ProviderCommand::Setup {
             platform,
             agent_name,
+            openclaw_agent_id,
             platform_base_url,
             webhook_host,
             webhook_port,
@@ -74,6 +75,7 @@ pub(crate) fn execute_provider_command(
             let result = provider.setup(&ProviderSetupOptions {
                 home_dir,
                 agent_name,
+                openclaw_agent_id,
                 platform_base_url,
                 webhook_host,
                 webhook_port,

--- a/crates/clawdentity-core/src/providers/mod.rs
+++ b/crates/clawdentity-core/src/providers/mod.rs
@@ -163,6 +163,7 @@ pub struct ProviderDoctorResult {
 pub struct ProviderSetupOptions {
     pub home_dir: Option<PathBuf>,
     pub agent_name: Option<String>,
+    pub openclaw_agent_id: Option<String>,
     pub platform_base_url: Option<String>,
     pub webhook_host: Option<String>,
     pub webhook_port: Option<u16>,

--- a/crates/clawdentity-core/src/providers/openclaw/AGENTS.md
+++ b/crates/clawdentity-core/src/providers/openclaw/AGENTS.md
@@ -11,6 +11,9 @@
 - Provider setup must project the selected local agent DID into `hooks/transforms/clawdentity-relay.json` as `localAgentDid`; the container/runtime transform must not need host-home agent lookup for relay lane derivation.
 - Keep OpenClaw target validation strict: provider setup/runtime metadata must treat `openclawBaseUrl` as the OpenClaw gateway only, never the Clawdentity registry or proxy.
 - Inbound peer delivery for OpenClaw must target the visible main-session ingress (`/hooks/wake`) by default; `/hooks/agent` creates isolated hook sessions and hides relay traffic from normal chat UX.
+- Provider setup must persist `openclawAgentId` per Clawdentity agent in `~/.clawdentity/openclaw-connectors.json`, defaulting to `main` when the operator omits `--openclaw-agent-id`.
+- Setup must validate `openclawAgentId` against OpenClaw-configured agent IDs from `openclaw.json` and fail fast with remediation when the requested ID is unknown.
+- Connector assignment parsing must stay backward-compatible with legacy entries that do not contain `openclawAgentId`.
 - Wake-style inbound payloads must carry the rendered relay copy in both `text` and top-level `message`; OpenClaw may accept the hook without surfacing it when `message` is omitted.
 - Wake-style inbound payloads must only include `sessionId` when the inbound relay payload explicitly provides one; never hardcode `"main"` because operators may use a different default session.
 - The custom `send-to-peer` hook mapping must stay on OpenClaw `wake` action semantics; `agent` mappings no longer guarantee that side-effect transforms relay anything before local hook completion.

--- a/crates/clawdentity-core/src/providers/openclaw/AGENTS.md
+++ b/crates/clawdentity-core/src/providers/openclaw/AGENTS.md
@@ -12,6 +12,7 @@
 - Keep OpenClaw target validation strict: provider setup/runtime metadata must treat `openclawBaseUrl` as the OpenClaw gateway only, never the Clawdentity registry or proxy.
 - Inbound peer delivery for OpenClaw must target the visible main-session ingress (`/hooks/wake`) by default; `/hooks/agent` creates isolated hook sessions and hides relay traffic from normal chat UX.
 - Provider setup must persist `openclawAgentId` per Clawdentity agent in `~/.clawdentity/openclaw-connectors.json`, defaulting to `main` when the operator omits `--openclaw-agent-id`.
+- Provider setup should backfill legacy connector assignments missing `openclawAgentId` to `main` so `/hooks/agent` routing does not depend on implicit fallback behavior.
 - Setup must validate `openclawAgentId` against OpenClaw-configured agent IDs from `openclaw.json` and fail fast with remediation when the requested ID is unknown.
 - Connector assignment parsing must stay backward-compatible with legacy entries that do not contain `openclawAgentId`.
 - Wake-style inbound payloads must carry the rendered relay copy in both `text` and top-level `message`; OpenClaw may accept the hook without surfacing it when `message` is omitted.

--- a/crates/clawdentity-core/src/providers/openclaw/doctor_tests.rs
+++ b/crates/clawdentity-core/src/providers/openclaw/doctor_tests.rs
@@ -94,7 +94,8 @@ async fn doctor_reports_healthy_when_runtime_is_ready() {
         .mount(&server)
         .await;
 
-    save_connector_assignment(&config_dir, "alpha", &server.uri()).expect("assignment");
+    save_connector_assignment(&config_dir, "alpha", &server.uri(), Some("main"))
+        .expect("assignment");
     let doctor_config_dir = config_dir.clone();
     let doctor_store = store.clone();
     let result = tokio::task::spawn_blocking(move || {

--- a/crates/clawdentity-core/src/providers/openclaw/mod.rs
+++ b/crates/clawdentity-core/src/providers/openclaw/mod.rs
@@ -19,7 +19,8 @@ pub use self::setup::{
     OPENCLAW_DEFAULT_BASE_URL, OPENCLAW_RELAY_RUNTIME_FILE_NAME, OpenclawConnectorAssignment,
     OpenclawConnectorsConfig, OpenclawRelayRuntimeConfig, build_connector_base_url,
     connector_port_from_base_url, load_connector_assignments, load_relay_runtime_config,
-    openclaw_agent_name_path, openclaw_connectors_path, openclaw_relay_runtime_path,
+    list_configured_openclaw_agent_ids, openclaw_agent_name_path, openclaw_connectors_path,
+    openclaw_relay_runtime_path,
     read_selected_openclaw_agent, resolve_connector_base_url, resolve_openclaw_base_url,
     resolve_openclaw_config_path, resolve_openclaw_dir, resolve_openclaw_hook_token,
     save_connector_assignment, save_relay_runtime_config, suggest_connector_base_url,
@@ -63,6 +64,7 @@ struct OpenclawSetupContext {
     openclaw_dir: PathBuf,
     store: SqliteStore,
     agent_name: String,
+    openclaw_agent_id: String,
 }
 
 struct OpenclawSetupArtifacts {
@@ -131,13 +133,40 @@ impl OpenclawProvider {
                 crate::error::CoreError::InvalidInput("agent name is required".to_string())
             })?
             .to_string();
+        let openclaw_config_path =
+            resolve_openclaw_config_path(state_options.home_dir.as_deref(), None)?;
+        let openclaw_agent_id = self.resolve_setup_openclaw_agent_id(opts, &openclaw_config_path)?;
         Ok(OpenclawSetupContext {
             state_options,
             config_dir,
             openclaw_dir,
             store,
             agent_name,
+            openclaw_agent_id,
         })
+    }
+
+    fn resolve_setup_openclaw_agent_id(
+        &self,
+        opts: &ProviderSetupOptions,
+        openclaw_config_path: &Path,
+    ) -> Result<String> {
+        let requested = opts
+            .openclaw_agent_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or("main")
+            .to_ascii_lowercase();
+        let configured = list_configured_openclaw_agent_ids(openclaw_config_path)?;
+        if configured.iter().any(|id| id == &requested) {
+            return Ok(requested);
+        }
+        Err(crate::error::CoreError::InvalidInput(format!(
+            "OpenClaw agent id `{requested}` is not configured in {}. Configure the agent in OpenClaw first (for example `openclaw agents list`), then rerun `clawdentity provider setup --for openclaw --agent-name <agentName> --openclaw-agent-id <agentId>`. Known agent ids: {}",
+            openclaw_config_path.display(),
+            configured.join(", ")
+        )))
     }
 
     fn resolve_setup_connector_base_url(
@@ -200,6 +229,7 @@ impl OpenclawProvider {
             &context.config_dir,
             &context.agent_name,
             connector_base_url,
+            Some(&context.openclaw_agent_id),
         )?;
         let relay_snapshot_path = write_transform_peers_snapshot(
             &relay_snapshot_path,
@@ -304,6 +334,10 @@ impl OpenclawProvider {
         ));
         notes.push(format!(
             "connector assignment saved as `{connector_base_url}`"
+        ));
+        notes.push(format!(
+            "OpenClaw inbound routing target set to agent `{}` (applies when connector hook path is `/hooks/agent`)",
+            context.openclaw_agent_id
         ));
         notes.push("next: run `openclaw dashboard` for a quick OpenClaw UI check".to_string());
         notes.push(

--- a/crates/clawdentity-core/src/providers/openclaw/mod.rs
+++ b/crates/clawdentity-core/src/providers/openclaw/mod.rs
@@ -18,13 +18,12 @@ pub use self::setup::{
     OPENCLAW_AGENT_FILE_NAME, OPENCLAW_CONFIG_FILE_NAME, OPENCLAW_CONNECTORS_FILE_NAME,
     OPENCLAW_DEFAULT_BASE_URL, OPENCLAW_RELAY_RUNTIME_FILE_NAME, OpenclawConnectorAssignment,
     OpenclawConnectorsConfig, OpenclawRelayRuntimeConfig, build_connector_base_url,
-    connector_port_from_base_url, load_connector_assignments, load_relay_runtime_config,
-    list_configured_openclaw_agent_ids, openclaw_agent_name_path, openclaw_connectors_path,
-    openclaw_relay_runtime_path,
-    read_selected_openclaw_agent, resolve_connector_base_url, resolve_openclaw_base_url,
-    resolve_openclaw_config_path, resolve_openclaw_dir, resolve_openclaw_hook_token,
-    save_connector_assignment, save_relay_runtime_config, suggest_connector_base_url,
-    write_selected_openclaw_agent,
+    connector_port_from_base_url, list_configured_openclaw_agent_ids, load_connector_assignments,
+    load_relay_runtime_config, openclaw_agent_name_path, openclaw_connectors_path,
+    openclaw_relay_runtime_path, read_selected_openclaw_agent, resolve_connector_base_url,
+    resolve_openclaw_base_url, resolve_openclaw_config_path, resolve_openclaw_dir,
+    resolve_openclaw_hook_token, save_connector_assignment, save_relay_runtime_config,
+    suggest_connector_base_url, write_selected_openclaw_agent,
 };
 
 use self::assets::{
@@ -51,6 +50,7 @@ const PROVIDER_NAME: &str = "openclaw";
 const PROVIDER_DISPLAY_NAME: &str = "OpenClaw";
 const OPENCLAW_BINARY: &str = "openclaw";
 const OPENCLAW_WEBHOOK_PATH: &str = "/hooks/wake";
+const OPENCLAW_AGENT_HOOK_PATH: &str = "/hooks/agent";
 
 #[derive(Debug, Clone, Default)]
 pub struct OpenclawProvider {
@@ -73,6 +73,26 @@ struct OpenclawSetupArtifacts {
 }
 
 impl OpenclawProvider {
+    fn normalize_hook_path(value: &str) -> String {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            return OPENCLAW_WEBHOOK_PATH.to_string();
+        }
+        let normalized = trimmed.trim_start_matches('/');
+        if normalized.is_empty() {
+            OPENCLAW_WEBHOOK_PATH.to_string()
+        } else {
+            format!("/{normalized}")
+        }
+    }
+
+    fn resolve_setup_hook_path(&self) -> String {
+        std::env::var("OPENCLAW_HOOK_PATH")
+            .ok()
+            .map(|value| Self::normalize_hook_path(&value))
+            .unwrap_or_else(|| OPENCLAW_WEBHOOK_PATH.to_string())
+    }
+
     fn install_home_dir(&self, opts: &InstallOptions) -> Result<PathBuf> {
         resolve_home_dir_with_fallback(opts.home_dir.as_deref(), self.home_dir_override.as_deref())
     }
@@ -135,7 +155,8 @@ impl OpenclawProvider {
             .to_string();
         let openclaw_config_path =
             resolve_openclaw_config_path(state_options.home_dir.as_deref(), None)?;
-        let openclaw_agent_id = self.resolve_setup_openclaw_agent_id(opts, &openclaw_config_path)?;
+        let openclaw_agent_id =
+            self.resolve_setup_openclaw_agent_id(opts, &openclaw_config_path)?;
         Ok(OpenclawSetupContext {
             state_options,
             config_dir,
@@ -209,6 +230,32 @@ impl OpenclawProvider {
         (existing_runtime, peers_path)
     }
 
+    fn backfill_legacy_openclaw_agent_ids(&self, config_dir: &Path) -> Result<Vec<String>> {
+        let assignments = load_connector_assignments(config_dir)?;
+        let mut backfilled_agents = Vec::new();
+        for (agent_name, assignment) in assignments.agents {
+            let has_agent_mapping = assignment
+                .openclaw_agent_id
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .is_some();
+            if has_agent_mapping {
+                continue;
+            }
+            save_connector_assignment(
+                config_dir,
+                &agent_name,
+                &assignment.connector_base_url,
+                Some("main"),
+            )?;
+            backfilled_agents.push(agent_name);
+        }
+        backfilled_agents.sort();
+        backfilled_agents.dedup();
+        Ok(backfilled_agents)
+    }
+
     fn persist_setup_artifacts(
         &self,
         context: &OpenclawSetupContext,
@@ -216,6 +263,8 @@ impl OpenclawProvider {
         connector_base_url: &str,
         install_notes: Vec<String>,
     ) -> Result<OpenclawSetupArtifacts> {
+        let setup_hook_path = self.resolve_setup_hook_path();
+        let backfilled_agents = self.backfill_legacy_openclaw_agent_ids(&context.config_dir)?;
         let (_, relay_snapshot_path) =
             self.resolve_setup_runtime_paths(opts, &context.config_dir, &context.openclaw_dir);
         let marker_path = write_selected_openclaw_agent(&context.config_dir, &context.agent_name)?;
@@ -245,6 +294,8 @@ impl OpenclawProvider {
         Ok(self.finalize_setup_artifacts(
             context,
             connector_base_url,
+            &setup_hook_path,
+            &backfilled_agents,
             install_notes,
             [
                 marker_path,
@@ -317,6 +368,8 @@ impl OpenclawProvider {
         &self,
         context: &OpenclawSetupContext,
         connector_base_url: &str,
+        setup_hook_path: &str,
+        backfilled_agents: &[String],
         install_notes: Vec<String>,
         paths: [PathBuf; 5],
     ) -> OpenclawSetupArtifacts {
@@ -339,6 +392,17 @@ impl OpenclawProvider {
             "OpenClaw inbound routing target set to agent `{}` (applies when connector hook path is `/hooks/agent`)",
             context.openclaw_agent_id
         ));
+        if !backfilled_agents.is_empty() {
+            notes.push(format!(
+                "migrated legacy connector assignments to include `openclawAgentId=main` for: {}",
+                backfilled_agents.join(", ")
+            ));
+            if setup_hook_path == OPENCLAW_AGENT_HOOK_PATH {
+                notes.push(
+                    "warning: connector hook path is `/hooks/agent`; legacy assignments without explicit OpenClaw routing were backfilled to `main`.".to_string(),
+                );
+            }
+        }
         notes.push("next: run `openclaw dashboard` for a quick OpenClaw UI check".to_string());
         notes.push(
             "next: run `clawdentity provider doctor --for openclaw` to validate relay readiness"
@@ -600,6 +664,9 @@ impl PlatformProvider for OpenclawProvider {
 
     fn setup(&self, opts: &ProviderSetupOptions) -> Result<ProviderSetupResult> {
         self.ensure_openclaw_cli()?;
+        let home_dir = opts.home_dir.clone().or(self.home_dir_override.clone());
+        let config_path = resolve_openclaw_config_path(home_dir.as_deref(), None)?;
+        self.ensure_openclaw_base_ready(&config_path)?;
         let context = self.resolve_setup_context(opts)?;
         let connector_base_url =
             self.resolve_setup_connector_base_url(opts, &context.config_dir, &context.agent_name);

--- a/crates/clawdentity-core/src/providers/openclaw/mod_tests.rs
+++ b/crates/clawdentity-core/src/providers/openclaw/mod_tests.rs
@@ -288,6 +288,66 @@ fn setup_persists_explicit_openclaw_agent_id() {
 }
 
 #[test]
+fn setup_backfills_legacy_connector_assignments_with_default_agent_id() {
+    let home = TempDir::new().expect("temp home");
+    let bin_dir = install_mock_openclaw_cli();
+    write_openclaw_profile(
+        home.path(),
+        r#"{
+  "agents": {
+    "list": [
+      { "id": "main" },
+      { "id": "coder" }
+    ]
+  },
+  "gateway": {
+    "auth": {
+      "mode": "token",
+      "token": "gateway-token"
+    }
+  }
+}
+"#,
+    );
+    let provider = OpenclawProvider::with_test_context(
+        home.path().to_path_buf(),
+        vec![bin_dir.path().to_path_buf()],
+    );
+    let config_dir = get_config_dir(&ConfigPathOptions {
+        home_dir: Some(home.path().to_path_buf()),
+        registry_url_hint: None,
+    })
+    .expect("config dir");
+    seed_inspectable_agent(&config_dir, "alpha", ALPHA_AGENT_DID);
+    super::save_connector_assignment(&config_dir, "legacy-agent", "http://127.0.0.1:19411", None)
+        .expect("legacy assignment");
+
+    let result = provider
+        .setup(&ProviderSetupOptions {
+            agent_name: Some("alpha".to_string()),
+            platform_base_url: Some("http://127.0.0.1:19001".to_string()),
+            ..ProviderSetupOptions::default()
+        })
+        .expect("setup");
+
+    assert_eq!(result.status, ProviderSetupStatus::ActionRequired);
+    assert!(
+        result
+            .notes
+            .iter()
+            .any(|note| note.contains("migrated legacy connector assignments"))
+    );
+    let assignments = load_connector_assignments(&config_dir).expect("assignments");
+    assert_eq!(
+        assignments
+            .agents
+            .get("legacy-agent")
+            .and_then(|entry| entry.openclaw_agent_id.as_deref()),
+        Some("main")
+    );
+}
+
+#[test]
 fn install_requires_openclaw_cli() {
     let home = TempDir::new().expect("temp home");
     write_openclaw_profile(
@@ -357,6 +417,27 @@ fn setup_requires_openclaw_onboarding_first() {
 }
 
 #[test]
+fn setup_reports_onboarding_error_before_agent_id_validation() {
+    let home = TempDir::new().expect("temp home");
+    let bin_dir = install_mock_openclaw_cli();
+    let provider = OpenclawProvider::with_test_context(
+        home.path().to_path_buf(),
+        vec![bin_dir.path().to_path_buf()],
+    );
+
+    let error = provider
+        .setup(&ProviderSetupOptions {
+            agent_name: Some("alpha".to_string()),
+            openclaw_agent_id: Some("coder".to_string()),
+            ..ProviderSetupOptions::default()
+        })
+        .expect_err("missing openclaw config should fail before agent id validation");
+
+    assert!(error.to_string().contains("openclaw onboard"));
+    assert!(!error.to_string().contains("is not configured"));
+}
+
+#[test]
 fn setup_rejects_unknown_openclaw_agent_id() {
     let home = TempDir::new().expect("temp home");
     let bin_dir = install_mock_openclaw_cli();
@@ -397,7 +478,11 @@ fn setup_rejects_unknown_openclaw_agent_id() {
         })
         .expect_err("unknown OpenClaw agent id should fail");
 
-    assert!(error.to_string().contains("OpenClaw agent id `missing` is not configured"));
+    assert!(
+        error
+            .to_string()
+            .contains("OpenClaw agent id `missing` is not configured")
+    );
 }
 
 #[test]

--- a/crates/clawdentity-core/src/providers/openclaw/mod_tests.rs
+++ b/crates/clawdentity-core/src/providers/openclaw/mod_tests.rs
@@ -158,6 +158,7 @@ fn setup_honors_explicit_connector_url_and_custom_peers_path() {
         .setup(&ProviderSetupOptions {
             home_dir: None,
             agent_name: Some("alpha".to_string()),
+            openclaw_agent_id: None,
             platform_base_url: Some("http://127.0.0.1:19001".to_string()),
             webhook_host: None,
             webhook_port: None,
@@ -210,6 +211,13 @@ fn setup_honors_explicit_connector_url_and_custom_peers_path() {
             .map(|entry| entry.connector_base_url.as_str()),
         Some("https://relay.example.test:24444/")
     );
+    assert_eq!(
+        assignments
+            .agents
+            .get("alpha")
+            .and_then(|entry| entry.openclaw_agent_id.as_deref()),
+        Some("main")
+    );
 
     let config_body =
         fs::read_to_string(openclaw_dir.join(super::OPENCLAW_CONFIG_FILE_NAME)).expect("config");
@@ -223,6 +231,59 @@ fn setup_honors_explicit_connector_url_and_custom_peers_path() {
             .and_then(|value| value.get("mode"))
             .and_then(Value::as_str),
         Some("password")
+    );
+}
+
+#[test]
+fn setup_persists_explicit_openclaw_agent_id() {
+    let home = TempDir::new().expect("temp home");
+    let bin_dir = install_mock_openclaw_cli();
+    write_openclaw_profile(
+        home.path(),
+        r#"{
+  "agents": {
+    "list": [
+      { "id": "main" },
+      { "id": "coder" }
+    ]
+  },
+  "gateway": {
+    "auth": {
+      "mode": "token",
+      "token": "gateway-token"
+    }
+  }
+}
+"#,
+    );
+    let provider = OpenclawProvider::with_test_context(
+        home.path().to_path_buf(),
+        vec![bin_dir.path().to_path_buf()],
+    );
+    let config_dir = get_config_dir(&ConfigPathOptions {
+        home_dir: Some(home.path().to_path_buf()),
+        registry_url_hint: None,
+    })
+    .expect("config dir");
+    seed_inspectable_agent(&config_dir, "alpha", ALPHA_AGENT_DID);
+
+    let result = provider
+        .setup(&ProviderSetupOptions {
+            agent_name: Some("alpha".to_string()),
+            openclaw_agent_id: Some("coder".to_string()),
+            platform_base_url: Some("http://127.0.0.1:19001".to_string()),
+            ..ProviderSetupOptions::default()
+        })
+        .expect("setup");
+
+    assert_eq!(result.status, ProviderSetupStatus::ActionRequired);
+    let assignments = load_connector_assignments(&config_dir).expect("assignments");
+    assert_eq!(
+        assignments
+            .agents
+            .get("alpha")
+            .and_then(|entry| entry.openclaw_agent_id.as_deref()),
+        Some("coder")
     );
 }
 
@@ -293,6 +354,50 @@ fn setup_requires_openclaw_onboarding_first() {
         .expect_err("missing openclaw config should fail");
 
     assert!(error.to_string().contains("openclaw onboard"));
+}
+
+#[test]
+fn setup_rejects_unknown_openclaw_agent_id() {
+    let home = TempDir::new().expect("temp home");
+    let bin_dir = install_mock_openclaw_cli();
+    write_openclaw_profile(
+        home.path(),
+        r#"{
+  "agents": {
+    "list": [
+      { "id": "main" },
+      { "id": "coder" }
+    ]
+  },
+  "gateway": {
+    "auth": {
+      "mode": "token",
+      "token": "gateway-token"
+    }
+  }
+}
+"#,
+    );
+    let provider = OpenclawProvider::with_test_context(
+        home.path().to_path_buf(),
+        vec![bin_dir.path().to_path_buf()],
+    );
+    let config_dir = get_config_dir(&ConfigPathOptions {
+        home_dir: Some(home.path().to_path_buf()),
+        registry_url_hint: None,
+    })
+    .expect("config dir");
+    seed_inspectable_agent(&config_dir, "alpha", ALPHA_AGENT_DID);
+
+    let error = provider
+        .setup(&ProviderSetupOptions {
+            agent_name: Some("alpha".to_string()),
+            openclaw_agent_id: Some("missing".to_string()),
+            ..ProviderSetupOptions::default()
+        })
+        .expect_err("unknown OpenClaw agent id should fail");
+
+    assert!(error.to_string().contains("OpenClaw agent id `missing` is not configured"));
 }
 
 #[test]

--- a/crates/clawdentity-core/src/providers/openclaw/setup.rs
+++ b/crates/clawdentity-core/src/providers/openclaw/setup.rs
@@ -32,6 +32,8 @@ pub struct OpenclawRelayRuntimeConfig {
 #[serde(rename_all = "camelCase")]
 pub struct OpenclawConnectorAssignment {
     pub connector_base_url: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub openclaw_agent_id: Option<String>,
     pub updated_at: String,
 }
 
@@ -46,6 +48,30 @@ fn parse_non_empty(value: &str, field: &str) -> Result<String> {
         return Err(CoreError::InvalidInput(format!("{field} is required")));
     }
     Ok(trimmed.to_string())
+}
+
+fn is_valid_openclaw_agent_id(value: &str) -> bool {
+    if value.is_empty() || value.len() > 64 {
+        return false;
+    }
+    let mut chars = value.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !first.is_ascii_alphanumeric() {
+        return false;
+    }
+    chars.all(|ch| ch.is_ascii_alphanumeric() || ch == '-' || ch == '_')
+}
+
+fn normalize_openclaw_agent_id(value: &str, field: &str) -> Result<String> {
+    let trimmed = value.trim().to_ascii_lowercase();
+    if !is_valid_openclaw_agent_id(&trimmed) {
+        return Err(CoreError::InvalidInput(format!(
+            "{field} must match [a-z0-9][a-z0-9_-]{{0,63}}"
+        )));
+    }
+    Ok(trimmed)
 }
 
 fn normalize_http_url(value: &str, field: &'static str) -> Result<String> {
@@ -125,6 +151,24 @@ fn read_json_if_exists<T: for<'de> Deserialize<'de>>(path: &Path) -> Result<Opti
         source,
     })?;
     Ok(Some(parsed))
+}
+
+fn parse_json_or_default(path: &Path) -> Result<serde_json::Value> {
+    let raw = match fs::read_to_string(path) {
+        Ok(raw) => raw,
+        Err(error) if error.kind() == ErrorKind::NotFound => {
+            return Ok(serde_json::Value::Object(serde_json::Map::new()));
+        }
+        Err(source) => {
+            return Err(CoreError::Io {
+                path: path.to_path_buf(),
+                source,
+            });
+        }
+    };
+    json5::from_str::<serde_json::Value>(&raw).map_err(|source| {
+        CoreError::InvalidInput(format!("failed to parse OpenClaw config {}: {source}", path.display()))
+    })
 }
 
 fn now_iso() -> String {
@@ -358,14 +402,23 @@ pub fn save_connector_assignment(
     config_dir: &Path,
     agent_name: &str,
     connector_base_url: &str,
+    openclaw_agent_id: Option<&str>,
 ) -> Result<PathBuf> {
     let agent_name = parse_non_empty(agent_name, "agentName")?;
     let connector_base_url = normalize_http_url(connector_base_url, "connectorBaseUrl")?;
     let mut assignments = load_connector_assignments(config_dir)?;
+    let normalized_openclaw_agent_id = match openclaw_agent_id {
+        Some(value) => Some(normalize_openclaw_agent_id(value, "openclawAgentId")?),
+        None => assignments
+            .agents
+            .get(&agent_name)
+            .and_then(|assignment| assignment.openclaw_agent_id.clone()),
+    };
     assignments.agents.insert(
         agent_name,
         OpenclawConnectorAssignment {
             connector_base_url,
+            openclaw_agent_id: normalized_openclaw_agent_id,
             updated_at: now_iso(),
         },
     );
@@ -449,16 +502,51 @@ pub fn resolve_connector_base_url(
         .map(|entry| entry.connector_base_url.clone()))
 }
 
+/// Reads the OpenClaw config file and returns normalized agent ids for connector routing.
+/// The returned list always includes `"main"` so older configs without `agents.list` still
+/// support the default routing target.
+pub fn list_configured_openclaw_agent_ids(config_path: &Path) -> Result<Vec<String>> {
+    let config = parse_json_or_default(config_path)?;
+    let mut ids = vec!["main".to_string()];
+    if let Some(entries) = config
+        .get("agents")
+        .and_then(serde_json::Value::as_object)
+        .and_then(|agents| agents.get("list"))
+        .and_then(serde_json::Value::as_array)
+    {
+        for entry in entries {
+            let Some(id) = entry
+                .get("id")
+                .and_then(serde_json::Value::as_str)
+                .map(str::trim)
+            else {
+                continue;
+            };
+            if id.is_empty() {
+                continue;
+            }
+            let normalized = id.to_ascii_lowercase();
+            if !ids.iter().any(|existing| existing == &normalized) {
+                ids.push(normalized);
+            }
+        }
+    }
+    ids.sort_unstable();
+    ids.dedup();
+    Ok(ids)
+}
+
 #[cfg(test)]
 mod tests {
     use tempfile::TempDir;
 
     use super::{
-        OPENCLAW_DEFAULT_BASE_URL, OpenclawRelayRuntimeConfig, build_connector_base_url,
-        connector_port_from_base_url, load_connector_assignments, load_relay_runtime_config,
-        read_selected_openclaw_agent, resolve_openclaw_base_url, resolve_openclaw_config_path,
-        resolve_openclaw_dir, save_connector_assignment, save_relay_runtime_config,
-        suggest_connector_base_url, write_selected_openclaw_agent,
+        OPENCLAW_CONNECTORS_FILE_NAME, OPENCLAW_DEFAULT_BASE_URL, OpenclawRelayRuntimeConfig,
+        build_connector_base_url, connector_port_from_base_url, list_configured_openclaw_agent_ids,
+        load_connector_assignments, load_relay_runtime_config, read_selected_openclaw_agent,
+        resolve_openclaw_base_url, resolve_openclaw_config_path, resolve_openclaw_dir,
+        save_connector_assignment, save_relay_runtime_config, suggest_connector_base_url,
+        write_selected_openclaw_agent,
     };
 
     #[test]
@@ -499,8 +587,13 @@ mod tests {
     #[test]
     fn connector_assignments_round_trip() {
         let temp = TempDir::new().expect("temp dir");
-        let _ = save_connector_assignment(temp.path(), "alpha", "http://127.0.0.1:19400")
-            .expect("save");
+        let _ = save_connector_assignment(
+            temp.path(),
+            "alpha",
+            "http://127.0.0.1:19400",
+            Some("coder"),
+        )
+        .expect("save");
         let assignments = load_connector_assignments(temp.path()).expect("load");
         assert_eq!(assignments.agents.len(), 1);
         assert_eq!(
@@ -509,6 +602,49 @@ mod tests {
                 .get("alpha")
                 .map(|entry| entry.connector_base_url.as_str()),
             Some("http://127.0.0.1:19400/")
+        );
+        assert_eq!(
+            assignments
+                .agents
+                .get("alpha")
+                .and_then(|entry| entry.openclaw_agent_id.as_deref()),
+            Some("coder")
+        );
+    }
+
+    #[test]
+    fn connector_assignments_support_legacy_entries_without_openclaw_agent_id() {
+        let temp = TempDir::new().expect("temp dir");
+        let connectors_path = temp.path().join(OPENCLAW_CONNECTORS_FILE_NAME);
+        std::fs::write(
+            &connectors_path,
+            r#"{
+  "agents": {
+    "alpha": {
+      "connectorBaseUrl": "http://127.0.0.1:19400/",
+      "updatedAt": "2026-03-27T00:00:00Z"
+    }
+  }
+}
+"#,
+        )
+        .expect("write legacy connectors config");
+
+        let assignments = load_connector_assignments(temp.path()).expect("load");
+        assert_eq!(assignments.agents.len(), 1);
+        assert_eq!(
+            assignments
+                .agents
+                .get("alpha")
+                .map(|entry| entry.connector_base_url.as_str()),
+            Some("http://127.0.0.1:19400/")
+        );
+        assert_eq!(
+            assignments
+                .agents
+                .get("alpha")
+                .and_then(|entry| entry.openclaw_agent_id.as_deref()),
+            None
         );
     }
 
@@ -527,10 +663,68 @@ mod tests {
     #[test]
     fn connector_suggestion_uses_next_available_port() {
         let temp = TempDir::new().expect("temp dir");
-        let _ = save_connector_assignment(temp.path(), "alpha", "http://127.0.0.1:19400")
-            .expect("save alpha");
+        let _ = save_connector_assignment(
+            temp.path(),
+            "alpha",
+            "http://127.0.0.1:19400",
+            Some("main"),
+        )
+        .expect("save alpha");
         let suggested = suggest_connector_base_url(temp.path(), "beta").expect("suggest");
         assert_eq!(suggested, "http://127.0.0.1:19401");
+    }
+
+    #[test]
+    fn connector_assignment_backfills_openclaw_agent_id_from_existing_entry() {
+        let temp = TempDir::new().expect("temp dir");
+        let _ = save_connector_assignment(
+            temp.path(),
+            "alpha",
+            "http://127.0.0.1:19400",
+            Some("ops"),
+        )
+        .expect("save alpha");
+        let _ = save_connector_assignment(temp.path(), "alpha", "http://127.0.0.1:19401", None)
+            .expect("update alpha");
+
+        let assignments = load_connector_assignments(temp.path()).expect("load");
+        assert_eq!(
+            assignments
+                .agents
+                .get("alpha")
+                .map(|entry| entry.connector_base_url.as_str()),
+            Some("http://127.0.0.1:19401/")
+        );
+        assert_eq!(
+            assignments
+                .agents
+                .get("alpha")
+                .and_then(|entry| entry.openclaw_agent_id.as_deref()),
+            Some("ops")
+        );
+    }
+
+    #[test]
+    fn list_configured_openclaw_agent_ids_includes_default_and_configured_agents() {
+        let temp = TempDir::new().expect("temp dir");
+        let config_path = temp.path().join("openclaw.json");
+        std::fs::write(
+            &config_path,
+            r#"{
+  agents: {
+    list: [
+      { id: "main" },
+      { id: "coder" },
+      { id: "OPS" }
+    ]
+  }
+}
+"#,
+        )
+        .expect("config");
+
+        let agent_ids = list_configured_openclaw_agent_ids(&config_path).expect("agent ids");
+        assert_eq!(agent_ids, vec!["coder", "main", "ops"]);
     }
 
     #[test]

--- a/crates/clawdentity-core/src/runtime/openclaw.rs
+++ b/crates/clawdentity-core/src/runtime/openclaw.rs
@@ -6,6 +6,7 @@ pub struct OpenclawRuntimeConfig {
     pub base_url: String,
     pub hook_path: String,
     pub hook_token: Option<String>,
+    pub target_agent_id: Option<String>,
 }
 
 impl OpenclawRuntimeConfig {
@@ -70,6 +71,7 @@ mod tests {
             base_url: "http://127.0.0.1:11434".to_string(),
             hook_path: "/v1/hooks/relay".to_string(),
             hook_token: None,
+            target_agent_id: None,
         };
         let url = config.hook_url().expect("hook url");
         assert_eq!(url, "http://127.0.0.1:11434/v1/hooks/relay");


### PR DESCRIPTION
## Summary
- add `--openclaw-agent-id` to `clawdentity provider setup --for openclaw`
- persist per-agent `openclawAgentId` in `~/.clawdentity/openclaw-connectors.json` with default `main`
- validate configured OpenClaw agent IDs against OpenClaw config during setup
- resolve mapped `openclawAgentId` at connector runtime startup
- inject `agentId` only for `/hooks/agent` payloads; keep `/hooks/wake` payload shape unchanged
- update docs and AGENTS guardrails for routing/default-hook behavior

## Validation
- `cargo test -p clawdentity-core`
- `cargo test -p clawdentity-cli`
- `cargo check`

Closes #126
