### PR TITLE
feat(pairing): add static proxy message to pair.accepted notifications

### DIFF
--- a/apps/proxy/src/AGENTS.md
+++ b/apps/proxy/src/AGENTS.md
@@ -87,10 +87,12 @@
   - enforce `allowResponderAgentDid` when present and reject mismatches with `403 PROXY_PAIR_RESPONDER_FORBIDDEN`.
 - Keep `/pair/confirm` queue-first for initiator sync:
   - after trust commit, publish a `pair.accepted` event to `clawdentity-events*` as best-effort.
+  - include fixed UX text in `pair.accepted.message` (`Clawdentity pairing complete. You can now message this peer.`) for initiator-facing notification consistency.
   - queue publish failures must log warnings and still return `201` success.
   - `/pair/status` remains the fallback recovery path when queue delivery is delayed or unavailable.
 - Keep queue consumer routing explicit for `pair.accepted`: route event payloads to initiator relay sessions via DO RPC delivery, and keep malformed/unsupported events as `ack` + warn.
 - Pair-accepted queue routing must stamp trusted relay provenance (`deliverySource=proxy.events.queue.pair_accepted`) so connector runtimes can reject spoofed user payloads.
+- Pair-accepted structured fields remain the source of truth for trust side effects; `message` is UX-only metadata and must never replace structured pairing fields.
 - Keep ticket parsing tolerant for operator copy/paste paths: normalize surrounding markdown/backticks and whitespace before parse + trust-store lookup in both in-memory and Durable Object backends.
 - Keep `/hooks/agent` runtime auth contract strict: require `x-claw-agent-access` and map missing/invalid access credentials to `401`.
 - Keep `/hooks/agent` recipient routing explicit: require `x-claw-recipient-agent-did` and resolve DO IDs from that recipient DID, never from owner DID env.

--- a/apps/proxy/src/AGENTS.md
+++ b/apps/proxy/src/AGENTS.md
@@ -87,7 +87,7 @@
   - enforce `allowResponderAgentDid` when present and reject mismatches with `403 PROXY_PAIR_RESPONDER_FORBIDDEN`.
 - Keep `/pair/confirm` queue-first for initiator sync:
   - after trust commit, publish a `pair.accepted` event to `clawdentity-events*` as best-effort.
-  - include fixed UX text in `pair.accepted.message` (`Clawdentity pairing complete. You can now message this peer.`) for initiator-facing notification consistency.
+  - include fixed UX text in `pair.accepted.message` using shared protocol constant `PAIR_ACCEPTED_NOTIFICATION_MESSAGE` for initiator-facing notification consistency.
   - queue publish failures must log warnings and still return `201` success.
   - `/pair/status` remains the fallback recovery path when queue delivery is delayed or unavailable.
 - Keep queue consumer routing explicit for `pair.accepted`: route event payloads to initiator relay sessions via DO RPC delivery, and keep malformed/unsupported events as `ack` + warn.

--- a/apps/proxy/src/pairing-route.test/confirm.test.ts
+++ b/apps/proxy/src/pairing-route.test/confirm.test.ts
@@ -332,6 +332,7 @@ describe(`POST ${PAIR_CONFIRM_PATH}`, () => {
       String(queueSendSpy.mock.calls[0]?.[0] ?? "{}"),
     ) as {
       type?: string;
+      message?: string;
       initiatorAgentDid?: string;
       responderAgentDid?: string;
       responderProfile?: {
@@ -341,6 +342,7 @@ describe(`POST ${PAIR_CONFIRM_PATH}`, () => {
     };
     expect(queuedBody).toMatchObject({
       type: "pair.accepted",
+      message: "Clawdentity pairing complete. You can now message this peer.",
       initiatorAgentDid: INITIATOR_AGENT_DID,
       responderAgentDid: RESPONDER_AGENT_DID,
       responderProfile: {

--- a/apps/proxy/src/pairing-route.test/confirm.test.ts
+++ b/apps/proxy/src/pairing-route.test/confirm.test.ts
@@ -1,5 +1,6 @@
 import {
   generateUlid,
+  PAIR_ACCEPTED_NOTIFICATION_MESSAGE,
   makeAgentDid as protocolMakeAgentDid,
   makeHumanDid as protocolMakeHumanDid,
 } from "@clawdentity/protocol";
@@ -63,6 +64,7 @@ import { parseProxyConfig } from "../config.js";
 import { PAIR_CONFIRM_PATH } from "../pairing-constants.js";
 import { createInMemoryProxyTrustStore } from "../proxy-trust-store.js";
 import { createProxyApp } from "../server.js";
+import { type ProxyWorkerBindings, worker } from "../worker.js";
 
 async function createSignedTicketFixture(input: {
   issuerProxyUrl: string;
@@ -342,13 +344,120 @@ describe(`POST ${PAIR_CONFIRM_PATH}`, () => {
     };
     expect(queuedBody).toMatchObject({
       type: "pair.accepted",
-      message: "Clawdentity pairing complete. You can now message this peer.",
+      message: PAIR_ACCEPTED_NOTIFICATION_MESSAGE,
       initiatorAgentDid: INITIATOR_AGENT_DID,
       responderAgentDid: RESPONDER_AGENT_DID,
       responderProfile: {
         agentName: RESPONDER_PROFILE_WITH_PROXY_ORIGIN.agentName,
       },
       issuerProxyOrigin: "http://localhost",
+    });
+  });
+
+  it("routes confirm-published pair.accepted event through worker queue to connector delivery", async () => {
+    const queueSendSpy = vi.fn(async (_message: string) => {});
+    const { app, trustStore } = createPairingApp({
+      nowMs: () => 1_700_000_000_000,
+    });
+    const createdTicket = await createSignedTicketFixture({
+      issuerProxyUrl: "http://localhost",
+      nowMs: 1_700_000_000_000,
+      expiresAtMs: 1_700_000_900_000,
+    });
+    const ticket = await trustStore.createPairingTicket({
+      initiatorAgentDid: INITIATOR_AGENT_DID,
+      initiatorProfile: INITIATOR_PROFILE,
+      issuerProxyUrl: "http://localhost",
+      ticket: createdTicket.ticket,
+      publicKeyX: createdTicket.publicKeyX,
+      expiresAtMs: 1_700_000_900_000,
+      nowMs: 1_700_000_000_000,
+    });
+
+    const confirmResponse = await app.fetch(
+      new Request(`https://proxy.example.test${PAIR_CONFIRM_PATH}`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-test-agent-did": RESPONDER_AGENT_DID,
+        },
+        body: JSON.stringify({
+          ticket: ticket.ticket,
+          responderProfile: RESPONDER_PROFILE_WITH_PROXY_ORIGIN,
+        }),
+      }),
+      {
+        EVENTS_QUEUE: {
+          send: queueSendSpy,
+        } as unknown as Queue<string>,
+      },
+    );
+
+    expect(confirmResponse.status).toBe(201);
+    const queuedBody = String(queueSendSpy.mock.calls[0]?.[0] ?? "");
+    expect(queuedBody.length).toBeGreaterThan(0);
+
+    const relayDeliveryFetchSpy = vi.fn(async (_request: Request) =>
+      Response.json({ accepted: true }, { status: 202 }),
+    );
+    const relaySessionNamespace: NonNullable<
+      ProxyWorkerBindings["AGENT_RELAY_SESSION"]
+    > = {
+      idFromName: vi.fn(
+        (name: string) =>
+          ({ toString: () => name }) as unknown as DurableObjectId,
+      ),
+      get: vi.fn(() => ({
+        fetch: async (request: Request) => relayDeliveryFetchSpy(request),
+      })),
+    };
+
+    const ack = vi.fn();
+    const retry = vi.fn();
+    await worker.queue(
+      {
+        messages: [
+          {
+            body: queuedBody,
+            ack,
+            retry,
+          },
+        ],
+      } as unknown as MessageBatch<string>,
+      {
+        ENVIRONMENT: "local",
+        REGISTRY_URL: "https://registry.example.test",
+        BOOTSTRAP_INTERNAL_SERVICE_ID: "svc-proxy-registry",
+        BOOTSTRAP_INTERNAL_SERVICE_SECRET: "secret-proxy-registry",
+        AGENT_RELAY_SESSION: relaySessionNamespace,
+      },
+    );
+
+    expect(ack).toHaveBeenCalledTimes(1);
+    expect(retry).not.toHaveBeenCalled();
+    expect(relayDeliveryFetchSpy).toHaveBeenCalledTimes(1);
+
+    const request = relayDeliveryFetchSpy.mock.calls[0]?.[0] as Request;
+    expect(new URL(request.url).pathname).toBe("/rpc/deliver-to-connector");
+    const relayPayload = (await request.json()) as {
+      senderAgentDid?: string;
+      recipientAgentDid?: string;
+      payload?: {
+        system?: {
+          type?: string;
+          message?: string;
+        };
+      };
+    };
+    expect(relayPayload).toMatchObject({
+      senderAgentDid: RESPONDER_AGENT_DID,
+      recipientAgentDid: INITIATOR_AGENT_DID,
+      payload: {
+        system: {
+          type: "pair.accepted",
+          message: PAIR_ACCEPTED_NOTIFICATION_MESSAGE,
+        },
+      },
     });
   });
 

--- a/apps/proxy/src/pairing-route.ts
+++ b/apps/proxy/src/pairing-route.ts
@@ -1,5 +1,6 @@
 import {
   createPairAcceptedEvent,
+  PAIR_ACCEPTED_NOTIFICATION_MESSAGE,
   parseAgentDid as parseProtocolAgentDid,
 } from "@clawdentity/protocol";
 import {
@@ -73,9 +74,6 @@ type CreatePairStatusHandlerOptions = PairStatusRuntimeOptions & {
 };
 
 const MAX_PROFILE_NAME_LENGTH = 64;
-const PAIR_ACCEPTED_NOTIFICATION_MESSAGE =
-  "Clawdentity pairing complete. You can now message this peer.";
-
 function parseInternalServiceCredentials(input: {
   serviceId?: string;
   serviceSecret?: string;

--- a/apps/proxy/src/pairing-route.ts
+++ b/apps/proxy/src/pairing-route.ts
@@ -73,6 +73,8 @@ type CreatePairStatusHandlerOptions = PairStatusRuntimeOptions & {
 };
 
 const MAX_PROFILE_NAME_LENGTH = 64;
+const PAIR_ACCEPTED_NOTIFICATION_MESSAGE =
+  "Clawdentity pairing complete. You can now message this peer.";
 
 function parseInternalServiceCredentials(input: {
   serviceId?: string;
@@ -405,6 +407,7 @@ async function publishPairAcceptedEvent(input: {
     },
     issuerProxyOrigin: input.confirmedPairingTicket.issuerProxyUrl,
     eventTimestampUtc: input.eventTimestampUtc,
+    message: PAIR_ACCEPTED_NOTIFICATION_MESSAGE,
   });
 
   if (input.eventsQueue === undefined) {

--- a/apps/proxy/src/queue-consumer/AGENTS.md
+++ b/apps/proxy/src/queue-consumer/AGENTS.md
@@ -9,7 +9,9 @@
 - Route `delivery_receipt` events to the sender relay Durable Object using typed RPC helpers (`recordRelayDeliveryReceipt`) rather than ad-hoc `fetch` payload strings.
 - Route `agent.auth.revoked` events to proxy trust-state via typed trust-store methods (`markAgentRevoked`) rather than bespoke DO endpoint strings.
 - Route `pair.accepted` events to the initiator relay Durable Object using typed relay RPC helpers (`deliverToRelaySession`) with system payload wrapping.
+- Preserve optional `pair.accepted.message` during routing so initiator UX can show proxy-authored static notifications.
 - Queue-routed `pair.accepted` relay deliveries must set trusted delivery provenance (`deliverySource=proxy.events.queue.pair_accepted`) so connector runtimes can reject spoofed payload-only system events.
+- Pair-accepted structured fields remain mandatory for trusted side effects; queue consumers must not treat `message` as a replacement for those fields.
 - Treat queue events as at-least-once: handlers must be idempotent against duplicate messages.
 - Keep the `delivery_receipt` queue contract minimal (sender/recipient/request/status/reason/timestamp) and avoid carrying callback-origin metadata that is not consumed by handlers.
 - Keep registry revocation queue handling strict: only hard revokes (`data.reason=agent_revoked`) with valid `data.metadata.agentDid` may mutate trust state.

--- a/apps/proxy/src/queue-consumer/AGENTS.md
+++ b/apps/proxy/src/queue-consumer/AGENTS.md
@@ -10,6 +10,7 @@
 - Route `agent.auth.revoked` events to proxy trust-state via typed trust-store methods (`markAgentRevoked`) rather than bespoke DO endpoint strings.
 - Route `pair.accepted` events to the initiator relay Durable Object using typed relay RPC helpers (`deliverToRelaySession`) with system payload wrapping.
 - Preserve optional `pair.accepted.message` during routing so initiator UX can show proxy-authored static notifications.
+- Treat blank optional `pair.accepted.message` as ignorable UX metadata; do not let cosmetic message issues block trusted relay routing.
 - Queue-routed `pair.accepted` relay deliveries must set trusted delivery provenance (`deliverySource=proxy.events.queue.pair_accepted`) so connector runtimes can reject spoofed payload-only system events.
 - Pair-accepted structured fields remain mandatory for trusted side effects; queue consumers must not treat `message` as a replacement for those fields.
 - Treat queue events as at-least-once: handlers must be idempotent against duplicate messages.

--- a/apps/proxy/src/queue-consumer/pairing-events.test.ts
+++ b/apps/proxy/src/queue-consumer/pairing-events.test.ts
@@ -20,6 +20,7 @@ describe("pair accepted queue events", () => {
       },
       issuerProxyOrigin: "https://proxy.clawdentity.dev/pair/confirm",
       eventTimestampUtc: "2026-03-28T00:00:00.000Z",
+      message: "Clawdentity pairing complete. You can now message this peer.",
     });
 
     expect(event).toEqual({
@@ -35,6 +36,7 @@ describe("pair accepted queue events", () => {
       },
       issuerProxyOrigin: "https://proxy.clawdentity.dev",
       eventTimestampUtc: "2026-03-28T00:00:00.000Z",
+      message: "Clawdentity pairing complete. You can now message this peer.",
     });
   });
 
@@ -82,6 +84,7 @@ describe("pair accepted queue events", () => {
         },
         issuerProxyOrigin: "https://proxy.clawdentity.dev",
         eventTimestampUtc: "2026-03-28T00:00:00.000Z",
+        message: "Clawdentity pairing complete. You can now message this peer.",
       }),
       relaySessionNamespace,
     });
@@ -96,6 +99,7 @@ describe("pair accepted queue events", () => {
       payload?: {
         system?: {
           type?: string;
+          message?: string;
         };
       };
     };
@@ -107,5 +111,8 @@ describe("pair accepted queue events", () => {
     );
     expect(payload.deliverySource).toBe("proxy.events.queue.pair_accepted");
     expect(payload.payload?.system?.type).toBe(PAIR_ACCEPTED_EVENT_TYPE);
+    expect(payload.payload?.system?.message).toBe(
+      "Clawdentity pairing complete. You can now message this peer.",
+    );
   });
 });

--- a/apps/proxy/src/queue-consumer/pairing-events.test.ts
+++ b/apps/proxy/src/queue-consumer/pairing-events.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   handlePairAcceptedQueueEvent,
   PAIR_ACCEPTED_EVENT_TYPE,
+  PAIR_ACCEPTED_NOTIFICATION_MESSAGE,
   parsePairAcceptedQueueEvent,
 } from "./pairing-events.js";
 
@@ -20,7 +21,7 @@ describe("pair accepted queue events", () => {
       },
       issuerProxyOrigin: "https://proxy.clawdentity.dev/pair/confirm",
       eventTimestampUtc: "2026-03-28T00:00:00.000Z",
-      message: "Clawdentity pairing complete. You can now message this peer.",
+      message: PAIR_ACCEPTED_NOTIFICATION_MESSAGE,
     });
 
     expect(event).toEqual({
@@ -36,7 +37,7 @@ describe("pair accepted queue events", () => {
       },
       issuerProxyOrigin: "https://proxy.clawdentity.dev",
       eventTimestampUtc: "2026-03-28T00:00:00.000Z",
-      message: "Clawdentity pairing complete. You can now message this peer.",
+      message: PAIR_ACCEPTED_NOTIFICATION_MESSAGE,
     });
   });
 
@@ -84,7 +85,7 @@ describe("pair accepted queue events", () => {
         },
         issuerProxyOrigin: "https://proxy.clawdentity.dev",
         eventTimestampUtc: "2026-03-28T00:00:00.000Z",
-        message: "Clawdentity pairing complete. You can now message this peer.",
+        message: PAIR_ACCEPTED_NOTIFICATION_MESSAGE,
       }),
       relaySessionNamespace,
     });
@@ -112,7 +113,7 @@ describe("pair accepted queue events", () => {
     expect(payload.deliverySource).toBe("proxy.events.queue.pair_accepted");
     expect(payload.payload?.system?.type).toBe(PAIR_ACCEPTED_EVENT_TYPE);
     expect(payload.payload?.system?.message).toBe(
-      "Clawdentity pairing complete. You can now message this peer.",
+      PAIR_ACCEPTED_NOTIFICATION_MESSAGE,
     );
   });
 });

--- a/apps/proxy/src/queue-consumer/pairing-events.ts
+++ b/apps/proxy/src/queue-consumer/pairing-events.ts
@@ -1,5 +1,6 @@
 import {
   PAIR_ACCEPTED_EVENT_TYPE,
+  PAIR_ACCEPTED_NOTIFICATION_MESSAGE,
   PAIR_ACCEPTED_TRUSTED_DELIVERY_SOURCE,
   type PairAcceptedEvent,
   parsePairAcceptedEvent,
@@ -10,6 +11,7 @@ import {
 } from "../agent-relay-session.js";
 
 export { PAIR_ACCEPTED_EVENT_TYPE };
+export { PAIR_ACCEPTED_NOTIFICATION_MESSAGE };
 
 export type PairAcceptedQueueEvent = PairAcceptedEvent;
 

--- a/apps/proxy/src/queue-consumer/pairing-events.ts
+++ b/apps/proxy/src/queue-consumer/pairing-events.ts
@@ -48,6 +48,7 @@ function toSystemPayload(event: PairAcceptedQueueEvent): {
       responderProfile: event.responderProfile,
       issuerProxyOrigin: event.issuerProxyOrigin,
       eventTimestampUtc: event.eventTimestampUtc,
+      message: event.message,
     },
   };
 }

--- a/apps/proxy/src/worker.pairing-events.test.ts
+++ b/apps/proxy/src/worker.pairing-events.test.ts
@@ -70,6 +70,8 @@ describe("proxy worker pair.accepted queue routing", () => {
             },
             issuerProxyOrigin: "https://proxy.clawdentity.dev",
             eventTimestampUtc: "2026-03-28T00:00:00.000Z",
+            message:
+              "Clawdentity pairing complete. You can now message this peer.",
           }),
           ack,
           retry,
@@ -89,6 +91,7 @@ describe("proxy worker pair.accepted queue routing", () => {
       payload?: {
         system?: {
           type?: string;
+          message?: string;
         };
       };
     };
@@ -101,6 +104,8 @@ describe("proxy worker pair.accepted queue routing", () => {
       payload: {
         system: {
           type: "pair.accepted",
+          message:
+            "Clawdentity pairing complete. You can now message this peer.",
         },
       },
     });

--- a/apps/proxy/src/worker.pairing-events.test.ts
+++ b/apps/proxy/src/worker.pairing-events.test.ts
@@ -1,14 +1,7 @@
+import { PAIR_ACCEPTED_NOTIFICATION_MESSAGE } from "@clawdentity/protocol";
 import { describe, expect, it, vi } from "vitest";
 import type { AgentRelaySessionStub } from "./agent-relay-session.js";
 import { type ProxyWorkerBindings, worker } from "./worker.js";
-
-function createExecutionContext(): ExecutionContext {
-  return {
-    waitUntil: vi.fn(),
-    passThroughOnException: vi.fn(),
-    props: {},
-  } as unknown as ExecutionContext;
-}
 
 function createRelaySessionNamespaceWithFetchSpy(
   fetchSpy: ReturnType<typeof vi.fn>,
@@ -70,8 +63,7 @@ describe("proxy worker pair.accepted queue routing", () => {
             },
             issuerProxyOrigin: "https://proxy.clawdentity.dev",
             eventTimestampUtc: "2026-03-28T00:00:00.000Z",
-            message:
-              "Clawdentity pairing complete. You can now message this peer.",
+            message: PAIR_ACCEPTED_NOTIFICATION_MESSAGE,
           }),
           ack,
           retry,
@@ -104,8 +96,7 @@ describe("proxy worker pair.accepted queue routing", () => {
       payload: {
         system: {
           type: "pair.accepted",
-          message:
-            "Clawdentity pairing complete. You can now message this peer.",
+          message: PAIR_ACCEPTED_NOTIFICATION_MESSAGE,
         },
       },
     });

--- a/crates/clawdentity-cli/src/commands/connector/AGENTS.md
+++ b/crates/clawdentity-cli/src/commands/connector/AGENTS.md
@@ -26,6 +26,7 @@
 - Pair-accepted system payload validation must include DID checks, responder proxy origin URL checks, and event timestamp parsing before mutating peer state.
 - Pair-accepted structured fields are mandatory for trusted side effects; optional `system.message` is UX-only and must never be used as a replacement for persistence/trust metadata.
 - For OpenClaw-facing notifications, prefer proxy-provided non-empty `system.message` when present and fall back to local generated message text when absent.
+- Treat blank/whitespace `system.message` as absent UX metadata so trusted peer persistence cannot fail on cosmetic message formatting drift.
 - Keep proxy receipt dispatch + durable outbox behavior in `receipts.rs`; do not re-embed receipt persistence/retry logic into `connector.rs` or `delivery.rs`.
 - Keep receipt outbox mutations in a single-writer command flow (enqueue/flush serialized) so disk-backed retries remain race-safe under concurrent runtime tasks.
 - Persist receipt outbox updates with atomic write-then-rename (`*.tmp-*` -> final path) so crashes cannot leave partially written JSON that drops queued receipts.

--- a/crates/clawdentity-cli/src/commands/connector/AGENTS.md
+++ b/crates/clawdentity-cli/src/commands/connector/AGENTS.md
@@ -24,6 +24,8 @@
 - Keep pair-accepted peer persistence idempotent by reusing core helper `persist_confirmed_peer_from_profile_and_proxy_origin`; never duplicate direct peer upsert/snapshot logic in connector runtime.
 - Pair-accepted system side effects must run only for trusted relay delivery provenance (`deliverySource=proxy.events.queue.pair_accepted`); never mutate peer state for user-authored payload-only `system.type=pair.accepted`.
 - Pair-accepted system payload validation must include DID checks, responder proxy origin URL checks, and event timestamp parsing before mutating peer state.
+- Pair-accepted structured fields are mandatory for trusted side effects; optional `system.message` is UX-only and must never be used as a replacement for persistence/trust metadata.
+- For OpenClaw-facing notifications, prefer proxy-provided non-empty `system.message` when present and fall back to local generated message text when absent.
 - Keep proxy receipt dispatch + durable outbox behavior in `receipts.rs`; do not re-embed receipt persistence/retry logic into `connector.rs` or `delivery.rs`.
 - Keep receipt outbox mutations in a single-writer command flow (enqueue/flush serialized) so disk-backed retries remain race-safe under concurrent runtime tasks.
 - Persist receipt outbox updates with atomic write-then-rename (`*.tmp-*` -> final path) so crashes cannot leave partially written JSON that drops queued receipts.

--- a/crates/clawdentity-cli/src/commands/connector/delivery/pair_accepted.rs
+++ b/crates/clawdentity-cli/src/commands/connector/delivery/pair_accepted.rs
@@ -61,9 +61,10 @@ fn normalize_event_timestamp_utc(value: &str) -> Result<String> {
 }
 
 fn normalize_optional_message(value: Option<&str>) -> Result<Option<String>> {
-    value
-        .map(|candidate| normalize_non_empty(candidate, "message"))
-        .transpose()
+    Ok(value
+        .map(str::trim)
+        .filter(|candidate| !candidate.is_empty())
+        .map(|candidate| candidate.to_string()))
 }
 
 fn normalize_pair_accepted_event(raw: PairAcceptedSystemEvent) -> Result<PairAcceptedSystemEvent> {
@@ -394,7 +395,7 @@ mod tests {
     }
 
     #[test]
-    fn pair_accepted_rejects_blank_proxy_message() {
+    fn pair_accepted_ignores_blank_proxy_message_and_uses_fallback() {
         let temp = TempDir::new().expect("temp dir");
         let store = clawdentity_core::SqliteStore::open_path(temp.path().join("db.sqlite3"))
             .expect("open db");
@@ -404,8 +405,13 @@ mod tests {
         let mut deliver = fixture_deliver_frame();
         deliver.payload["system"]["message"] = json!("   ");
 
-        let error = apply_pair_accepted_system_delivery(&store, temp.path(), &mut deliver)
-            .expect_err("blank message should fail validation");
-        assert!(error.to_string().contains("message is required"));
+        apply_pair_accepted_system_delivery(&store, temp.path(), &mut deliver).expect("apply");
+
+        let message = deliver
+            .payload
+            .get("message")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default();
+        assert!(message.contains("Clawdentity pairing accepted"));
     }
 }

--- a/crates/clawdentity-cli/src/commands/connector/delivery/pair_accepted.rs
+++ b/crates/clawdentity-cli/src/commands/connector/delivery/pair_accepted.rs
@@ -30,6 +30,7 @@ struct PairAcceptedSystemEvent {
     responder_profile: PairAcceptedSystemProfile,
     issuer_proxy_origin: String,
     event_timestamp_utc: String,
+    message: Option<String>,
 }
 
 fn normalize_non_empty(value: &str, field: &str) -> Result<String> {
@@ -57,6 +58,12 @@ fn normalize_event_timestamp_utc(value: &str) -> Result<String> {
     Ok(parsed
         .with_timezone(&Utc)
         .to_rfc3339_opts(SecondsFormat::Millis, true))
+}
+
+fn normalize_optional_message(value: Option<&str>) -> Result<Option<String>> {
+    value
+        .map(|candidate| normalize_non_empty(candidate, "message"))
+        .transpose()
 }
 
 fn normalize_pair_accepted_event(raw: PairAcceptedSystemEvent) -> Result<PairAcceptedSystemEvent> {
@@ -88,6 +95,7 @@ fn normalize_pair_accepted_event(raw: PairAcceptedSystemEvent) -> Result<PairAcc
     let issuer_proxy_origin =
         normalize_proxy_origin(&raw.issuer_proxy_origin, "issuerProxyOrigin")?;
     let event_timestamp_utc = normalize_event_timestamp_utc(&raw.event_timestamp_utc)?;
+    let message = normalize_optional_message(raw.message.as_deref())?;
 
     Ok(PairAcceptedSystemEvent {
         event_type: PAIR_ACCEPTED_SYSTEM_EVENT_TYPE.to_string(),
@@ -96,6 +104,7 @@ fn normalize_pair_accepted_event(raw: PairAcceptedSystemEvent) -> Result<PairAcc
         responder_profile,
         issuer_proxy_origin,
         event_timestamp_utc,
+        message,
     })
 }
 
@@ -121,10 +130,12 @@ fn parse_pair_accepted_system_event(payload: &Value) -> Result<Option<PairAccept
 }
 
 fn build_notification_payload(event: &PairAcceptedSystemEvent, peer_alias: &str) -> Value {
-    let message = format!(
-        "Clawdentity pairing accepted: {} ({}) is now saved as peer alias {}.",
-        event.responder_profile.agent_name, event.responder_profile.human_name, peer_alias
-    );
+    let message = event.message.clone().unwrap_or_else(|| {
+        format!(
+            "Clawdentity pairing accepted: {} ({}) is now saved as peer alias {}.",
+            event.responder_profile.agent_name, event.responder_profile.human_name, peer_alias
+        )
+    });
 
     json!({
         "type": "clawdentity:pair-accepted",
@@ -357,5 +368,44 @@ mod tests {
                 .and_then(serde_json::Value::as_str),
             Some("2026-03-28T00:00:00.000Z")
         );
+    }
+
+    #[test]
+    fn pair_accepted_notification_prefers_proxy_message_when_present() {
+        let temp = TempDir::new().expect("temp dir");
+        let store = clawdentity_core::SqliteStore::open_path(temp.path().join("db.sqlite3"))
+            .expect("open db");
+        let snapshot_path = temp.path().join("relay-peers.json");
+        write_runtime_snapshot_config(temp.path(), &snapshot_path);
+
+        let mut deliver = fixture_deliver_frame();
+        deliver.payload["system"]["message"] =
+            json!("Clawdentity pairing complete. You can now message this peer.");
+
+        apply_pair_accepted_system_delivery(&store, temp.path(), &mut deliver).expect("apply");
+
+        assert_eq!(
+            deliver
+                .payload
+                .get("message")
+                .and_then(serde_json::Value::as_str),
+            Some("Clawdentity pairing complete. You can now message this peer.")
+        );
+    }
+
+    #[test]
+    fn pair_accepted_rejects_blank_proxy_message() {
+        let temp = TempDir::new().expect("temp dir");
+        let store = clawdentity_core::SqliteStore::open_path(temp.path().join("db.sqlite3"))
+            .expect("open db");
+        let snapshot_path = temp.path().join("relay-peers.json");
+        write_runtime_snapshot_config(temp.path(), &snapshot_path);
+
+        let mut deliver = fixture_deliver_frame();
+        deliver.payload["system"]["message"] = json!("   ");
+
+        let error = apply_pair_accepted_system_delivery(&store, temp.path(), &mut deliver)
+            .expect_err("blank message should fail validation");
+        assert!(error.to_string().contains("message is required"));
     }
 }

--- a/packages/protocol/AGENTS.md
+++ b/packages/protocol/AGENTS.md
@@ -37,6 +37,8 @@
 - Keep trusted transport provenance constants for pair-accepted deliveries (`PAIR_ACCEPTED_TRUSTED_DELIVERY_SOURCE`) in protocol exports so queue producers and consumers cannot drift.
 - Keep pair-accepted payload side-effect fields (`initiatorAgentDid`, `responderAgentDid`, `responderProfile`, `issuerProxyOrigin`, `eventTimestampUtc`) mandatory for trusted processing; do not replace them with UI-only text.
 - Keep pair-accepted user text optional (`message`) and non-empty when present; it is UX metadata only and must not drive trust or persistence decisions.
+- Keep static pair-accepted UX wording centralized in a single exported contract constant (`PAIR_ACCEPTED_NOTIFICATION_MESSAGE`) so proxy producers/tests stay in sync.
+- Treat blank pair-accepted `message` as absent metadata (not a parse failure) to prevent cosmetic text drift from blocking trusted pairing side effects.
 
 ## Testing
 - Add focused Vitest tests per helper module and one root export test in `src/index.test.ts`.

--- a/packages/protocol/AGENTS.md
+++ b/packages/protocol/AGENTS.md
@@ -35,6 +35,8 @@
 - Parse and normalize pair-accepted payload values once in the protocol parser (DIDs, proxy origins, timestamp), require `responderProfile.proxyOrigin`, and pass normalized values downstream without duplicate re-validation in app layers.
 - Pair-accepted `eventTimestampUtc` parsing must enforce ISO-8601/RFC3339 shape and always normalize output to canonical UTC ISO (`toISOString`) so consumers never persist locale-dependent timestamp strings.
 - Keep trusted transport provenance constants for pair-accepted deliveries (`PAIR_ACCEPTED_TRUSTED_DELIVERY_SOURCE`) in protocol exports so queue producers and consumers cannot drift.
+- Keep pair-accepted payload side-effect fields (`initiatorAgentDid`, `responderAgentDid`, `responderProfile`, `issuerProxyOrigin`, `eventTimestampUtc`) mandatory for trusted processing; do not replace them with UI-only text.
+- Keep pair-accepted user text optional (`message`) and non-empty when present; it is UX metadata only and must not drive trust or persistence decisions.
 
 ## Testing
 - Add focused Vitest tests per helper module and one root export test in `src/index.test.ts`.

--- a/packages/protocol/src/index.test.ts
+++ b/packages/protocol/src/index.test.ts
@@ -33,6 +33,7 @@ import {
   makeAgentDid,
   makeHumanDid,
   PAIR_ACCEPTED_EVENT_TYPE,
+  PAIR_ACCEPTED_NOTIFICATION_MESSAGE,
   PAIR_ACCEPTED_TRUSTED_DELIVERY_SOURCE,
   PROTOCOL_VERSION,
   ProtocolParseError,
@@ -100,6 +101,9 @@ describe("protocol", () => {
 
   it("exports pair accepted queue event constants and parser", () => {
     expect(PAIR_ACCEPTED_EVENT_TYPE).toBe("pair.accepted");
+    expect(PAIR_ACCEPTED_NOTIFICATION_MESSAGE).toBe(
+      "Clawdentity pairing complete. You can now message this peer.",
+    );
     expect(PAIR_ACCEPTED_TRUSTED_DELIVERY_SOURCE).toBe(
       "proxy.events.queue.pair_accepted",
     );

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -71,6 +71,7 @@ export type {
 export {
   createPairAcceptedEvent,
   PAIR_ACCEPTED_EVENT_TYPE,
+  PAIR_ACCEPTED_NOTIFICATION_MESSAGE,
   PAIR_ACCEPTED_TRUSTED_DELIVERY_SOURCE,
   parsePairAcceptedEvent,
 } from "./pairing-events.js";

--- a/packages/protocol/src/pairing-events.test.ts
+++ b/packages/protocol/src/pairing-events.test.ts
@@ -20,6 +20,7 @@ describe("pair accepted event contract", () => {
       },
       issuerProxyOrigin: "https://proxy.clawdentity.dev/pair/confirm",
       eventTimestampUtc: "2026-03-28T00:00:00.000Z",
+      message: " Clawdentity pairing complete. You can now message this peer. ",
     });
 
     expect(parsed).toEqual({
@@ -35,6 +36,7 @@ describe("pair accepted event contract", () => {
       },
       issuerProxyOrigin: "https://proxy.clawdentity.dev",
       eventTimestampUtc: "2026-03-28T00:00:00.000Z",
+      message: "Clawdentity pairing complete. You can now message this peer.",
     });
   });
 
@@ -71,9 +73,13 @@ describe("pair accepted event contract", () => {
       },
       issuerProxyOrigin: "https://proxy.clawdentity.dev",
       eventTimestampUtc: "2026-03-28T00:00:00.000Z",
+      message: "Clawdentity pairing complete. You can now message this peer.",
     });
 
     expect(event.type).toBe(PAIR_ACCEPTED_EVENT_TYPE);
+    expect(event.message).toBe(
+      "Clawdentity pairing complete. You can now message this peer.",
+    );
   });
 
   it("rejects non-ISO event timestamps", () => {
@@ -114,5 +120,44 @@ describe("pair accepted event contract", () => {
     });
 
     expect(parsed.eventTimestampUtc).toBe("2026-03-28T00:00:00.000Z");
+  });
+
+  it("keeps message optional for backward compatibility", () => {
+    const parsed = parsePairAcceptedEvent({
+      type: PAIR_ACCEPTED_EVENT_TYPE,
+      initiatorAgentDid:
+        "did:cdi:registry.clawdentity.dev:agent:01HF7YAT31JZHSMW1CG6Q6MHB7",
+      responderAgentDid:
+        "did:cdi:registry.clawdentity.dev:agent:01HF7YAT00EXEKCZ140TBBFB97",
+      responderProfile: {
+        agentName: "beta",
+        humanName: "Ira",
+        proxyOrigin: "https://beta.proxy.example",
+      },
+      issuerProxyOrigin: "https://proxy.clawdentity.dev",
+      eventTimestampUtc: "2026-03-28T00:00:00.000Z",
+    });
+
+    expect(parsed.message).toBeUndefined();
+  });
+
+  it("rejects blank message when provided", () => {
+    expect(() =>
+      parsePairAcceptedEvent({
+        type: PAIR_ACCEPTED_EVENT_TYPE,
+        initiatorAgentDid:
+          "did:cdi:registry.clawdentity.dev:agent:01HF7YAT31JZHSMW1CG6Q6MHB7",
+        responderAgentDid:
+          "did:cdi:registry.clawdentity.dev:agent:01HF7YAT00EXEKCZ140TBBFB97",
+        responderProfile: {
+          agentName: "beta",
+          humanName: "Ira",
+          proxyOrigin: "https://beta.proxy.example",
+        },
+        issuerProxyOrigin: "https://proxy.clawdentity.dev",
+        eventTimestampUtc: "2026-03-28T00:00:00.000Z",
+        message: "   ",
+      }),
+    ).toThrow("Pair accepted event field 'message' must be a non-empty string");
   });
 });

--- a/packages/protocol/src/pairing-events.test.ts
+++ b/packages/protocol/src/pairing-events.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   createPairAcceptedEvent,
   PAIR_ACCEPTED_EVENT_TYPE,
+  PAIR_ACCEPTED_NOTIFICATION_MESSAGE,
   parsePairAcceptedEvent,
 } from "./pairing-events.js";
 
@@ -20,7 +21,7 @@ describe("pair accepted event contract", () => {
       },
       issuerProxyOrigin: "https://proxy.clawdentity.dev/pair/confirm",
       eventTimestampUtc: "2026-03-28T00:00:00.000Z",
-      message: " Clawdentity pairing complete. You can now message this peer. ",
+      message: ` ${PAIR_ACCEPTED_NOTIFICATION_MESSAGE} `,
     });
 
     expect(parsed).toEqual({
@@ -36,7 +37,7 @@ describe("pair accepted event contract", () => {
       },
       issuerProxyOrigin: "https://proxy.clawdentity.dev",
       eventTimestampUtc: "2026-03-28T00:00:00.000Z",
-      message: "Clawdentity pairing complete. You can now message this peer.",
+      message: PAIR_ACCEPTED_NOTIFICATION_MESSAGE,
     });
   });
 
@@ -73,13 +74,11 @@ describe("pair accepted event contract", () => {
       },
       issuerProxyOrigin: "https://proxy.clawdentity.dev",
       eventTimestampUtc: "2026-03-28T00:00:00.000Z",
-      message: "Clawdentity pairing complete. You can now message this peer.",
+      message: PAIR_ACCEPTED_NOTIFICATION_MESSAGE,
     });
 
     expect(event.type).toBe(PAIR_ACCEPTED_EVENT_TYPE);
-    expect(event.message).toBe(
-      "Clawdentity pairing complete. You can now message this peer.",
-    );
+    expect(event.message).toBe(PAIR_ACCEPTED_NOTIFICATION_MESSAGE);
   });
 
   it("rejects non-ISO event timestamps", () => {
@@ -141,7 +140,27 @@ describe("pair accepted event contract", () => {
     expect(parsed.message).toBeUndefined();
   });
 
-  it("rejects blank message when provided", () => {
+  it("ignores blank message when provided", () => {
+    const parsed = parsePairAcceptedEvent({
+      type: PAIR_ACCEPTED_EVENT_TYPE,
+      initiatorAgentDid:
+        "did:cdi:registry.clawdentity.dev:agent:01HF7YAT31JZHSMW1CG6Q6MHB7",
+      responderAgentDid:
+        "did:cdi:registry.clawdentity.dev:agent:01HF7YAT00EXEKCZ140TBBFB97",
+      responderProfile: {
+        agentName: "beta",
+        humanName: "Ira",
+        proxyOrigin: "https://beta.proxy.example",
+      },
+      issuerProxyOrigin: "https://proxy.clawdentity.dev",
+      eventTimestampUtc: "2026-03-28T00:00:00.000Z",
+      message: "   ",
+    });
+
+    expect(parsed.message).toBeUndefined();
+  });
+
+  it("rejects non-string message values", () => {
     expect(() =>
       parsePairAcceptedEvent({
         type: PAIR_ACCEPTED_EVENT_TYPE,
@@ -156,8 +175,8 @@ describe("pair accepted event contract", () => {
         },
         issuerProxyOrigin: "https://proxy.clawdentity.dev",
         eventTimestampUtc: "2026-03-28T00:00:00.000Z",
-        message: "   ",
+        message: 42,
       }),
-    ).toThrow("Pair accepted event field 'message' must be a non-empty string");
+    ).toThrow("Pair accepted event field 'message' must be a string");
   });
 });

--- a/packages/protocol/src/pairing-events.ts
+++ b/packages/protocol/src/pairing-events.ts
@@ -17,6 +17,7 @@ export type PairAcceptedEvent = {
   responderProfile: PairAcceptedResponderProfile;
   issuerProxyOrigin: string;
   eventTimestampUtc: string;
+  message?: string;
 };
 
 function parseNonBlankString(value: unknown, field: string): string {
@@ -88,6 +89,14 @@ function parseTimestampUtc(value: unknown): string {
   return new Date(epochMs).toISOString();
 }
 
+function parseOptionalMessage(value: unknown): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  return parseNonBlankString(value, "message");
+}
+
 function parseResponderProfile(value: unknown): PairAcceptedResponderProfile {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
     throw new Error(
@@ -134,11 +143,14 @@ export function parsePairAcceptedEvent(payload: unknown): PairAcceptedEvent {
     responderProfile?: unknown;
     issuerProxyOrigin?: unknown;
     eventTimestampUtc?: unknown;
+    message?: unknown;
   };
 
   if (event.type !== PAIR_ACCEPTED_EVENT_TYPE) {
     throw new Error("Unsupported pair accepted event type");
   }
+
+  const message = parseOptionalMessage(event.message);
 
   return {
     type: PAIR_ACCEPTED_EVENT_TYPE,
@@ -156,6 +168,7 @@ export function parsePairAcceptedEvent(payload: unknown): PairAcceptedEvent {
       "issuerProxyOrigin",
     ),
     eventTimestampUtc: parseTimestampUtc(event.eventTimestampUtc),
+    ...(message === undefined ? {} : { message }),
   };
 }
 
@@ -165,6 +178,7 @@ export type CreatePairAcceptedEventInput = {
   responderProfile: PairAcceptedResponderProfile;
   issuerProxyOrigin: string;
   eventTimestampUtc: string;
+  message?: string;
 };
 
 export function createPairAcceptedEvent(

--- a/packages/protocol/src/pairing-events.ts
+++ b/packages/protocol/src/pairing-events.ts
@@ -3,6 +3,8 @@ import { parseAgentDid } from "./did.js";
 export const PAIR_ACCEPTED_EVENT_TYPE = "pair.accepted";
 export const PAIR_ACCEPTED_TRUSTED_DELIVERY_SOURCE =
   "proxy.events.queue.pair_accepted";
+export const PAIR_ACCEPTED_NOTIFICATION_MESSAGE =
+  "Clawdentity pairing complete. You can now message this peer.";
 
 export type PairAcceptedResponderProfile = {
   agentName: string;
@@ -93,8 +95,14 @@ function parseOptionalMessage(value: unknown): string | undefined {
   if (value === undefined) {
     return undefined;
   }
-
-  return parseNonBlankString(value, "message");
+  if (typeof value !== "string") {
+    throw new Error("Pair accepted event field 'message' must be a string");
+  }
+  const normalized = value.trim();
+  if (normalized.length === 0) {
+    return undefined;
+  }
+  return normalized;
 }
 
 function parseResponderProfile(value: unknown): PairAcceptedResponderProfile {


### PR DESCRIPTION
## Summary
- add optional `message` to protocol `pair.accepted` contract with non-empty validation when present
- publish fixed proxy notification message on pairing confirm:
  - `Clawdentity pairing complete. You can now message this peer.`
- preserve queue-first trusted structured pairing flow and forward `system.message` through queue consumer routing
- update Rust connector trusted pair-accepted handling to prefer proxy-provided message for OpenClaw notification payload, with fallback to existing generated message
- update AGENTS guidance in touched folders to document that structured fields remain required for side effects and message is UX-only metadata

## Validation
- `pnpm -F @clawdentity/protocol test`
- `pnpm -F @clawdentity/proxy test -- pairing-route.test/confirm.test.ts queue-consumer/pairing-events.test.ts worker.pairing-events.test.ts`
- `cd crates && cargo test -p clawdentity-cli pair_accepted`
- pre-push hook also ran affected `lint/format/typecheck/test` successfully

Closes #205