### PR TITLE
chore(rust): formatting cleanup in receipts and openclaw setup

### DIFF
--- a/crates/clawdentity-cli/src/commands/connector/receipts.rs
+++ b/crates/clawdentity-cli/src/commands/connector/receipts.rs
@@ -143,11 +143,7 @@ fn save_outbox(path: &Path, entries: &[QueuedDeliveryReceipt]) -> Result<()> {
     }
     let body = serde_json::to_string_pretty(entries)
         .map_err(|error| anyhow!("failed to encode receipt outbox: {error}"))?;
-    let tmp_path = path.with_extension(format!(
-        "tmp-{}-{}",
-        std::process::id(),
-        now_utc_ms()
-    ));
+    let tmp_path = path.with_extension(format!("tmp-{}-{}", std::process::id(), now_utc_ms()));
     fs::write(&tmp_path, format!("{body}\n"))
         .map_err(|error| anyhow!("failed to write receipt outbox temp file: {error}"))?;
     fs::rename(&tmp_path, path)

--- a/crates/clawdentity-core/src/providers/openclaw/setup.rs
+++ b/crates/clawdentity-core/src/providers/openclaw/setup.rs
@@ -167,7 +167,10 @@ fn parse_json_or_default(path: &Path) -> Result<serde_json::Value> {
         }
     };
     json5::from_str::<serde_json::Value>(&raw).map_err(|source| {
-        CoreError::InvalidInput(format!("failed to parse OpenClaw config {}: {source}", path.display()))
+        CoreError::InvalidInput(format!(
+            "failed to parse OpenClaw config {}: {source}",
+            path.display()
+        ))
     })
 }
 
@@ -663,13 +666,9 @@ mod tests {
     #[test]
     fn connector_suggestion_uses_next_available_port() {
         let temp = TempDir::new().expect("temp dir");
-        let _ = save_connector_assignment(
-            temp.path(),
-            "alpha",
-            "http://127.0.0.1:19400",
-            Some("main"),
-        )
-        .expect("save alpha");
+        let _ =
+            save_connector_assignment(temp.path(), "alpha", "http://127.0.0.1:19400", Some("main"))
+                .expect("save alpha");
         let suggested = suggest_connector_base_url(temp.path(), "beta").expect("suggest");
         assert_eq!(suggested, "http://127.0.0.1:19401");
     }
@@ -677,13 +676,9 @@ mod tests {
     #[test]
     fn connector_assignment_backfills_openclaw_agent_id_from_existing_entry() {
         let temp = TempDir::new().expect("temp dir");
-        let _ = save_connector_assignment(
-            temp.path(),
-            "alpha",
-            "http://127.0.0.1:19400",
-            Some("ops"),
-        )
-        .expect("save alpha");
+        let _ =
+            save_connector_assignment(temp.path(), "alpha", "http://127.0.0.1:19400", Some("ops"))
+                .expect("save alpha");
         let _ = save_connector_assignment(temp.path(), "alpha", "http://127.0.0.1:19401", None)
             .expect("update alpha");
 


### PR DESCRIPTION
## Summary
- clean up formatting and readability in connector receipts flow
- clean up formatting in OpenClaw setup flow
- no behavior change intended

## Changed Files
- crates/clawdentity-cli/src/commands/connector/receipts.rs
- crates/clawdentity-core/src/providers/openclaw/setup.rs

## Validation
- local commit created from existing working tree changes
