### PR TITLE
feat(proxy): queue-based agent revocation enforcement

### DIFF
--- a/apps/proxy/AGENTS.md
+++ b/apps/proxy/AGENTS.md
@@ -13,7 +13,10 @@
 - Keep Wrangler observability logging enabled (`observability.enabled=true`, `logs.enabled=true`) so relay/auth failures are visible in Cloudflare logs.
 - Production must keep `invocation_logs=false` to reduce noisy request-volume logs while preserving structured warn/error events.
 - Keep `worker-configuration.d.ts` committed and regenerate with `CLOUDFLARE_LOAD_DEV_VARS_FROM_DOT_ENV=false wrangler types --env dev` (or `pnpm -F @clawdentity/proxy run types:dev`) after `wrangler.jsonc` or binding changes.
-- Keep proxy queue consumers scoped to queues this worker handles (`clawdentity-receipts*`); do not subscribe proxy to `clawdentity-events*` until matching handlers are implemented.
+- Keep proxy queue consumers scoped to queues this worker handles:
+  - `clawdentity-receipts*` for delivery receipt fan-in.
+  - `clawdentity-events*` for registry `agent.auth.revoked` propagation.
+- Keep revocation queue behavior strict: only `agent.auth.revoked` events with `data.reason=agent_revoked` and valid `data.metadata.agentDid` may mark trust-state revocation overlays.
 - Keep `src/worker.ts` in module-worker shape: export the fetch handler as the default export when this Worker owns Durable Objects, and keep any named `worker` export only as a test convenience.
 - Parse config with a schema and fail fast with `CONFIG_VALIDATION_FAILED` before startup proceeds.
 - Keep defaults explicit for non-secret settings (`listenPort`, `openclawBaseUrl`, `registryUrl`, CRL timings, stale behavior).

--- a/apps/proxy/src/agent-hook-route.test.ts
+++ b/apps/proxy/src/agent-hook-route.test.ts
@@ -125,6 +125,8 @@ function createHookRouteApp(input: {
     createPairingTicket: vi.fn(),
     confirmPairingTicket: vi.fn(),
     getPairingTicketStatus: vi.fn(),
+    markAgentRevoked: vi.fn(async () => {}),
+    isAgentRevoked: vi.fn(async () => false),
     isAgentKnown: vi.fn(async () => true),
     isPairAllowed: vi.fn(
       async (pair) =>

--- a/apps/proxy/src/auth-middleware.test/helpers.ts
+++ b/apps/proxy/src/auth-middleware.test/helpers.ts
@@ -38,6 +38,7 @@ export type AuthHarnessOptions = {
   fetchKeysFails?: boolean;
   allowCurrentAgent?: boolean;
   revoked?: boolean;
+  revokedByTrustStore?: boolean;
   validateStatus?: number;
   nonceCache?: ProxyNonceCache;
 };
@@ -186,6 +187,9 @@ export async function createAuthHarness(
       initiatorAgentDid: claims.sub,
       responderAgentDid: KNOWN_PEER_DID,
     });
+  }
+  if (options.revokedByTrustStore) {
+    await trustStore.markAgentRevoked(claims.sub);
   }
 
   const relaySession = {

--- a/apps/proxy/src/auth-middleware.test/robustness.test.ts
+++ b/apps/proxy/src/auth-middleware.test/robustness.test.ts
@@ -257,6 +257,24 @@ describe("proxy auth middleware", () => {
     expect(body.error.code).toBe("PROXY_AUTH_REVOKED");
   });
 
+  it("rejects agents revoked by trust-state overlay before CRL refresh", async () => {
+    const harness = await createAuthHarness({
+      revokedByTrustStore: true,
+    });
+    const headers = await harness.createSignedHeaders({
+      nonce: "nonce-revoked-by-trust-state",
+    });
+    const response = await harness.app.request("/protected", {
+      method: "POST",
+      headers,
+      body: BODY_JSON,
+    });
+
+    expect(response.status).toBe(401);
+    const body = (await response.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("PROXY_AUTH_REVOKED");
+  });
+
   it("rejects expired AITs", async () => {
     const harness = await createAuthHarness({
       expired: true,

--- a/apps/proxy/src/auth-middleware/AGENTS.md
+++ b/apps/proxy/src/auth-middleware/AGENTS.md
@@ -13,3 +13,4 @@
 - Keep nonce replay TTL tied to `maxTimestampSkewSeconds` (milliseconds) when calling nonce cache implementations.
 - Prefer `verifyHttpRequestWithReplayProtection` from `@clawdentity/sdk` for inbound proof auth so timestamp skew + signature + replay checks are enforced together in one call.
 - Keep proxy error mapping explicit when translating SDK proof errors into proxy auth error codes (`PROXY_AUTH_INVALID_TIMESTAMP`, `PROXY_AUTH_TIMESTAMP_SKEW`, `PROXY_AUTH_INVALID_NONCE`, `PROXY_AUTH_REPLAY`, `PROXY_AUTH_INVALID_PROOF`).
+- Keep revocation enforcement order explicit: trust-state revocation overlay check by agent DID before CRL/JTI polling checks.

--- a/apps/proxy/src/auth-middleware/middleware.ts
+++ b/apps/proxy/src/auth-middleware/middleware.ts
@@ -355,6 +355,27 @@ export function createProxyAuthMiddleware(options: ProxyAuthMiddlewareOptions) {
         });
       }
 
+      let isRevokedByTrustState: boolean;
+      try {
+        isRevokedByTrustState = await options.trustStore.isAgentRevoked(
+          claims.sub,
+        );
+      } catch (error) {
+        throw dependencyUnavailableError({
+          message: "Proxy trust state is unavailable",
+          details: {
+            reason: toErrorMessage(error),
+          },
+        });
+      }
+
+      if (isRevokedByTrustState) {
+        throw unauthorizedError({
+          code: "PROXY_AUTH_REVOKED",
+          message: "Agent has been revoked",
+        });
+      }
+
       let isRevoked: boolean;
       try {
         isRevoked = await crlCache.isRevoked(claims.jti);

--- a/apps/proxy/src/proxy-trust-state.test.ts
+++ b/apps/proxy/src/proxy-trust-state.test.ts
@@ -102,6 +102,44 @@ async function createSignedTicket(input: {
 }
 
 describe("ProxyTrustState", () => {
+  it("persists revoked-agent markers and serves revoked checks", async () => {
+    const { proxyTrustState, harness } = createProxyTrustState();
+    const agentDid =
+      "did:cdi:dev.registry.clawdentity.com:agent:01HF7YAT00EXEKCZ140TBBFB97";
+
+    const beforeResponse = await proxyTrustState.fetch(
+      makeRequest(TRUST_STORE_ROUTES.isAgentRevoked, {
+        agentDid,
+      }),
+    );
+    expect(beforeResponse.status).toBe(200);
+    expect((await beforeResponse.json()) as { revoked: boolean }).toEqual({
+      revoked: false,
+    });
+
+    const markResponse = await proxyTrustState.fetch(
+      makeRequest(TRUST_STORE_ROUTES.markAgentRevoked, {
+        agentDid,
+      }),
+    );
+    expect(markResponse.status).toBe(200);
+    expect((await markResponse.json()) as { ok: boolean }).toEqual({
+      ok: true,
+    });
+
+    const afterResponse = await proxyTrustState.fetch(
+      makeRequest(TRUST_STORE_ROUTES.isAgentRevoked, {
+        agentDid,
+      }),
+    );
+    expect(afterResponse.status).toBe(200);
+    expect((await afterResponse.json()) as { revoked: boolean }).toEqual({
+      revoked: true,
+    });
+
+    expect(harness.values.has("trust:revoked-agents")).toBe(true);
+  });
+
   it("persists and answers known-agent checks via agent peer index", async () => {
     const { proxyTrustState, harness } = createProxyTrustState();
 

--- a/apps/proxy/src/proxy-trust-state.test.ts
+++ b/apps/proxy/src/proxy-trust-state.test.ts
@@ -140,6 +140,44 @@ describe("ProxyTrustState", () => {
     expect(harness.values.has("trust:revoked-agents")).toBe(true);
   });
 
+  it("expires revoked-agent markers after TTL and prunes them on lookup", async () => {
+    const { proxyTrustState, harness } = createProxyTrustState();
+    const agentDid =
+      "did:cdi:dev.registry.clawdentity.com:agent:01HF7YAT00EXEKCZ140TBBFB97";
+
+    const markResponse = await proxyTrustState.fetch(
+      makeRequest(TRUST_STORE_ROUTES.markAgentRevoked, {
+        agentDid,
+        nowMs: 10_000,
+        ttlMs: 1_000,
+      }),
+    );
+    expect(markResponse.status).toBe(200);
+
+    const activeResponse = await proxyTrustState.fetch(
+      makeRequest(TRUST_STORE_ROUTES.isAgentRevoked, {
+        agentDid,
+        nowMs: 10_500,
+      }),
+    );
+    expect(activeResponse.status).toBe(200);
+    expect((await activeResponse.json()) as { revoked: boolean }).toEqual({
+      revoked: true,
+    });
+
+    const expiredResponse = await proxyTrustState.fetch(
+      makeRequest(TRUST_STORE_ROUTES.isAgentRevoked, {
+        agentDid,
+        nowMs: 11_000,
+      }),
+    );
+    expect(expiredResponse.status).toBe(200);
+    expect((await expiredResponse.json()) as { revoked: boolean }).toEqual({
+      revoked: false,
+    });
+    expect(harness.values.get("trust:revoked-agents")).toEqual({});
+  });
+
   it("persists and answers known-agent checks via agent peer index", async () => {
     const { proxyTrustState, harness } = createProxyTrustState();
 

--- a/apps/proxy/src/proxy-trust-state/AGENTS.md
+++ b/apps/proxy/src/proxy-trust-state/AGENTS.md
@@ -21,7 +21,8 @@
 - Keep pair authorization symmetric using `toPairKey` + `addPeer` for both directions.
 - Keep revoked-agent overlays durable and idempotent:
   - `markAgentRevoked` must accept only valid agent DIDs and remain safe for duplicate events.
-  - `isAgentRevoked` must be a pure lookup with no side effects.
+  - `isAgentRevoked` may prune expired revoked markers but must remain side-effect-free for non-expired entries.
+  - revoked markers must have an explicit TTL lifecycle (not infinite growth) and cleanup must happen via lookup pruning plus alarm-driven storage cleanup.
 - Keep storage normalization defensive: ignore malformed persisted records instead of throwing.
 - Keep external API stable:
   - class name remains `ProxyTrustState`

--- a/apps/proxy/src/proxy-trust-state/AGENTS.md
+++ b/apps/proxy/src/proxy-trust-state/AGENTS.md
@@ -19,6 +19,9 @@
   - confirm/status delete expired entries before returning `410`
   - alarm cleanup removes expired pending/confirmed entries and re-schedules next alarm.
 - Keep pair authorization symmetric using `toPairKey` + `addPeer` for both directions.
+- Keep revoked-agent overlays durable and idempotent:
+  - `markAgentRevoked` must accept only valid agent DIDs and remain safe for duplicate events.
+  - `isAgentRevoked` must be a pure lookup with no side effects.
 - Keep storage normalization defensive: ignore malformed persisted records instead of throwing.
 - Keep external API stable:
   - class name remains `ProxyTrustState`

--- a/apps/proxy/src/proxy-trust-state/controller.ts
+++ b/apps/proxy/src/proxy-trust-state/controller.ts
@@ -31,6 +31,14 @@ export class ProxyTrustState {
       return this.handlers.handleGetPairingTicketStatus(request);
     }
 
+    if (url.pathname === TRUST_STORE_ROUTES.markAgentRevoked) {
+      return this.handlers.handleMarkAgentRevoked(request);
+    }
+
+    if (url.pathname === TRUST_STORE_ROUTES.isAgentRevoked) {
+      return this.handlers.handleIsAgentRevoked(request);
+    }
+
     if (url.pathname === TRUST_STORE_ROUTES.upsertPair) {
       return this.handlers.handleUpsertPair(request);
     }

--- a/apps/proxy/src/proxy-trust-state/handlers.ts
+++ b/apps/proxy/src/proxy-trust-state/handlers.ts
@@ -444,6 +444,67 @@ export class ProxyTrustStateHandlers {
     });
   }
 
+  async handleMarkAgentRevoked(request: Request): Promise<Response> {
+    const body = (await parseBody(request)) as
+      | { agentDid?: unknown }
+      | undefined;
+    if (!body || !isNonEmptyString(body.agentDid)) {
+      return toErrorResponse({
+        code: "PROXY_AGENT_REVOKE_INVALID_BODY",
+        message: "Agent revoke input is invalid",
+        status: 400,
+      });
+    }
+
+    try {
+      const parsedAgentDid = parseDid(body.agentDid);
+      if (parsedAgentDid.entity !== "agent") {
+        throw new Error("invalid kind");
+      }
+    } catch {
+      return toErrorResponse({
+        code: "PROXY_AGENT_REVOKE_INVALID_BODY",
+        message: "Agent revoke input is invalid",
+        status: 400,
+      });
+    }
+
+    const revokedAgents = await this.storage.loadRevokedAgents();
+    revokedAgents.add(body.agentDid);
+    await this.storage.saveRevokedAgents(revokedAgents);
+
+    return Response.json({ ok: true });
+  }
+
+  async handleIsAgentRevoked(request: Request): Promise<Response> {
+    const body = (await parseBody(request)) as
+      | { agentDid?: unknown }
+      | undefined;
+    if (!body || !isNonEmptyString(body.agentDid)) {
+      return toErrorResponse({
+        code: "PROXY_AGENT_REVOKED_CHECK_INVALID_BODY",
+        message: "Agent revoked check input is invalid",
+        status: 400,
+      });
+    }
+
+    try {
+      const parsedAgentDid = parseDid(body.agentDid);
+      if (parsedAgentDid.entity !== "agent") {
+        throw new Error("invalid kind");
+      }
+    } catch {
+      return toErrorResponse({
+        code: "PROXY_AGENT_REVOKED_CHECK_INVALID_BODY",
+        message: "Agent revoked check input is invalid",
+        status: 400,
+      });
+    }
+
+    const revokedAgents = await this.storage.loadRevokedAgents();
+    return Response.json({ revoked: revokedAgents.has(body.agentDid) });
+  }
+
   async handleIsAgentKnown(request: Request): Promise<Response> {
     const body = (await parseBody(request)) as
       | { agentDid?: unknown }

--- a/apps/proxy/src/proxy-trust-state/handlers.ts
+++ b/apps/proxy/src/proxy-trust-state/handlers.ts
@@ -1,4 +1,4 @@
-import { parseDid } from "@clawdentity/protocol";
+import { parseAgentDid } from "@clawdentity/protocol";
 import { nowUtcMs } from "@clawdentity/sdk";
 import { verifyPairingTicketSignature } from "../pairing-ticket.js";
 import {
@@ -10,6 +10,7 @@ import type {
   PairingTicketInput,
   PairingTicketStatusInput,
 } from "../proxy-trust-store.js";
+import { REVOKED_AGENT_MARKER_TTL_MS } from "../proxy-trust-store.js";
 import type { ProxyTrustStateStorage } from "./storage.js";
 import {
   addPeer,
@@ -61,10 +62,7 @@ export class ProxyTrustStateHandlers {
         });
       }
       try {
-        const parsedResponderDid = parseDid(body.allowResponderAgentDid.trim());
-        if (parsedResponderDid.entity !== "agent") {
-          throw new Error("invalid kind");
-        }
+        parseAgentDid(body.allowResponderAgentDid.trim());
       } catch {
         return toErrorResponse({
           code: "PROXY_PAIR_START_INVALID_BODY",
@@ -446,7 +444,7 @@ export class ProxyTrustStateHandlers {
 
   async handleMarkAgentRevoked(request: Request): Promise<Response> {
     const body = (await parseBody(request)) as
-      | { agentDid?: unknown }
+      | { agentDid?: unknown; nowMs?: unknown; ttlMs?: unknown }
       | undefined;
     if (!body || !isNonEmptyString(body.agentDid)) {
       return toErrorResponse({
@@ -456,11 +454,9 @@ export class ProxyTrustStateHandlers {
       });
     }
 
+    const agentDid = body.agentDid.trim();
     try {
-      const parsedAgentDid = parseDid(body.agentDid);
-      if (parsedAgentDid.entity !== "agent") {
-        throw new Error("invalid kind");
-      }
+      parseAgentDid(agentDid);
     } catch {
       return toErrorResponse({
         code: "PROXY_AGENT_REVOKE_INVALID_BODY",
@@ -469,16 +465,53 @@ export class ProxyTrustStateHandlers {
       });
     }
 
+    if (
+      body.nowMs !== undefined &&
+      (typeof body.nowMs !== "number" ||
+        !Number.isInteger(body.nowMs) ||
+        body.nowMs <= 0)
+    ) {
+      return toErrorResponse({
+        code: "PROXY_AGENT_REVOKE_INVALID_BODY",
+        message: "Agent revoke input is invalid",
+        status: 400,
+      });
+    }
+    if (
+      body.ttlMs !== undefined &&
+      (typeof body.ttlMs !== "number" ||
+        !Number.isInteger(body.ttlMs) ||
+        body.ttlMs <= 0)
+    ) {
+      return toErrorResponse({
+        code: "PROXY_AGENT_REVOKE_INVALID_BODY",
+        message: "Agent revoke input is invalid",
+        status: 400,
+      });
+    }
+
+    const nowMs = body.nowMs ?? nowUtcMs();
+    const ttlMs = body.ttlMs ?? REVOKED_AGENT_MARKER_TTL_MS;
+    const expiresAtMs = nowMs + ttlMs;
+    if (!Number.isSafeInteger(expiresAtMs) || expiresAtMs <= nowMs) {
+      return toErrorResponse({
+        code: "PROXY_AGENT_REVOKE_INVALID_BODY",
+        message: "Agent revoke input is invalid",
+        status: 400,
+      });
+    }
+
     const revokedAgents = await this.storage.loadRevokedAgents();
-    revokedAgents.add(body.agentDid);
-    await this.storage.saveRevokedAgents(revokedAgents);
+    this.storage.pruneExpiredRevokedAgents(revokedAgents, nowMs);
+    revokedAgents[agentDid] = { expiresAtMs };
+    await this.storage.saveRevokedAgentsAndSchedule(revokedAgents);
 
     return Response.json({ ok: true });
   }
 
   async handleIsAgentRevoked(request: Request): Promise<Response> {
     const body = (await parseBody(request)) as
-      | { agentDid?: unknown }
+      | { agentDid?: unknown; nowMs?: unknown }
       | undefined;
     if (!body || !isNonEmptyString(body.agentDid)) {
       return toErrorResponse({
@@ -488,11 +521,9 @@ export class ProxyTrustStateHandlers {
       });
     }
 
+    const agentDid = body.agentDid.trim();
     try {
-      const parsedAgentDid = parseDid(body.agentDid);
-      if (parsedAgentDid.entity !== "agent") {
-        throw new Error("invalid kind");
-      }
+      parseAgentDid(agentDid);
     } catch {
       return toErrorResponse({
         code: "PROXY_AGENT_REVOKED_CHECK_INVALID_BODY",
@@ -501,8 +532,29 @@ export class ProxyTrustStateHandlers {
       });
     }
 
+    if (
+      body.nowMs !== undefined &&
+      (typeof body.nowMs !== "number" ||
+        !Number.isInteger(body.nowMs) ||
+        body.nowMs <= 0)
+    ) {
+      return toErrorResponse({
+        code: "PROXY_AGENT_REVOKED_CHECK_INVALID_BODY",
+        message: "Agent revoked check input is invalid",
+        status: 400,
+      });
+    }
+
+    const nowMs = body.nowMs ?? nowUtcMs();
     const revokedAgents = await this.storage.loadRevokedAgents();
-    return Response.json({ revoked: revokedAgents.has(body.agentDid) });
+    const pruned = this.storage.pruneExpiredRevokedAgents(revokedAgents, nowMs);
+    if (pruned) {
+      await this.storage.saveRevokedAgentsAndSchedule(revokedAgents);
+    }
+
+    return Response.json({
+      revoked: (revokedAgents[agentDid]?.expiresAtMs ?? 0) > nowMs,
+    });
   }
 
   async handleIsAgentKnown(request: Request): Promise<Response> {

--- a/apps/proxy/src/proxy-trust-state/storage.ts
+++ b/apps/proxy/src/proxy-trust-state/storage.ts
@@ -5,6 +5,7 @@ import type {
   ExpirableStateSaveOptions,
   ExpirableTrustState,
   PairingTicketMap,
+  RevokedAgentMap,
 } from "./types.js";
 import {
   AGENT_PEERS_STORAGE_KEY,
@@ -46,18 +47,34 @@ export class ProxyTrustStateStorage {
   }
 
   async runAlarmCleanup(nowMs: number): Promise<void> {
-    const expirableState = await this.loadExpirableState();
-    const mutated = this.removeExpiredEntries(expirableState, nowMs);
-    if (mutated) {
-      await this.saveExpirableState(expirableState, {
-        pairingTickets: true,
-        confirmedPairingTickets: true,
-      });
+    const [expirableState, revokedAgents] = await Promise.all([
+      this.loadExpirableState(),
+      this.loadRevokedAgents(),
+    ]);
+    const expirableMutated = this.removeExpiredEntries(expirableState, nowMs);
+    const revokedMutated = this.pruneExpiredRevokedAgents(revokedAgents, nowMs);
+
+    const saves: Promise<void>[] = [];
+    if (expirableMutated) {
+      saves.push(
+        this.saveExpirableState(expirableState, {
+          pairingTickets: true,
+          confirmedPairingTickets: true,
+        }),
+      );
+    }
+    if (revokedMutated) {
+      saves.push(this.saveRevokedAgents(revokedAgents));
+    }
+
+    if (saves.length > 0) {
+      await Promise.all(saves);
     }
 
     await this.scheduleNextCodeCleanup(
       expirableState.pairingTickets,
       expirableState.confirmedPairingTickets,
+      revokedAgents,
     );
   }
 
@@ -75,9 +92,11 @@ export class ProxyTrustStateStorage {
     options: ExpirableStateSaveOptions,
   ): Promise<void> {
     await this.saveExpirableState(state, options);
+    const revokedAgents = await this.loadRevokedAgents();
     await this.scheduleNextCodeCleanup(
       state.pairingTickets,
       state.confirmedPairingTickets,
+      revokedAgents,
     );
   }
 
@@ -121,25 +140,81 @@ export class ProxyTrustStateStorage {
     await this.state.storage.put(AGENT_PEERS_STORAGE_KEY, agentPeers);
   }
 
-  async loadRevokedAgents(): Promise<Set<string>> {
-    const raw = await this.state.storage.get<string[]>(
+  async loadRevokedAgents(): Promise<RevokedAgentMap> {
+    const raw = await this.state.storage.get<unknown>(
       REVOKED_AGENTS_STORAGE_KEY,
     );
-    if (!Array.isArray(raw)) {
-      return new Set<string>();
+    if (Array.isArray(raw)) {
+      const migrated: RevokedAgentMap = {};
+      for (const value of raw) {
+        if (!isNonEmptyString(value)) {
+          continue;
+        }
+        migrated[value] = {
+          expiresAtMs: Number.MAX_SAFE_INTEGER,
+        };
+      }
+      return migrated;
     }
 
-    const normalized = raw.filter((value): value is string =>
-      isNonEmptyString(value),
-    );
-    return new Set(normalized);
+    if (typeof raw !== "object" || raw === null) {
+      return {};
+    }
+
+    const normalized: RevokedAgentMap = {};
+    for (const [agentDid, details] of Object.entries(raw)) {
+      if (
+        typeof details !== "object" ||
+        details === null ||
+        !isNonEmptyString(agentDid)
+      ) {
+        continue;
+      }
+
+      const expiresAtMs = (details as { expiresAtMs?: unknown }).expiresAtMs;
+      if (
+        typeof expiresAtMs !== "number" ||
+        !Number.isInteger(expiresAtMs) ||
+        expiresAtMs <= 0
+      ) {
+        continue;
+      }
+
+      normalized[agentDid] = { expiresAtMs };
+    }
+
+    return normalized;
   }
 
-  async saveRevokedAgents(revokedAgents: Set<string>): Promise<void> {
-    await this.state.storage.put(
-      REVOKED_AGENTS_STORAGE_KEY,
-      [...revokedAgents].sort(),
+  async saveRevokedAgents(revokedAgents: RevokedAgentMap): Promise<void> {
+    await this.state.storage.put(REVOKED_AGENTS_STORAGE_KEY, revokedAgents);
+  }
+
+  async saveRevokedAgentsAndSchedule(
+    revokedAgents: RevokedAgentMap,
+  ): Promise<void> {
+    await this.saveRevokedAgents(revokedAgents);
+    const expirableState = await this.loadExpirableState();
+    await this.scheduleNextCodeCleanup(
+      expirableState.pairingTickets,
+      expirableState.confirmedPairingTickets,
+      revokedAgents,
     );
+  }
+
+  pruneExpiredRevokedAgents(
+    revokedAgents: RevokedAgentMap,
+    nowMs: number,
+  ): boolean {
+    let mutated = false;
+    for (const [agentDid, details] of Object.entries(revokedAgents)) {
+      if (details.expiresAtMs <= nowMs) {
+        delete revokedAgents[agentDid];
+        mutated = true;
+      }
+    }
+
+    return mutated;
   }
 
   private removeExpiredEntries(
@@ -359,10 +434,12 @@ export class ProxyTrustStateStorage {
   private async scheduleNextCodeCleanup(
     pairingTickets: PairingTicketMap,
     confirmedPairingTickets: ConfirmedPairingTicketMap,
+    revokedAgents: RevokedAgentMap,
   ): Promise<void> {
     const expiryValues = [
       ...Object.values(pairingTickets),
       ...Object.values(confirmedPairingTickets),
+      ...Object.values(revokedAgents),
     ].map((details) => details.expiresAtMs);
 
     if (expiryValues.length === 0) {

--- a/apps/proxy/src/proxy-trust-state/storage.ts
+++ b/apps/proxy/src/proxy-trust-state/storage.ts
@@ -11,6 +11,7 @@ import {
   CONFIRMED_PAIRING_TICKETS_STORAGE_KEY,
   PAIRING_TICKETS_STORAGE_KEY,
   PAIRS_STORAGE_KEY,
+  REVOKED_AGENTS_STORAGE_KEY,
 } from "./types.js";
 import { isNonEmptyString, parsePeerProfile } from "./utils.js";
 
@@ -118,6 +119,27 @@ export class ProxyTrustStateStorage {
 
   async saveAgentPeers(agentPeers: AgentPeersIndex): Promise<void> {
     await this.state.storage.put(AGENT_PEERS_STORAGE_KEY, agentPeers);
+  }
+
+  async loadRevokedAgents(): Promise<Set<string>> {
+    const raw = await this.state.storage.get<string[]>(
+      REVOKED_AGENTS_STORAGE_KEY,
+    );
+    if (!Array.isArray(raw)) {
+      return new Set<string>();
+    }
+
+    const normalized = raw.filter((value): value is string =>
+      isNonEmptyString(value),
+    );
+    return new Set(normalized);
+  }
+
+  async saveRevokedAgents(revokedAgents: Set<string>): Promise<void> {
+    await this.state.storage.put(
+      REVOKED_AGENTS_STORAGE_KEY,
+      [...revokedAgents].sort(),
+    );
   }
 
   private removeExpiredEntries(

--- a/apps/proxy/src/proxy-trust-state/types.ts
+++ b/apps/proxy/src/proxy-trust-state/types.ts
@@ -29,6 +29,12 @@ export type ConfirmedPairingTicketMap = Record<
   StoredConfirmedPairingTicket
 >;
 export type AgentPeersIndex = Record<string, string[]>;
+export type RevokedAgentMap = Record<
+  string,
+  {
+    expiresAtMs: number;
+  }
+>;
 
 export type ExpirableTrustState = {
   pairingTickets: PairingTicketMap;

--- a/apps/proxy/src/proxy-trust-state/types.ts
+++ b/apps/proxy/src/proxy-trust-state/types.ts
@@ -42,6 +42,7 @@ export type ExpirableStateSaveOptions = {
 
 export const PAIRS_STORAGE_KEY = "trust:pairs";
 export const AGENT_PEERS_STORAGE_KEY = "trust:agent-peers";
+export const REVOKED_AGENTS_STORAGE_KEY = "trust:revoked-agents";
 export const PAIRING_TICKETS_STORAGE_KEY = "trust:pairing-tickets";
 export const CONFIRMED_PAIRING_TICKETS_STORAGE_KEY =
   "trust:pairing-tickets-confirmed";

--- a/apps/proxy/src/proxy-trust-store.test.ts
+++ b/apps/proxy/src/proxy-trust-store.test.ts
@@ -1,10 +1,13 @@
 import { decodeBase64url, encodeBase64url } from "@clawdentity/protocol";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   createPairingTicket,
   createPairingTicketSigningKey,
 } from "./pairing-ticket.js";
-import { createInMemoryProxyTrustStore } from "./proxy-trust-store.js";
+import {
+  createInMemoryProxyTrustStore,
+  REVOKED_AGENT_MARKER_TTL_MS,
+} from "./proxy-trust-store.js";
 
 const INITIATOR_PROFILE = {
   agentName: "alpha",
@@ -142,6 +145,25 @@ describe("in-memory proxy trust store", () => {
     expect(await store.isAgentRevoked(revokedAgentDid)).toBe(false);
     await store.markAgentRevoked(revokedAgentDid);
     expect(await store.isAgentRevoked(revokedAgentDid)).toBe(true);
+  });
+
+  it("expires revoked-agent overlays after TTL", async () => {
+    vi.useFakeTimers();
+    try {
+      const now = new Date("2026-01-01T00:00:00.000Z");
+      vi.setSystemTime(now);
+      const store = createInMemoryProxyTrustStore();
+      const revokedAgentDid =
+        "did:cdi:dev.registry.clawdentity.com:agent:01HF7YAT00EXEKCZ140TBBFB97";
+
+      await store.markAgentRevoked(revokedAgentDid);
+      expect(await store.isAgentRevoked(revokedAgentDid)).toBe(true);
+
+      vi.setSystemTime(now.getTime() + REVOKED_AGENT_MARKER_TTL_MS + 1);
+      expect(await store.isAgentRevoked(revokedAgentDid)).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("confirms one-time pairing tickets and establishes trust", async () => {

--- a/apps/proxy/src/proxy-trust-store.test.ts
+++ b/apps/proxy/src/proxy-trust-store.test.ts
@@ -134,6 +134,16 @@ describe("in-memory proxy trust store", () => {
     ).toBe(false);
   });
 
+  it("marks and checks revoked agents", async () => {
+    const store = createInMemoryProxyTrustStore();
+    const revokedAgentDid =
+      "did:cdi:dev.registry.clawdentity.com:agent:01HF7YAT00EXEKCZ140TBBFB97";
+
+    expect(await store.isAgentRevoked(revokedAgentDid)).toBe(false);
+    await store.markAgentRevoked(revokedAgentDid);
+    expect(await store.isAgentRevoked(revokedAgentDid)).toBe(true);
+  });
+
   it("confirms one-time pairing tickets and establishes trust", async () => {
     const store = createInMemoryProxyTrustStore();
     const created = await createSignedTicket({

--- a/apps/proxy/src/proxy-trust-store.ts
+++ b/apps/proxy/src/proxy-trust-store.ts
@@ -83,6 +83,9 @@ export type PairingInput = {
   responderAgentDid: string;
 };
 
+// Keep revoked-agent overlays bounded while preserving enough time for CRL refresh fallback.
+export const REVOKED_AGENT_MARKER_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+
 export interface ProxyTrustStore {
   createPairingTicket(input: PairingTicketInput): Promise<PairingTicketResult>;
   confirmPairingTicket(
@@ -268,7 +271,7 @@ export function createDurableProxyTrustStore(
 export function createInMemoryProxyTrustStore(): ProxyTrustStore {
   const pairKeys = new Set<string>();
   const agentPeers = new Map<string, Set<string>>();
-  const revokedAgents = new Set<string>();
+  const revokedAgents = new Map<string, number>();
   const confirmedPairingTickets = new Map<
     string,
     {
@@ -314,6 +317,12 @@ export function createInMemoryProxyTrustStore(): ProxyTrustStore {
 
       if (details.expiresAtMs <= nowMs) {
         confirmedPairingTickets.delete(ticketKid);
+      }
+    }
+
+    for (const [agentDid, expiresAtMs] of revokedAgents.entries()) {
+      if (expiresAtMs <= nowMs) {
+        revokedAgents.delete(agentDid);
       }
     }
   }
@@ -674,7 +683,9 @@ export function createInMemoryProxyTrustStore(): ProxyTrustStore {
         });
       }
 
-      revokedAgents.add(agentDid);
+      const nowMs = nowUtcMs();
+      cleanup(nowMs);
+      revokedAgents.set(agentDid, nowMs + REVOKED_AGENT_MARKER_TTL_MS);
     },
     async isAgentRevoked(agentDid) {
       try {
@@ -687,7 +698,10 @@ export function createInMemoryProxyTrustStore(): ProxyTrustStore {
         });
       }
 
-      return revokedAgents.has(agentDid);
+      const nowMs = nowUtcMs();
+      cleanup(nowMs);
+      const expiresAtMs = revokedAgents.get(agentDid);
+      return typeof expiresAtMs === "number" && expiresAtMs > nowMs;
     },
     async isAgentKnown(agentDid) {
       return (agentPeers.get(agentDid)?.size ?? 0) > 0;

--- a/apps/proxy/src/proxy-trust-store.ts
+++ b/apps/proxy/src/proxy-trust-store.ts
@@ -91,6 +91,8 @@ export interface ProxyTrustStore {
   getPairingTicketStatus(
     input: PairingTicketStatusInput,
   ): Promise<PairingTicketStatusResult>;
+  markAgentRevoked(agentDid: string): Promise<void>;
+  isAgentRevoked(agentDid: string): Promise<boolean>;
   isAgentKnown(agentDid: string): Promise<boolean>;
   isPairAllowed(input: PairingInput): Promise<boolean>;
   upsertPair(input: PairingInput): Promise<void>;
@@ -121,6 +123,8 @@ export const TRUST_STORE_ROUTES = {
   createPairingTicket: "/pairing-tickets/create",
   confirmPairingTicket: "/pairing-tickets/confirm",
   getPairingTicketStatus: "/pairing-tickets/status",
+  markAgentRevoked: "/agents/revoked/mark",
+  isAgentRevoked: "/agents/revoked/check",
   isAgentKnown: "/agents/known",
   isPairAllowed: "/pairs/check",
   upsertPair: "/pairs/upsert",
@@ -220,6 +224,21 @@ export function createDurableProxyTrustStore(
         { ...input, ticket },
       );
     },
+    async markAgentRevoked(agentDid) {
+      await callDurableState<{ ok: true }>(
+        namespace,
+        TRUST_STORE_ROUTES.markAgentRevoked,
+        { agentDid },
+      );
+    },
+    async isAgentRevoked(agentDid) {
+      const result = await callDurableState<{ revoked: boolean }>(
+        namespace,
+        TRUST_STORE_ROUTES.isAgentRevoked,
+        { agentDid },
+      );
+      return result.revoked;
+    },
     async isAgentKnown(agentDid) {
       const result = await callDurableState<{ known: boolean }>(
         namespace,
@@ -249,6 +268,7 @@ export function createDurableProxyTrustStore(
 export function createInMemoryProxyTrustStore(): ProxyTrustStore {
   const pairKeys = new Set<string>();
   const agentPeers = new Map<string, Set<string>>();
+  const revokedAgents = new Set<string>();
   const confirmedPairingTickets = new Map<
     string,
     {
@@ -642,6 +662,32 @@ export function createInMemoryProxyTrustStore(): ProxyTrustStore {
     },
     async getPairingTicketStatus(input) {
       return resolveTicketStatus(input);
+    },
+    async markAgentRevoked(agentDid) {
+      try {
+        parseAgentDid(agentDid);
+      } catch {
+        throw new ProxyTrustStoreError({
+          code: "PROXY_AGENT_REVOKE_INVALID_BODY",
+          message: "Agent revoke input is invalid",
+          status: 400,
+        });
+      }
+
+      revokedAgents.add(agentDid);
+    },
+    async isAgentRevoked(agentDid) {
+      try {
+        parseAgentDid(agentDid);
+      } catch {
+        throw new ProxyTrustStoreError({
+          code: "PROXY_AGENT_REVOKED_CHECK_INVALID_BODY",
+          message: "Agent revoked check input is invalid",
+          status: 400,
+        });
+      }
+
+      return revokedAgents.has(agentDid);
     },
     async isAgentKnown(agentDid) {
       return (agentPeers.get(agentDid)?.size ?? 0) > 0;

--- a/apps/proxy/src/queue-consumer/AGENTS.md
+++ b/apps/proxy/src/queue-consumer/AGENTS.md
@@ -7,6 +7,8 @@
 - Parse queue payloads with explicit field validation; reject malformed messages early so retries/DLQ behavior is intentional.
 - Keep each event handler focused by event type and route only supported events; add dedicated handlers before subscribing this worker to new queue event families.
 - Route `delivery_receipt` events to the sender relay Durable Object using typed RPC helpers (`recordRelayDeliveryReceipt`) rather than ad-hoc `fetch` payload strings.
+- Route `agent.auth.revoked` events to proxy trust-state via typed trust-store methods (`markAgentRevoked`) rather than bespoke DO endpoint strings.
 - Treat queue events as at-least-once: handlers must be idempotent against duplicate messages.
 - Keep the `delivery_receipt` queue contract minimal (sender/recipient/request/status/reason/timestamp) and avoid carrying callback-origin metadata that is not consumed by handlers.
-- Keep queue acknowledgment policy explicit: unsupported/invalid events are `ack` + warn; reserve `retry` for transient delivery failures only.
+- Keep registry revocation queue handling strict: only hard revokes (`data.reason=agent_revoked`) with valid `data.metadata.agentDid` may mutate trust state.
+- Keep queue acknowledgment policy explicit: unsupported/invalid events are `ack` + warn; reserve `retry` for transient delivery or trust-state dependency failures only.

--- a/apps/proxy/src/queue-consumer/AGENTS.md
+++ b/apps/proxy/src/queue-consumer/AGENTS.md
@@ -11,4 +11,6 @@
 - Treat queue events as at-least-once: handlers must be idempotent against duplicate messages.
 - Keep the `delivery_receipt` queue contract minimal (sender/recipient/request/status/reason/timestamp) and avoid carrying callback-origin metadata that is not consumed by handlers.
 - Keep registry revocation queue handling strict: only hard revokes (`data.reason=agent_revoked`) with valid `data.metadata.agentDid` may mutate trust state.
+- Parse and normalize revoked `agentDid` once per queue message, then pass the normalized value through handler layers without re-validating it in the same flow.
 - Keep queue acknowledgment policy explicit: unsupported/invalid events are `ack` + warn; reserve `retry` for transient delivery or trust-state dependency failures only.
+- Missing queue bindings (for example `PROXY_TRUST_STATE` for `agent.auth.revoked`) must be handled as explicit non-retryable `ack` failures with a dedicated reason code, not through generic retry fallback.

--- a/apps/proxy/src/queue-consumer/registry-events.test.ts
+++ b/apps/proxy/src/queue-consumer/registry-events.test.ts
@@ -24,7 +24,10 @@ describe("registry revocation queue events", () => {
     });
 
     expect(event).not.toBeNull();
-    expect(event?.type).toBe(AGENT_AUTH_REVOKED_EVENT_TYPE);
+    expect(event?.event.type).toBe(AGENT_AUTH_REVOKED_EVENT_TYPE);
+    expect(event?.agentDid).toBe(
+      "did:cdi:registry.clawdentity.dev:agent:01HF7YAT31JZHSMW1CG6Q6MHB7",
+    );
   });
 
   it("ignores revoked events that are not hard agent revokes", () => {
@@ -95,7 +98,7 @@ describe("registry revocation queue events", () => {
     }
 
     await handleRegistryRevocationEvent({
-      event,
+      agentDid: event.agentDid,
       trustStateNamespace,
     });
 

--- a/apps/proxy/src/queue-consumer/registry-events.test.ts
+++ b/apps/proxy/src/queue-consumer/registry-events.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  AGENT_AUTH_REVOKED_EVENT_TYPE,
+  handleRegistryRevocationEvent,
+  parseRegistryRevocationEvent,
+} from "./registry-events.js";
+
+describe("registry revocation queue events", () => {
+  it("parses hard-revoke events with metadata agent DID", () => {
+    const event = parseRegistryRevocationEvent({
+      type: AGENT_AUTH_REVOKED_EVENT_TYPE,
+      id: "evt-1",
+      version: "v1",
+      timestampUtc: "2026-03-27T00:00:00.000Z",
+      initiatedByAccountId:
+        "did:cdi:dev.registry.clawdentity.com:human:01HF7YAT00W6W7CM7N3W5FDXT4",
+      data: {
+        reason: "agent_revoked",
+        metadata: {
+          agentDid:
+            "did:cdi:registry.clawdentity.dev:agent:01HF7YAT31JZHSMW1CG6Q6MHB7",
+        },
+      },
+    });
+
+    expect(event).not.toBeNull();
+    expect(event?.type).toBe(AGENT_AUTH_REVOKED_EVENT_TYPE);
+  });
+
+  it("ignores revoked events that are not hard agent revokes", () => {
+    const event = parseRegistryRevocationEvent({
+      type: AGENT_AUTH_REVOKED_EVENT_TYPE,
+      id: "evt-2",
+      version: "v1",
+      timestampUtc: "2026-03-27T00:00:00.000Z",
+      initiatedByAccountId:
+        "did:cdi:dev.registry.clawdentity.com:human:01HF7YAT00W6W7CM7N3W5FDXT4",
+      data: {
+        reason: "owner_auth_revoke",
+        metadata: {
+          agentDid:
+            "did:cdi:registry.clawdentity.dev:agent:01HF7YAT31JZHSMW1CG6Q6MHB7",
+        },
+      },
+    });
+
+    expect(event).toBeNull();
+  });
+
+  it("rejects malformed hard-revoke events", () => {
+    expect(() =>
+      parseRegistryRevocationEvent({
+        type: AGENT_AUTH_REVOKED_EVENT_TYPE,
+        id: "evt-3",
+        version: "v1",
+        timestampUtc: "2026-03-27T00:00:00.000Z",
+        initiatedByAccountId:
+          "did:cdi:dev.registry.clawdentity.com:human:01HF7YAT00W6W7CM7N3W5FDXT4",
+        data: {
+          reason: "agent_revoked",
+          metadata: {},
+        },
+      }),
+    ).toThrow("metadata must include a non-empty agentDid");
+  });
+
+  it("routes hard revoke marker to trust-state durable object", async () => {
+    const fetchSpy = vi.fn(async (_request: Request) =>
+      Response.json({ ok: true }, { status: 200 }),
+    );
+    const trustStateNamespace = {
+      idFromName: vi.fn((name: string) => name as unknown as DurableObjectId),
+      get: vi.fn(() => ({
+        fetch: fetchSpy,
+      })),
+    };
+
+    const event = parseRegistryRevocationEvent({
+      type: AGENT_AUTH_REVOKED_EVENT_TYPE,
+      id: "evt-4",
+      version: "v1",
+      timestampUtc: "2026-03-27T00:00:00.000Z",
+      initiatedByAccountId:
+        "did:cdi:dev.registry.clawdentity.com:human:01HF7YAT00W6W7CM7N3W5FDXT4",
+      data: {
+        reason: "agent_revoked",
+        metadata: {
+          agentDid:
+            "did:cdi:registry.clawdentity.dev:agent:01HF7YAT31JZHSMW1CG6Q6MHB7",
+        },
+      },
+    });
+    if (event === null) {
+      throw new Error("Expected revocation event to parse");
+    }
+
+    await handleRegistryRevocationEvent({
+      event,
+      trustStateNamespace,
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const request = fetchSpy.mock.calls[0]?.[0] as Request;
+    expect(new URL(request.url).pathname).toBe("/agents/revoked/mark");
+    expect((await request.json()) as { agentDid?: string }).toEqual({
+      agentDid:
+        "did:cdi:registry.clawdentity.dev:agent:01HF7YAT31JZHSMW1CG6Q6MHB7",
+    });
+  });
+});

--- a/apps/proxy/src/queue-consumer/registry-events.ts
+++ b/apps/proxy/src/queue-consumer/registry-events.ts
@@ -1,0 +1,77 @@
+import { parseAgentDid } from "@clawdentity/protocol";
+import type { EventEnvelope } from "@clawdentity/sdk";
+import {
+  createDurableProxyTrustStore,
+  type ProxyTrustStateNamespace,
+} from "../proxy-trust-store.js";
+
+export const AGENT_AUTH_REVOKED_EVENT_TYPE = "agent.auth.revoked";
+const AGENT_REVOKED_REASON = "agent_revoked";
+
+type RegistryRevocationEventData = {
+  reason?: unknown;
+  metadata?: unknown;
+};
+
+export type RegistryRevocationEvent =
+  EventEnvelope<RegistryRevocationEventData>;
+
+function parseRegistryRevocationMetadataAgentDid(metadata: unknown): string {
+  if (typeof metadata !== "object" || metadata === null) {
+    throw new Error("Registry revocation event metadata must be an object");
+  }
+
+  const agentDid = (metadata as { agentDid?: unknown }).agentDid;
+  if (typeof agentDid !== "string" || agentDid.trim().length === 0) {
+    throw new Error(
+      "Registry revocation event metadata must include a non-empty agentDid",
+    );
+  }
+
+  const normalizedAgentDid = agentDid.trim();
+  parseAgentDid(normalizedAgentDid);
+  return normalizedAgentDid;
+}
+
+export function parseRegistryRevocationEvent(
+  payload: unknown,
+): RegistryRevocationEvent | null {
+  if (
+    typeof payload !== "object" ||
+    payload === null ||
+    Array.isArray(payload)
+  ) {
+    throw new Error("Registry event payload must be an object");
+  }
+
+  const event = payload as Partial<RegistryRevocationEvent>;
+  if (event.type !== AGENT_AUTH_REVOKED_EVENT_TYPE) {
+    throw new Error("Unsupported registry event type");
+  }
+
+  if (typeof event.data !== "object" || event.data === null) {
+    throw new Error("Registry event payload must include an object data field");
+  }
+
+  const reason = (event.data as { reason?: unknown }).reason;
+  if (reason !== AGENT_REVOKED_REASON) {
+    return null;
+  }
+
+  parseRegistryRevocationMetadataAgentDid(
+    (event.data as { metadata?: unknown }).metadata,
+  );
+
+  return event as RegistryRevocationEvent;
+}
+
+export async function handleRegistryRevocationEvent(input: {
+  event: RegistryRevocationEvent;
+  trustStateNamespace: ProxyTrustStateNamespace;
+}): Promise<void> {
+  const trustStore = createDurableProxyTrustStore(input.trustStateNamespace);
+  const agentDid = parseRegistryRevocationMetadataAgentDid(
+    input.event.data.metadata,
+  );
+  await trustStore.markAgentRevoked(agentDid);
+}

--- a/apps/proxy/src/queue-consumer/registry-events.ts
+++ b/apps/proxy/src/queue-consumer/registry-events.ts
@@ -1,12 +1,15 @@
-import { parseAgentDid } from "@clawdentity/protocol";
+import {
+  AGENT_AUTH_REVOKED_EVENT_TYPE,
+  AGENT_AUTH_REVOKED_REASON_AGENT_REVOKED,
+  parseAgentAuthRevokedMetadata,
+} from "@clawdentity/protocol";
 import type { EventEnvelope } from "@clawdentity/sdk";
 import {
   createDurableProxyTrustStore,
   type ProxyTrustStateNamespace,
 } from "../proxy-trust-store.js";
 
-export const AGENT_AUTH_REVOKED_EVENT_TYPE = "agent.auth.revoked";
-const AGENT_REVOKED_REASON = "agent_revoked";
+export { AGENT_AUTH_REVOKED_EVENT_TYPE };
 
 type RegistryRevocationEventData = {
   reason?: unknown;
@@ -16,26 +19,14 @@ type RegistryRevocationEventData = {
 export type RegistryRevocationEvent =
   EventEnvelope<RegistryRevocationEventData>;
 
-function parseRegistryRevocationMetadataAgentDid(metadata: unknown): string {
-  if (typeof metadata !== "object" || metadata === null) {
-    throw new Error("Registry revocation event metadata must be an object");
-  }
-
-  const agentDid = (metadata as { agentDid?: unknown }).agentDid;
-  if (typeof agentDid !== "string" || agentDid.trim().length === 0) {
-    throw new Error(
-      "Registry revocation event metadata must include a non-empty agentDid",
-    );
-  }
-
-  const normalizedAgentDid = agentDid.trim();
-  parseAgentDid(normalizedAgentDid);
-  return normalizedAgentDid;
-}
+export type ParsedRegistryRevocationEvent = {
+  event: RegistryRevocationEvent;
+  agentDid: string;
+};
 
 export function parseRegistryRevocationEvent(
   payload: unknown,
-): RegistryRevocationEvent | null {
+): ParsedRegistryRevocationEvent | null {
   if (
     typeof payload !== "object" ||
     payload === null ||
@@ -54,24 +45,24 @@ export function parseRegistryRevocationEvent(
   }
 
   const reason = (event.data as { reason?: unknown }).reason;
-  if (reason !== AGENT_REVOKED_REASON) {
+  if (reason !== AGENT_AUTH_REVOKED_REASON_AGENT_REVOKED) {
     return null;
   }
 
-  parseRegistryRevocationMetadataAgentDid(
+  const { agentDid } = parseAgentAuthRevokedMetadata(
     (event.data as { metadata?: unknown }).metadata,
   );
 
-  return event as RegistryRevocationEvent;
+  return {
+    event: event as RegistryRevocationEvent,
+    agentDid,
+  };
 }
 
 export async function handleRegistryRevocationEvent(input: {
-  event: RegistryRevocationEvent;
+  agentDid: string;
   trustStateNamespace: ProxyTrustStateNamespace;
 }): Promise<void> {
   const trustStore = createDurableProxyTrustStore(input.trustStateNamespace);
-  const agentDid = parseRegistryRevocationMetadataAgentDid(
-    input.event.data.metadata,
-  );
-  await trustStore.markAgentRevoked(agentDid);
+  await trustStore.markAgentRevoked(input.agentDid);
 }

--- a/apps/proxy/src/relay-delivery-receipt-route.test.ts
+++ b/apps/proxy/src/relay-delivery-receipt-route.test.ts
@@ -122,6 +122,8 @@ function createApp(input: {
     createPairingTicket: vi.fn(),
     confirmPairingTicket: vi.fn(),
     getPairingTicketStatus: vi.fn(),
+    markAgentRevoked: vi.fn(async () => {}),
+    isAgentRevoked: vi.fn(async () => false),
     isAgentKnown: vi.fn(async () => true),
     isPairAllowed: vi.fn(async (pair) =>
       input.allowedPairs.some(

--- a/apps/proxy/src/worker.test.ts
+++ b/apps/proxy/src/worker.test.ts
@@ -439,6 +439,40 @@ describe("proxy worker", () => {
     expect(retry).not.toHaveBeenCalled();
   });
 
+  it("acks revoked queue events when PROXY_TRUST_STATE is unavailable", async () => {
+    const bindings = createRequiredBindings();
+    const ack = vi.fn();
+    const retry = vi.fn();
+    const queueBatch = {
+      messages: [
+        {
+          body: JSON.stringify({
+            type: "agent.auth.revoked",
+            id: "evt-missing-trust-state",
+            version: "v1",
+            timestampUtc: "2026-03-27T00:00:00.000Z",
+            initiatedByAccountId:
+              "did:cdi:dev.registry.clawdentity.com:human:01HF7YAT00W6W7CM7N3W5FDXT4",
+            data: {
+              reason: "agent_revoked",
+              metadata: {
+                agentDid:
+                  "did:cdi:registry.clawdentity.dev:agent:01HF7YAT31JZHSMW1CG6Q6MHB7",
+              },
+            },
+          }),
+          ack,
+          retry,
+        },
+      ],
+    } as unknown as MessageBatch<string>;
+
+    await worker.queue(queueBatch, bindings);
+
+    expect(ack).toHaveBeenCalledTimes(1);
+    expect(retry).not.toHaveBeenCalled();
+  });
+
   it("acks revoked events with non-hard-revoke reason", async () => {
     const trustFetchSpy = vi.fn();
     const bindings = createRequiredBindings({

--- a/apps/proxy/src/worker.test.ts
+++ b/apps/proxy/src/worker.test.ts
@@ -17,6 +17,23 @@ function createTrustStateNamespace(): NonNullable<
   };
 }
 
+function createTrustStateNamespaceWithFetchSpy(
+  fetchSpy: ReturnType<typeof vi.fn>,
+): NonNullable<ProxyWorkerBindings["PROXY_TRUST_STATE"]> {
+  const invokeFetchSpy = fetchSpy as unknown as (
+    request: Request,
+  ) => Promise<Response>;
+  return {
+    idFromName: vi.fn(
+      (name: string) =>
+        ({ toString: () => name }) as unknown as DurableObjectId,
+    ),
+    get: vi.fn(() => ({
+      fetch: async (request: Request) => invokeFetchSpy(request),
+    })),
+  };
+}
+
 function createExecutionContext(): ExecutionContext {
   return {
     waitUntil: vi.fn(),
@@ -374,6 +391,172 @@ describe("proxy worker", () => {
     expect(fetchSpy).not.toHaveBeenCalled();
     expect(ack).toHaveBeenCalledTimes(1);
     expect(retry).not.toHaveBeenCalled();
+  });
+
+  it("marks revoked agent DID from registry queue events", async () => {
+    const trustFetchSpy = vi.fn(async (_request: Request) =>
+      Response.json({ ok: true }, { status: 200 }),
+    );
+    const bindings = createRequiredBindings({
+      PROXY_TRUST_STATE: createTrustStateNamespaceWithFetchSpy(trustFetchSpy),
+    });
+    const ack = vi.fn();
+    const retry = vi.fn();
+    const queueBatch = {
+      messages: [
+        {
+          body: JSON.stringify({
+            type: "agent.auth.revoked",
+            id: "evt-1",
+            version: "v1",
+            timestampUtc: "2026-03-27T00:00:00.000Z",
+            initiatedByAccountId:
+              "did:cdi:dev.registry.clawdentity.com:human:01HF7YAT00W6W7CM7N3W5FDXT4",
+            data: {
+              reason: "agent_revoked",
+              metadata: {
+                agentDid:
+                  "did:cdi:registry.clawdentity.dev:agent:01HF7YAT31JZHSMW1CG6Q6MHB7",
+              },
+            },
+          }),
+          ack,
+          retry,
+        },
+      ],
+    } as unknown as MessageBatch<string>;
+
+    await worker.queue(queueBatch, bindings);
+
+    expect(trustFetchSpy).toHaveBeenCalledTimes(1);
+    const request = trustFetchSpy.mock.calls[0]?.[0] as Request;
+    expect(new URL(request.url).pathname).toBe("/agents/revoked/mark");
+    expect((await request.json()) as { agentDid?: string }).toEqual({
+      agentDid:
+        "did:cdi:registry.clawdentity.dev:agent:01HF7YAT31JZHSMW1CG6Q6MHB7",
+    });
+    expect(ack).toHaveBeenCalledTimes(1);
+    expect(retry).not.toHaveBeenCalled();
+  });
+
+  it("acks revoked events with non-hard-revoke reason", async () => {
+    const trustFetchSpy = vi.fn();
+    const bindings = createRequiredBindings({
+      PROXY_TRUST_STATE: createTrustStateNamespaceWithFetchSpy(trustFetchSpy),
+    });
+    const ack = vi.fn();
+    const retry = vi.fn();
+    const queueBatch = {
+      messages: [
+        {
+          body: JSON.stringify({
+            type: "agent.auth.revoked",
+            id: "evt-2",
+            version: "v1",
+            timestampUtc: "2026-03-27T00:00:00.000Z",
+            initiatedByAccountId:
+              "did:cdi:dev.registry.clawdentity.com:human:01HF7YAT00W6W7CM7N3W5FDXT4",
+            data: {
+              reason: "owner_auth_revoke",
+              metadata: {
+                agentDid:
+                  "did:cdi:registry.clawdentity.dev:agent:01HF7YAT31JZHSMW1CG6Q6MHB7",
+              },
+            },
+          }),
+          ack,
+          retry,
+        },
+      ],
+    } as unknown as MessageBatch<string>;
+
+    await worker.queue(queueBatch, bindings);
+
+    expect(trustFetchSpy).not.toHaveBeenCalled();
+    expect(ack).toHaveBeenCalledTimes(1);
+    expect(retry).not.toHaveBeenCalled();
+  });
+
+  it("acks malformed revoked events without retrying", async () => {
+    const trustFetchSpy = vi.fn();
+    const bindings = createRequiredBindings({
+      PROXY_TRUST_STATE: createTrustStateNamespaceWithFetchSpy(trustFetchSpy),
+    });
+    const ack = vi.fn();
+    const retry = vi.fn();
+    const queueBatch = {
+      messages: [
+        {
+          body: JSON.stringify({
+            type: "agent.auth.revoked",
+            id: "evt-3",
+            version: "v1",
+            timestampUtc: "2026-03-27T00:00:00.000Z",
+            initiatedByAccountId:
+              "did:cdi:dev.registry.clawdentity.com:human:01HF7YAT00W6W7CM7N3W5FDXT4",
+            data: {
+              reason: "agent_revoked",
+            },
+          }),
+          ack,
+          retry,
+        },
+      ],
+    } as unknown as MessageBatch<string>;
+
+    await worker.queue(queueBatch, bindings);
+
+    expect(trustFetchSpy).not.toHaveBeenCalled();
+    expect(ack).toHaveBeenCalledTimes(1);
+    expect(retry).not.toHaveBeenCalled();
+  });
+
+  it("retries revoked events on transient trust-state failures", async () => {
+    const trustFetchSpy = vi.fn(async (_request: Request) =>
+      Response.json(
+        {
+          error: {
+            code: "PROXY_TRUST_STATE_UNAVAILABLE",
+            message: "Trust state unavailable",
+          },
+        },
+        { status: 503 },
+      ),
+    );
+    const bindings = createRequiredBindings({
+      PROXY_TRUST_STATE: createTrustStateNamespaceWithFetchSpy(trustFetchSpy),
+    });
+    const ack = vi.fn();
+    const retry = vi.fn();
+    const queueBatch = {
+      messages: [
+        {
+          body: JSON.stringify({
+            type: "agent.auth.revoked",
+            id: "evt-4",
+            version: "v1",
+            timestampUtc: "2026-03-27T00:00:00.000Z",
+            initiatedByAccountId:
+              "did:cdi:dev.registry.clawdentity.com:human:01HF7YAT00W6W7CM7N3W5FDXT4",
+            data: {
+              reason: "agent_revoked",
+              metadata: {
+                agentDid:
+                  "did:cdi:registry.clawdentity.dev:agent:01HF7YAT31JZHSMW1CG6Q6MHB7",
+              },
+            },
+          }),
+          ack,
+          retry,
+        },
+      ],
+    } as unknown as MessageBatch<string>;
+
+    await worker.queue(queueBatch, bindings);
+
+    expect(trustFetchSpy).toHaveBeenCalledTimes(1);
+    expect(ack).not.toHaveBeenCalled();
+    expect(retry).toHaveBeenCalledTimes(1);
   });
 
   it("retries delivery_receipt queue events on transient relay failures", async () => {

--- a/apps/proxy/src/worker.ts
+++ b/apps/proxy/src/worker.ts
@@ -81,6 +81,15 @@ class NonRetryableQueueError extends Error {
   }
 }
 
+class MissingQueueBindingError extends NonRetryableQueueError {
+  constructor(bindingName: string, eventType: string) {
+    super(
+      `Queue binding '${bindingName}' is unavailable for event type '${eventType}'`,
+    );
+    this.name = "MissingQueueBindingError";
+  }
+}
+
 function toCacheKey(env: ProxyWorkerBindings): string {
   const keyParts = [
     env.OPENCLAW_BASE_URL,
@@ -235,6 +244,10 @@ function resolveQueueFailureAction(error: unknown): {
   reasonCode: string;
 } {
   if (error instanceof NonRetryableQueueError) {
+    if (error instanceof MissingQueueBindingError) {
+      return { action: "ack", reasonCode: "missing_queue_binding" };
+    }
+
     return { action: "ack", reasonCode: "non_retryable_queue_error" };
   }
 
@@ -305,8 +318,9 @@ const worker = {
         if (event.type === DELIVERY_RECEIPT_EVENT_TYPE) {
           const relaySessionNamespace = env.AGENT_RELAY_SESSION;
           if (relaySessionNamespace === undefined) {
-            throw new NonRetryableQueueError(
-              "Relay session namespace is unavailable",
+            throw new MissingQueueBindingError(
+              "AGENT_RELAY_SESSION",
+              event.type,
             );
           }
 
@@ -323,7 +337,7 @@ const worker = {
         if (event.type === AGENT_AUTH_REVOKED_EVENT_TYPE) {
           const trustStateNamespace = env.PROXY_TRUST_STATE;
           if (trustStateNamespace === undefined) {
-            throw new Error("Proxy trust state namespace is unavailable");
+            throw new MissingQueueBindingError("PROXY_TRUST_STATE", event.type);
           }
 
           const parsedRevocationEvent = parseRegistryRevocationQueueEvent(
@@ -339,7 +353,7 @@ const worker = {
           }
 
           await handleRegistryRevocationEvent({
-            event: parsedRevocationEvent,
+            agentDid: parsedRevocationEvent.agentDid,
             trustStateNamespace,
           });
 

--- a/apps/proxy/src/worker.ts
+++ b/apps/proxy/src/worker.ts
@@ -12,11 +12,17 @@ import {
 import { resolveProxyVersion, resolveProxyVersionSource } from "./index.js";
 import { ProxyTrustState } from "./proxy-trust-state.js";
 import type { ProxyTrustStateNamespace } from "./proxy-trust-store.js";
+import { ProxyTrustStoreError } from "./proxy-trust-store.js";
 import {
   DELIVERY_RECEIPT_EVENT_TYPE,
   handleReceiptQueueEvent,
   parseReceiptQueueEvent,
 } from "./queue-consumer/receipt-events.js";
+import {
+  AGENT_AUTH_REVOKED_EVENT_TYPE,
+  handleRegistryRevocationEvent,
+  parseRegistryRevocationEvent,
+} from "./queue-consumer/registry-events.js";
 import { createProxyApp, type ProxyApp } from "./server.js";
 import { resolveWorkerTrustStore } from "./trust-store-backend.js";
 
@@ -210,6 +216,18 @@ function parseDeliveryReceiptEvent(payload: unknown) {
   }
 }
 
+function parseRegistryRevocationQueueEvent(payload: unknown) {
+  try {
+    return parseRegistryRevocationEvent(payload);
+  } catch (error) {
+    throw new NonRetryableQueueError(
+      error instanceof Error
+        ? error.message
+        : "Invalid registry revocation queue event payload",
+    );
+  }
+}
+
 type QueueFailureAction = "ack" | "retry";
 
 function resolveQueueFailureAction(error: unknown): {
@@ -236,6 +254,14 @@ function resolveQueueFailureAction(error: unknown): {
 
   if (error instanceof TypeError) {
     return { action: "retry", reasonCode: "transport_type_error" };
+  }
+
+  if (error instanceof ProxyTrustStoreError) {
+    if (error.status >= 500) {
+      return { action: "retry", reasonCode: "trust_state_transient_error" };
+    }
+
+    return { action: "ack", reasonCode: "trust_state_non_retryable_error" };
   }
 
   return { action: "retry", reasonCode: "unknown_retryable_error" };
@@ -276,28 +302,55 @@ const worker = {
     for (const message of batch.messages) {
       try {
         const event = parseQueueEventEnvelope(message.body);
-        if (event.type !== DELIVERY_RECEIPT_EVENT_TYPE) {
-          logger.warn("proxy.queue.message_ignored", {
-            reason: "unsupported_event_type",
-            eventType: event.type,
+        if (event.type === DELIVERY_RECEIPT_EVENT_TYPE) {
+          const relaySessionNamespace = env.AGENT_RELAY_SESSION;
+          if (relaySessionNamespace === undefined) {
+            throw new NonRetryableQueueError(
+              "Relay session namespace is unavailable",
+            );
+          }
+
+          const parsedReceiptEvent = parseDeliveryReceiptEvent(event.payload);
+          await handleReceiptQueueEvent({
+            event: parsedReceiptEvent,
+            relaySessionNamespace,
           });
+
           message.ack();
           continue;
         }
 
-        const relaySessionNamespace = env.AGENT_RELAY_SESSION;
-        if (relaySessionNamespace === undefined) {
-          throw new NonRetryableQueueError(
-            "Relay session namespace is unavailable",
+        if (event.type === AGENT_AUTH_REVOKED_EVENT_TYPE) {
+          const trustStateNamespace = env.PROXY_TRUST_STATE;
+          if (trustStateNamespace === undefined) {
+            throw new Error("Proxy trust state namespace is unavailable");
+          }
+
+          const parsedRevocationEvent = parseRegistryRevocationQueueEvent(
+            event.payload,
           );
+          if (parsedRevocationEvent === null) {
+            logger.warn("proxy.queue.message_ignored", {
+              reason: "unsupported_registry_revocation_reason",
+              eventType: event.type,
+            });
+            message.ack();
+            continue;
+          }
+
+          await handleRegistryRevocationEvent({
+            event: parsedRevocationEvent,
+            trustStateNamespace,
+          });
+
+          message.ack();
+          continue;
         }
 
-        const parsedReceiptEvent = parseDeliveryReceiptEvent(event.payload);
-        await handleReceiptQueueEvent({
-          event: parsedReceiptEvent,
-          relaySessionNamespace,
+        logger.warn("proxy.queue.message_ignored", {
+          reason: "unsupported_event_type",
+          eventType: event.type,
         });
-
         message.ack();
       } catch (error) {
         const failureAction = resolveQueueFailureAction(error);
@@ -310,6 +363,10 @@ const worker = {
             error instanceof RelaySessionDeliveryError ? error.status : null,
           relayCode:
             error instanceof RelaySessionDeliveryError ? error.code : null,
+          trustStoreStatus:
+            error instanceof ProxyTrustStoreError ? error.status : null,
+          trustStoreCode:
+            error instanceof ProxyTrustStoreError ? error.code : null,
         });
         if (failureAction.action === "retry") {
           message.retry();

--- a/apps/proxy/wrangler.jsonc
+++ b/apps/proxy/wrangler.jsonc
@@ -103,6 +103,12 @@
             "max_batch_size": 25,
             "max_batch_timeout": 5,
             "dead_letter_queue": "clawdentity-receipts-dlq-dev"
+          },
+          {
+            "queue": "clawdentity-events-dev",
+            "max_batch_size": 10,
+            "max_batch_timeout": 5,
+            "dead_letter_queue": "clawdentity-events-dlq-dev"
           }
         ]
       },
@@ -161,6 +167,12 @@
             "max_batch_size": 25,
             "max_batch_timeout": 5,
             "dead_letter_queue": "clawdentity-receipts-dlq"
+          },
+          {
+            "queue": "clawdentity-events",
+            "max_batch_size": 10,
+            "max_batch_timeout": 5,
+            "dead_letter_queue": "clawdentity-events-dlq"
           }
         ]
       },

--- a/apps/registry/src/AGENTS.md
+++ b/apps/registry/src/AGENTS.md
@@ -207,6 +207,7 @@
 - update `agents.status` to `revoked` and `agents.updated_at` to `nowIso()`
 - insert `revocations` row using the previous `current_jti`
 - revoke active `agent_auth_sessions` row for the same agent and write `agent_auth_events` entry with reason `agent_revoked`.
+- include `metadata.agentDid` in the `agent_auth_events` publish payload for `agent_revoked` so proxy queue consumers can hard-block by DID without extra registry lookups.
 
 ## DELETE /v1/agents/:id/auth/revoke Contract
 - Require PAT auth via `createApiKeyAuth`; only the caller-owned agent may be targeted.

--- a/apps/registry/src/server.test/agents-delete.test.ts
+++ b/apps/registry/src/server.test/agents-delete.test.ts
@@ -150,6 +150,78 @@ describe("DELETE /v1/agents/:id", () => {
     });
   });
 
+  it("publishes revoked auth event metadata with agent DID for queue consumers", async () => {
+    const { token, authRow } = await makeValidPatContext();
+    const nowIso = new Date().toISOString();
+    const agentId = generateUlid(1700200000302);
+    const agentDid = makeAgentDid(DID_AUTHORITY, agentId);
+    const agentJti = generateUlid(1700200000303);
+    const { database, agentAuthEventInserts } = createFakeDb(
+      [authRow],
+      [
+        {
+          id: agentId,
+          did: agentDid,
+          ownerId: "human-1",
+          name: "owned-agent-with-session",
+          framework: "openclaw",
+          status: "active",
+          expiresAt: "2026-04-01T00:00:00.000Z",
+          currentJti: agentJti,
+        },
+      ],
+      {
+        agentAuthSessionRows: [
+          {
+            id: generateUlid(1700200000304),
+            agentId,
+            refreshKeyHash: "refresh-hash",
+            refreshKeyPrefix: "clw_rft_test",
+            refreshIssuedAt: nowIso,
+            refreshExpiresAt: new Date(Date.now() + 60_000).toISOString(),
+            refreshLastUsedAt: null,
+            accessKeyHash: "access-hash",
+            accessKeyPrefix: "clw_agt_test",
+            accessIssuedAt: nowIso,
+            accessExpiresAt: new Date(Date.now() + 60_000).toISOString(),
+            accessLastUsedAt: null,
+            status: "active",
+            revokedAt: null,
+            createdAt: nowIso,
+            updatedAt: nowIso,
+          },
+        ],
+      },
+    );
+
+    const res = await createRegistryApp().request(
+      `/v1/agents/${agentId}`,
+      {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${token}` },
+      },
+      {
+        DB: database,
+        ENVIRONMENT: "local",
+        BOOTSTRAP_INTERNAL_SERVICE_ID: "proxy-pairing",
+        BOOTSTRAP_INTERNAL_SERVICE_SECRET: "bootstrap-test-secret",
+      },
+    );
+
+    expect(res.status).toBe(204);
+    expect(agentAuthEventInserts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          event_type: "revoked",
+          reason: "agent_revoked",
+          metadata_json: JSON.stringify({
+            agentDid,
+          }),
+        }),
+      ]),
+    );
+  });
+
   it("is idempotent for repeat revoke requests", async () => {
     const { token, authRow } = await makeValidPatContext();
     const agentId = generateUlid(1700200000400);

--- a/apps/registry/src/server/constants.ts
+++ b/apps/registry/src/server/constants.ts
@@ -1,3 +1,4 @@
+import { AGENT_AUTH_REVOKED_EVENT_TYPE } from "@clawdentity/protocol";
 import {
   createLogger,
   type EventBus,
@@ -169,6 +170,6 @@ export const AGENT_AUTH_EVENT_NAME_BY_TYPE: Record<
 > = {
   issued: "agent.auth.issued",
   refreshed: "agent.auth.refreshed",
-  revoked: "agent.auth.revoked",
+  revoked: AGENT_AUTH_REVOKED_EVENT_TYPE,
   refresh_rejected: "agent.auth.refresh_rejected",
 };

--- a/apps/registry/src/server/routes/AGENTS.md
+++ b/apps/registry/src/server/routes/AGENTS.md
@@ -16,3 +16,4 @@
 - Enforce human-level agent quotas server-side in agent registration routes before challenge finalization; UI copy is not a substitute for quota enforcement.
 - Enforce starter-pass agent quotas inside the guarded registration mutation itself so parallel `/v1/agents` requests cannot bypass the cap between challenge verification and insert.
 - Reissued AITs must stay aligned with the stored agent/human DID authority; do not switch issuer authority just because the current request arrived through a different hostname alias.
+- Agent auth revoke events that proxy consumes must use shared protocol constants/helpers for event name/reason/metadata shape (`agent.auth.revoked`, `agent_revoked`, `metadata.agentDid`) rather than ad-hoc inline literals.

--- a/apps/registry/src/server/routes/agents.ts
+++ b/apps/registry/src/server/routes/agents.ts
@@ -492,6 +492,9 @@ export function registerAgentRoutes(input: RegistryRouteDependencies): void {
           sessionId: existingSession.id,
           eventType: "revoked",
           reason: "agent_revoked",
+          metadata: {
+            agentDid: existingAgent.did,
+          },
           createdAt: revokedAt,
           eventBus: getEventBus(c.env),
           initiatedByAccountId: human.did,

--- a/apps/registry/src/server/routes/agents.ts
+++ b/apps/registry/src/server/routes/agents.ts
@@ -1,5 +1,7 @@
 import {
+  AGENT_AUTH_REVOKED_REASON_AGENT_REVOKED,
   AGENT_REGISTRATION_CHALLENGE_PATH,
+  createAgentAuthRevokedMetadata,
   generateUlid,
 } from "@clawdentity/protocol";
 import {
@@ -491,10 +493,8 @@ export function registerAgentRoutes(input: RegistryRouteDependencies): void {
           agentId: existingAgent.id,
           sessionId: existingSession.id,
           eventType: "revoked",
-          reason: "agent_revoked",
-          metadata: {
-            agentDid: existingAgent.did,
-          },
+          reason: AGENT_AUTH_REVOKED_REASON_AGENT_REVOKED,
+          metadata: createAgentAuthRevokedMetadata(existingAgent.did),
           createdAt: revokedAt,
           eventBus: getEventBus(c.env),
           initiatedByAccountId: human.did,

--- a/packages/protocol/AGENTS.md
+++ b/packages/protocol/AGENTS.md
@@ -24,6 +24,8 @@
 - Keep T02 canonicalization minimal and deterministic; replay/skew/nonce policy enforcement is handled in later tickets (`T07`, `T08`, `T09`).
 - Define shared API route fragments in protocol exports (for example `ADMIN_BOOTSTRAP_PATH`) so CLI/SDK/apps avoid hardcoded duplicate endpoint literals.
 - Keep lifecycle route constants together in `endpoints.ts` (e.g., `ADMIN_BOOTSTRAP_PATH`, `AGENT_REGISTRATION_CHALLENGE_PATH`, `AGENT_AUTH_REFRESH_PATH`, `AGENT_AUTH_VALIDATE_PATH`, `ME_API_KEYS_PATH`) so registry, proxy, and CLI stay contract-synchronized.
+- Keep agent-auth queue contract constants in protocol exports (`agent.auth.revoked`, `agent_revoked`, metadata key `agentDid`) so registry publishers and proxy consumers cannot drift.
+- Keep revocation metadata parsing/normalization centralized via protocol helpers (`parseAgentAuthRevokedMetadata`, `createAgentAuthRevokedMetadata`) instead of duplicating object-shape checks across apps.
 - Keep protocol route constants scoped to active contracts only; remove deprecated endpoint exports immediately when a flow is retired.
 - Keep internal identity route constants in protocol exports (`INTERNAL_IDENTITY_AGENT_OWNERSHIP_PATH`) so service-to-service ownership checks stay synchronized.
 - Keep relay contract constants in protocol exports (`RELAY_CONNECT_PATH`, `RELAY_RECIPIENT_AGENT_DID_HEADER`) so connector and hook routing stay synchronized across apps.

--- a/packages/protocol/src/agent-auth-events.ts
+++ b/packages/protocol/src/agent-auth-events.ts
@@ -1,0 +1,47 @@
+import { parseAgentDid } from "./did.js";
+
+export const AGENT_AUTH_ISSUED_EVENT_TYPE = "agent.auth.issued";
+export const AGENT_AUTH_REFRESHED_EVENT_TYPE = "agent.auth.refreshed";
+export const AGENT_AUTH_REVOKED_EVENT_TYPE = "agent.auth.revoked";
+export const AGENT_AUTH_REFRESH_REJECTED_EVENT_TYPE =
+  "agent.auth.refresh_rejected";
+
+export const AGENT_AUTH_REVOKED_REASON_AGENT_REVOKED = "agent_revoked";
+export const AGENT_AUTH_REVOKED_METADATA_AGENT_DID_KEY = "agentDid";
+
+export type AgentAuthRevokedMetadata = {
+  agentDid: string;
+};
+
+export function createAgentAuthRevokedMetadata(
+  agentDid: string,
+): AgentAuthRevokedMetadata {
+  const normalizedAgentDid = agentDid.trim();
+  parseAgentDid(normalizedAgentDid);
+  return {
+    [AGENT_AUTH_REVOKED_METADATA_AGENT_DID_KEY]: normalizedAgentDid,
+  };
+}
+
+export function parseAgentAuthRevokedMetadata(
+  metadata: unknown,
+): AgentAuthRevokedMetadata {
+  if (typeof metadata !== "object" || metadata === null) {
+    throw new Error("Registry revocation event metadata must be an object");
+  }
+
+  const agentDid = (metadata as { agentDid?: unknown })[
+    AGENT_AUTH_REVOKED_METADATA_AGENT_DID_KEY
+  ];
+  if (typeof agentDid !== "string" || agentDid.trim().length === 0) {
+    throw new Error(
+      "Registry revocation event metadata must include a non-empty agentDid",
+    );
+  }
+
+  const normalizedAgentDid = agentDid.trim();
+  parseAgentDid(normalizedAgentDid);
+  return {
+    [AGENT_AUTH_REVOKED_METADATA_AGENT_DID_KEY]: normalizedAgentDid,
+  };
+}

--- a/packages/protocol/src/index.test.ts
+++ b/packages/protocol/src/index.test.ts
@@ -2,7 +2,13 @@ import { describe, expect, it } from "vitest";
 import {
   ADMIN_BOOTSTRAP_PATH,
   ADMIN_INTERNAL_SERVICES_PATH,
+  AGENT_AUTH_ISSUED_EVENT_TYPE,
   AGENT_AUTH_REFRESH_PATH,
+  AGENT_AUTH_REFRESH_REJECTED_EVENT_TYPE,
+  AGENT_AUTH_REFRESHED_EVENT_TYPE,
+  AGENT_AUTH_REVOKED_EVENT_TYPE,
+  AGENT_AUTH_REVOKED_METADATA_AGENT_DID_KEY,
+  AGENT_AUTH_REVOKED_REASON_AGENT_REVOKED,
   AGENT_AUTH_VALIDATE_PATH,
   AGENT_NAME_REGEX,
   AGENT_REGISTRATION_CHALLENGE_PATH,
@@ -28,6 +34,7 @@ import {
   makeHumanDid,
   PROTOCOL_VERSION,
   ProtocolParseError,
+  parseAgentAuthRevokedMetadata,
   parseAgentDid,
   parseAitClaims,
   parseCrlClaims,
@@ -66,6 +73,26 @@ describe("protocol", () => {
     );
     expect(RELAY_CONNECT_PATH).toBe("/v1/relay/connect");
     expect(RELAY_RECIPIENT_AGENT_DID_HEADER).toBe("x-claw-recipient-agent-did");
+  });
+
+  it("exports shared agent-auth revocation constants and parser", () => {
+    expect(AGENT_AUTH_ISSUED_EVENT_TYPE).toBe("agent.auth.issued");
+    expect(AGENT_AUTH_REFRESHED_EVENT_TYPE).toBe("agent.auth.refreshed");
+    expect(AGENT_AUTH_REVOKED_EVENT_TYPE).toBe("agent.auth.revoked");
+    expect(AGENT_AUTH_REFRESH_REJECTED_EVENT_TYPE).toBe(
+      "agent.auth.refresh_rejected",
+    );
+    expect(AGENT_AUTH_REVOKED_REASON_AGENT_REVOKED).toBe("agent_revoked");
+    expect(AGENT_AUTH_REVOKED_METADATA_AGENT_DID_KEY).toBe("agentDid");
+    expect(
+      parseAgentAuthRevokedMetadata({
+        agentDid:
+          "did:cdi:registry.clawdentity.dev:agent:01HF7YAT31JZHSMW1CG6Q6MHB7",
+      }),
+    ).toEqual({
+      agentDid:
+        "did:cdi:registry.clawdentity.dev:agent:01HF7YAT31JZHSMW1CG6Q6MHB7",
+    });
   });
 
   it("exports helpers from package root", () => {

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -1,5 +1,15 @@
 export const PROTOCOL_VERSION = "0.0.0";
 
+export {
+  AGENT_AUTH_ISSUED_EVENT_TYPE,
+  AGENT_AUTH_REFRESH_REJECTED_EVENT_TYPE,
+  AGENT_AUTH_REFRESHED_EVENT_TYPE,
+  AGENT_AUTH_REVOKED_EVENT_TYPE,
+  AGENT_AUTH_REVOKED_METADATA_AGENT_DID_KEY,
+  AGENT_AUTH_REVOKED_REASON_AGENT_REVOKED,
+  createAgentAuthRevokedMetadata,
+  parseAgentAuthRevokedMetadata,
+} from "./agent-auth-events.js";
 export type { AgentRegistrationProofMessageInput } from "./agent-registration-proof.js";
 export {
   AGENT_REGISTRATION_PROOF_MESSAGE_TEMPLATE,


### PR DESCRIPTION
## Summary
- Extend proxy queue consumer to handle registry agent.auth.revoked events while preserving existing delivery_receipt routing.
- Add trust-state revocation overlay methods (markAgentRevoked and isAgentRevoked) in proxy trust store and Durable Object routes.
- Enforce trust-state revocation check before CRL polling in proxy auth middleware.
- Add proxy queue subscriptions for clawdentity-events-dev and clawdentity-events.
- Publish metadata.agentDid for agent_revoked auth events in the registry revoke flow.
- Update tests and AGENTS docs for queue contracts, trust-state routes, and revocation behavior.

## Validation
- pnpm -F @clawdentity/proxy test -- src/worker.test.ts src/queue-consumer/registry-events.test.ts src/proxy-trust-state.test.ts src/proxy-trust-store.test.ts src/auth-middleware.test/robustness.test.ts
- pnpm -F @clawdentity/registry test -- src/server.test/agents-delete.test.ts
- pnpm -F @clawdentity/proxy run types:dev
- pnpm -F @clawdentity/proxy typecheck && pnpm -F @clawdentity/registry typecheck
- pre-push hook completed affected lint/format/typecheck/test successfully

Closes #167
