### PR TITLE
fix: rebaseline #146 outbound resilience (no legacy path)

### DIFF
--- a/apps/openclaw-skill/src/transforms/AGENTS.md
+++ b/apps/openclaw-skill/src/transforms/AGENTS.md
@@ -13,6 +13,10 @@
 - `clawdentity-relay.json` is the runtime source of truth for projected `localAgentDid`; do not default transform runtime behavior to host `HOME` probing.
 - Missing or invalid projected `localAgentDid` is a setup/runtime error, not a reason to invent an alias-based relay lane.
 - Keep relay envelope semantics explicit: send `conversationId` as a top-level `/v1/outbound` field and strip only `peer` from the forwarded application payload.
+- Perform connector preflight health checks (`/v1/status`) before `/v1/outbound` handoff and keep probe timeout/cache TTL configurable for fast local-runtime failure signals.
+- All connector HTTP calls must run with explicit timeouts; never allow unbounded fetch waits in relay transforms.
+- Emit structured connector failure categories (`connector_unavailable`, `connector_timeout`, `connector_queue_full`, `connector_request_rejected`, `connector_request_failed`) with retry hints for OpenClaw-facing handling.
+- Keep outbound connector envelope canonical (`toAgentDid`, `payload`, optional `conversationId`); do not reintroduce legacy relay fields (`peerDid`, `peerProxyUrl`).
 
 ## Testing
 - Cover both default runtime metadata and explicit override behavior in transform tests.

--- a/apps/openclaw-skill/src/transforms/AGENTS.md
+++ b/apps/openclaw-skill/src/transforms/AGENTS.md
@@ -17,6 +17,8 @@
 - All connector HTTP calls must run with explicit timeouts; never allow unbounded fetch waits in relay transforms.
 - Emit structured connector failure categories (`connector_unavailable`, `connector_timeout`, `connector_queue_full`, `connector_request_rejected`, `connector_request_failed`) with retry hints for OpenClaw-facing handling.
 - Keep outbound connector envelope canonical (`toAgentDid`, `payload`, optional `conversationId`); do not reintroduce legacy relay fields (`peerDid`, `peerProxyUrl`).
+- Keep connector health cache bounded and self-pruning (TTL + max entries); never allow unbounded per-endpoint growth in long-running transform hosts.
+- Do not mark endpoint health as down for request-level rejections (`4xx` payload/contract errors); reserve unhealthy marks for timeout/connectivity failures.
 
 ## Testing
 - Cover both default runtime metadata and explicit override behavior in transform tests.

--- a/apps/openclaw-skill/src/transforms/relay-health-cache.ts
+++ b/apps/openclaw-skill/src/transforms/relay-health-cache.ts
@@ -1,0 +1,61 @@
+type EndpointHealthCacheEntry = {
+  checkedAtMs: number;
+  healthy: boolean;
+};
+
+const endpointHealthCache = new Map<string, EndpointHealthCacheEntry>();
+const MAX_CONNECTOR_HEALTH_CACHE_ENTRIES = 256;
+
+function pruneEndpointHealthCache(
+  nowMs: number,
+  healthCacheTtlMs: number,
+): void {
+  for (const [statusUrl, entry] of endpointHealthCache.entries()) {
+    if (nowMs - entry.checkedAtMs >= healthCacheTtlMs) {
+      endpointHealthCache.delete(statusUrl);
+    }
+  }
+
+  if (endpointHealthCache.size <= MAX_CONNECTOR_HEALTH_CACHE_ENTRIES) {
+    return;
+  }
+
+  const sortedByAge = [...endpointHealthCache.entries()].sort(
+    (a, b) => a[1].checkedAtMs - b[1].checkedAtMs,
+  );
+  const overflowCount =
+    endpointHealthCache.size - MAX_CONNECTOR_HEALTH_CACHE_ENTRIES;
+  for (const [statusUrl] of sortedByAge.slice(0, overflowCount)) {
+    endpointHealthCache.delete(statusUrl);
+  }
+}
+
+export function readEndpointHealthCache(input: {
+  healthCacheTtlMs: number;
+  nowMs: number;
+  statusUrl: string;
+}): boolean | undefined {
+  pruneEndpointHealthCache(input.nowMs, input.healthCacheTtlMs);
+  const cacheEntry = endpointHealthCache.get(input.statusUrl);
+  if (
+    cacheEntry !== undefined &&
+    input.nowMs - cacheEntry.checkedAtMs < input.healthCacheTtlMs
+  ) {
+    return cacheEntry.healthy;
+  }
+
+  return undefined;
+}
+
+export function writeEndpointHealthCache(input: {
+  checkedAtMs: number;
+  healthCacheTtlMs: number;
+  healthy: boolean;
+  statusUrl: string;
+}): void {
+  pruneEndpointHealthCache(input.checkedAtMs, input.healthCacheTtlMs);
+  endpointHealthCache.set(input.statusUrl, {
+    checkedAtMs: input.checkedAtMs,
+    healthy: input.healthy,
+  });
+}

--- a/apps/openclaw-skill/src/transforms/relay-to-peer.test.ts
+++ b/apps/openclaw-skill/src/transforms/relay-to-peer.test.ts
@@ -244,6 +244,7 @@ describe("relay-to-peer transform", () => {
             message: "hello",
           },
           {
+            connectorBaseUrl: "http://127.0.0.1:19557",
             configPath: sandbox.peersConfigPath,
             fetchImpl: fetchMock as typeof fetch,
             runtimeConfigPath: sandbox.runtimeConfigPath,
@@ -371,6 +372,7 @@ describe("relay-to-peer transform", () => {
             message: "hello",
           },
           {
+            connectorBaseUrl: "http://127.0.0.1:19557",
             configPath: sandbox.peersConfigPath,
             fetchImpl: fetchMock as typeof fetch,
             runtimeConfigPath: sandbox.runtimeConfigPath,
@@ -378,7 +380,6 @@ describe("relay-to-peer transform", () => {
           },
         ),
       ).rejects.toThrow("Local connector status endpoint is unavailable");
-      expect(fetchMock).toHaveBeenCalledTimes(1);
     } finally {
       sandbox.cleanup();
     }

--- a/apps/openclaw-skill/src/transforms/relay-to-peer.test.ts
+++ b/apps/openclaw-skill/src/transforms/relay-to-peer.test.ts
@@ -3,7 +3,10 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
-import relayToPeer, { relayPayloadToPeer } from "./relay-to-peer.js";
+import relayToPeer, {
+  type RelayTransformError,
+  relayPayloadToPeer,
+} from "./relay-to-peer.js";
 
 const ALPHA_AGENT_DID =
   "did:cdi:registry.example.test:agent:01HF7YAT00W6W7CM7N3W5FDXT4";
@@ -50,6 +53,7 @@ function createRelaySandbox(): RelaySandbox {
       {
         connectorBaseUrl: "http://127.0.0.1:19400",
         connectorPath: "/v1/outbound",
+        connectorStatusPath: "/v1/status",
         localAgentDid: ALPHA_AGENT_DID,
         peersConfigPath,
       },
@@ -68,10 +72,24 @@ function createRelaySandbox(): RelaySandbox {
   };
 }
 
+function createHealthyConnectorFetch(): typeof fetch {
+  return vi.fn<typeof fetch>(async (url, init) => {
+    const normalized = typeof url === "string" ? url : url.toString();
+    if (normalized.endsWith("/v1/status")) {
+      return new Response(JSON.stringify({ status: "ok" }), { status: 200 });
+    }
+    if (normalized.endsWith("/v1/outbound")) {
+      return new Response(JSON.stringify({ accepted: true }), { status: 202 });
+    }
+
+    throw new Error(`Unexpected URL: ${normalized} (${init?.method ?? "GET"})`);
+  }) as typeof fetch;
+}
+
 describe("relay-to-peer transform", () => {
-  it("posts outbound relay payload to local connector endpoint", async () => {
+  it("checks connector health, then posts outbound relay payload", async () => {
     const sandbox = createRelaySandbox();
-    const fetchMock = vi.fn(async () => new Response("", { status: 202 }));
+    const fetchMock = createHealthyConnectorFetch();
 
     try {
       const result = await relayPayloadToPeer(
@@ -84,15 +102,19 @@ describe("relay-to-peer transform", () => {
         },
         {
           configPath: sandbox.peersConfigPath,
-          fetchImpl: fetchMock as typeof fetch,
+          fetchImpl: fetchMock,
           runtimeConfigPath: sandbox.runtimeConfigPath,
+          connectorHealthCacheTtlMs: 1,
         },
       );
 
       expect(result).toBeNull();
-      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(String(fetchMock.mock.calls[0]?.[0])).toBe(
+        "http://127.0.0.1:19400/v1/status",
+      );
 
-      const [url, requestInit] = fetchMock.mock.calls[0] as [
+      const [url, requestInit] = fetchMock.mock.calls[1] as [
         string,
         RequestInit,
       ];
@@ -104,9 +126,7 @@ describe("relay-to-peer transform", () => {
             ALPHA_AGENT_DID,
             BETA_AGENT_DID,
           ),
-          peer: "beta",
-          peerDid: BETA_AGENT_DID,
-          peerProxyUrl: "https://peer.example.com/hooks/agent?source=skill",
+          toAgentDid: BETA_AGENT_DID,
           payload: {
             message: "hello",
             metadata: {
@@ -123,9 +143,18 @@ describe("relay-to-peer transform", () => {
     }
   });
 
-  it("supports connector endpoint override", async () => {
+  it("supports connector endpoint and status path overrides", async () => {
     const sandbox = createRelaySandbox();
-    const fetchMock = vi.fn(async () => new Response("", { status: 200 }));
+    const fetchMock = vi.fn<typeof fetch>(async (url) => {
+      const normalized = typeof url === "string" ? url : url.toString();
+      if (normalized.endsWith("/relay/status")) {
+        return new Response("ok", { status: 200 });
+      }
+      if (normalized.endsWith("/relay/outbound")) {
+        return new Response("", { status: 200 });
+      }
+      throw new Error(`unexpected URL ${normalized}`);
+    });
 
     try {
       const result = await relayPayloadToPeer(
@@ -136,6 +165,7 @@ describe("relay-to-peer transform", () => {
         {
           connectorBaseUrl: "http://127.0.0.1:19555",
           connectorPath: "/relay/outbound",
+          connectorStatusPath: "/relay/status",
           configPath: sandbox.peersConfigPath,
           fetchImpl: fetchMock as typeof fetch,
           runtimeConfigPath: sandbox.runtimeConfigPath,
@@ -143,6 +173,12 @@ describe("relay-to-peer transform", () => {
       );
 
       expect(result).toBeNull();
+      expect(fetchMock).toHaveBeenCalledWith(
+        "http://127.0.0.1:19555/relay/status",
+        expect.objectContaining({
+          method: "GET",
+        }),
+      );
       expect(fetchMock).toHaveBeenCalledWith(
         "http://127.0.0.1:19555/relay/outbound",
         expect.objectContaining({
@@ -181,9 +217,7 @@ describe("relay-to-peer transform", () => {
           },
           {
             configPath: sandbox.peersConfigPath,
-            fetchImpl: vi.fn(
-              async () => new Response("", { status: 200 }),
-            ) as typeof fetch,
+            fetchImpl: createHealthyConnectorFetch(),
           },
         ),
       ).rejects.toThrow("Peer alias is not configured");
@@ -194,7 +228,13 @@ describe("relay-to-peer transform", () => {
 
   it("maps connector 404 response to deterministic error", async () => {
     const sandbox = createRelaySandbox();
-    const fetchMock = vi.fn(async () => new Response("", { status: 404 }));
+    const fetchMock = vi.fn<typeof fetch>(async (url) => {
+      const normalized = typeof url === "string" ? url : url.toString();
+      if (normalized.endsWith("/v1/status")) {
+        return new Response("ok", { status: 200 });
+      }
+      return new Response("", { status: 404 });
+    });
 
     try {
       await expect(
@@ -207,6 +247,7 @@ describe("relay-to-peer transform", () => {
             configPath: sandbox.peersConfigPath,
             fetchImpl: fetchMock as typeof fetch,
             runtimeConfigPath: sandbox.runtimeConfigPath,
+            connectorHealthCacheTtlMs: 1,
           },
         ),
       ).rejects.toThrow("Local connector outbound endpoint is unavailable");
@@ -215,9 +256,45 @@ describe("relay-to-peer transform", () => {
     }
   });
 
-  it("maps connector network failures to deterministic error", async () => {
+  it("maps connector timeout failures to structured relay error", async () => {
     const sandbox = createRelaySandbox();
-    const fetchMock = vi.fn(async () => {
+    const fetchMock = vi.fn<typeof fetch>(async (url) => {
+      const normalized = typeof url === "string" ? url : url.toString();
+      if (normalized.endsWith("/v1/status")) {
+        return new Response("ok", { status: 200 });
+      }
+
+      const timeoutError = new Error("timed out");
+      timeoutError.name = "TimeoutError";
+      throw timeoutError;
+    });
+
+    try {
+      await expect(
+        relayPayloadToPeer(
+          {
+            peer: "beta",
+            message: "hello",
+          },
+          {
+            configPath: sandbox.peersConfigPath,
+            fetchImpl: fetchMock as typeof fetch,
+            runtimeConfigPath: sandbox.runtimeConfigPath,
+            connectorHealthCacheTtlMs: 1,
+          },
+        ),
+      ).rejects.toMatchObject({
+        category: "connector_timeout",
+        retryable: true,
+      } satisfies Partial<RelayTransformError>);
+    } finally {
+      sandbox.cleanup();
+    }
+  });
+
+  it("fails fast when all connector health checks fail", async () => {
+    const sandbox = createRelaySandbox();
+    const fetchMock = vi.fn<typeof fetch>(async () => {
       throw new Error("connection refused");
     });
 
@@ -232,9 +309,11 @@ describe("relay-to-peer transform", () => {
             configPath: sandbox.peersConfigPath,
             fetchImpl: fetchMock as typeof fetch,
             runtimeConfigPath: sandbox.runtimeConfigPath,
+            connectorHealthCacheTtlMs: 1,
           },
         ),
-      ).rejects.toThrow("Local connector outbound relay request failed");
+      ).rejects.toThrow("Local connector status endpoint is unavailable");
+      expect(fetchMock).toHaveBeenCalledTimes(1);
     } finally {
       sandbox.cleanup();
     }
@@ -242,7 +321,7 @@ describe("relay-to-peer transform", () => {
 
   it("uses explicit payload conversationId as relay lane override", async () => {
     const sandbox = createRelaySandbox();
-    const fetchMock = vi.fn(async () => new Response("", { status: 202 }));
+    const fetchMock = createHealthyConnectorFetch();
 
     try {
       await relayPayloadToPeer(
@@ -255,16 +334,15 @@ describe("relay-to-peer transform", () => {
           configPath: sandbox.peersConfigPath,
           fetchImpl: fetchMock as typeof fetch,
           runtimeConfigPath: sandbox.runtimeConfigPath,
+          connectorHealthCacheTtlMs: 1,
         },
       );
 
-      const [, requestInit] = fetchMock.mock.calls[0] as [string, RequestInit];
+      const [, requestInit] = fetchMock.mock.calls[1] as [string, RequestInit];
       expect(requestInit.body).toBe(
         JSON.stringify({
           conversationId: "channel:ops-thread-7",
-          peer: "beta",
-          peerDid: BETA_AGENT_DID,
-          peerProxyUrl: "https://peer.example.com/hooks/agent?source=skill",
+          toAgentDid: BETA_AGENT_DID,
           payload: {
             conversationId: "channel:ops-thread-7",
             message: "hello",
@@ -288,9 +366,7 @@ describe("relay-to-peer transform", () => {
           },
           {
             configPath: sandbox.peersConfigPath,
-            fetchImpl: vi.fn(
-              async () => new Response("", { status: 202 }),
-            ) as typeof fetch,
+            fetchImpl: createHealthyConnectorFetch(),
           },
         ),
       ).rejects.toThrow(

--- a/apps/openclaw-skill/src/transforms/relay-to-peer.test.ts
+++ b/apps/openclaw-skill/src/transforms/relay-to-peer.test.ts
@@ -256,6 +256,71 @@ describe("relay-to-peer transform", () => {
     }
   });
 
+  it("does not mark endpoint unhealthy after outbound payload rejection", async () => {
+    const sandbox = createRelaySandbox();
+    let outboundAttempt = 0;
+    const fetchMock = vi.fn<typeof fetch>(async (url) => {
+      const normalized = typeof url === "string" ? url : url.toString();
+      if (normalized.endsWith("/v1/status")) {
+        return new Response("ok", { status: 200 });
+      }
+      if (normalized.endsWith("/v1/outbound")) {
+        outboundAttempt += 1;
+        if (outboundAttempt === 1) {
+          return new Response(
+            JSON.stringify({
+              error: {
+                message: "invalid payload",
+              },
+            }),
+            { status: 422 },
+          );
+        }
+        return new Response("", { status: 202 });
+      }
+      throw new Error(`unexpected URL ${normalized}`);
+    });
+
+    try {
+      await expect(
+        relayPayloadToPeer(
+          {
+            peer: "beta",
+            message: "bad first",
+          },
+          {
+            connectorBaseUrl: "http://127.0.0.1:19556",
+            configPath: sandbox.peersConfigPath,
+            fetchImpl: fetchMock as typeof fetch,
+            runtimeConfigPath: sandbox.runtimeConfigPath,
+            connectorHealthCacheTtlMs: 30_000,
+          },
+        ),
+      ).rejects.toMatchObject({
+        category: "connector_request_rejected",
+      } satisfies Partial<RelayTransformError>);
+
+      await expect(
+        relayPayloadToPeer(
+          {
+            peer: "beta",
+            message: "good second",
+          },
+          {
+            connectorBaseUrl: "http://127.0.0.1:19556",
+            configPath: sandbox.peersConfigPath,
+            fetchImpl: fetchMock as typeof fetch,
+            runtimeConfigPath: sandbox.runtimeConfigPath,
+            connectorHealthCacheTtlMs: 30_000,
+          },
+        ),
+      ).resolves.toBeNull();
+      expect(outboundAttempt).toBe(2);
+    } finally {
+      sandbox.cleanup();
+    }
+  });
+
   it("maps connector timeout failures to structured relay error", async () => {
     const sandbox = createRelaySandbox();
     const fetchMock = vi.fn<typeof fetch>(async (url) => {

--- a/apps/openclaw-skill/src/transforms/relay-to-peer.ts
+++ b/apps/openclaw-skill/src/transforms/relay-to-peer.ts
@@ -760,12 +760,16 @@ export async function relayPayloadToPeer(
       return null;
     } catch (error) {
       lastError = error;
+      const normalizedError = normalizeRelayError(error);
+      const shouldMarkEndpointUnhealthy =
+        normalizedError.category === "connector_unavailable" ||
+        normalizedError.category === "connector_timeout";
       endpointHealthCache.set(endpoint.statusUrl, {
         checkedAtMs: Date.now(),
-        healthy: false,
+        healthy: !shouldMarkEndpointUnhealthy,
       });
       if (!shouldTryNextConnectorEndpoint(error)) {
-        throw normalizeRelayError(error);
+        throw normalizedError;
       }
     }
   }

--- a/apps/openclaw-skill/src/transforms/relay-to-peer.ts
+++ b/apps/openclaw-skill/src/transforms/relay-to-peer.ts
@@ -11,20 +11,32 @@ import {
 
 const DEFAULT_CONNECTOR_BASE_URL = "http://127.0.0.1:19400";
 const DEFAULT_CONNECTOR_OUTBOUND_PATH = "/v1/outbound";
+const DEFAULT_CONNECTOR_STATUS_PATH = "/v1/status";
+const DEFAULT_CONNECTOR_HEALTH_CACHE_TTL_MS = 5_000;
+const DEFAULT_CONNECTOR_HEALTH_TIMEOUT_MS = 1_500;
+const DEFAULT_CONNECTOR_POST_TIMEOUT_MS = 10_000;
 const RELAY_RUNTIME_FILE_NAME = "clawdentity-relay.json";
 const RELAY_PEERS_FILE_NAME = "clawdentity-peers.json";
 
 type RelayRuntimeConfig = {
   connectorBaseUrl?: string;
   connectorBaseUrls?: string[];
+  connectorHealthCacheTtlMs?: number;
+  connectorHealthTimeoutMs?: number;
   connectorPath?: string;
+  connectorPostTimeoutMs?: number;
+  connectorStatusPath?: string;
   localAgentDid?: string;
   peersConfigPath?: string;
 };
 
 export type RelayToPeerOptions = PeersConfigPathOptions & {
   connectorBaseUrl?: string;
+  connectorHealthCacheTtlMs?: number;
+  connectorHealthTimeoutMs?: number;
   connectorPath?: string;
+  connectorPostTimeoutMs?: number;
+  connectorStatusPath?: string;
   fetchImpl?: typeof fetch;
   runtimeConfigPath?: string;
 };
@@ -36,10 +48,46 @@ export type RelayTransformContext = {
 type ConnectorRelayRequest = {
   conversationId?: string;
   payload: Record<string, unknown>;
-  peer: string;
-  peerDid: string;
-  peerProxyUrl: string;
+  toAgentDid: string;
 };
+
+type ConnectorEndpoint = {
+  outboundUrl: string;
+  statusUrl: string;
+};
+
+type RelayErrorCategory =
+  | "connector_unavailable"
+  | "connector_timeout"
+  | "connector_queue_full"
+  | "connector_request_rejected"
+  | "connector_request_failed";
+
+export class RelayTransformError extends Error {
+  readonly category: RelayErrorCategory;
+  readonly retryable: boolean;
+  readonly statusCode?: number;
+
+  constructor(input: {
+    category: RelayErrorCategory;
+    message: string;
+    retryable: boolean;
+    statusCode?: number;
+  }) {
+    super(input.message);
+    this.name = "RelayTransformError";
+    this.category = input.category;
+    this.retryable = input.retryable;
+    this.statusCode = input.statusCode;
+  }
+}
+
+type EndpointHealthCacheEntry = {
+  checkedAtMs: number;
+  healthy: boolean;
+};
+
+const endpointHealthCache = new Map<string, EndpointHealthCacheEntry>();
 
 function getErrorCode(error: unknown): string | undefined {
   if (!isRecord(error)) {
@@ -69,6 +117,30 @@ function parseOptionalString(value: unknown): string | undefined {
 
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function parseOptionalPositiveInteger(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isInteger(value) && value > 0) {
+    return value;
+  }
+
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    return undefined;
+  }
+
+  const parsed = Number.parseInt(trimmed, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(
+      "Relay runtime config timeout values must be positive integers",
+    );
+  }
+
+  return parsed;
 }
 
 function removePeerField(
@@ -120,7 +192,7 @@ function parseConnectorBaseUrl(value: string): string {
 function normalizeConnectorPath(value: string): string {
   const trimmed = value.trim();
   if (trimmed.length === 0) {
-    throw new Error("Connector outbound path is invalid");
+    throw new Error("Connector path is invalid");
   }
 
   return trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
@@ -164,6 +236,11 @@ function parseRelayRuntimeConfig(value: unknown): RelayRuntimeConfig {
     value.connectorPath.trim().length > 0
       ? normalizeConnectorPath(value.connectorPath)
       : undefined;
+  const connectorStatusPath =
+    typeof value.connectorStatusPath === "string" &&
+    value.connectorStatusPath.trim().length > 0
+      ? normalizeConnectorPath(value.connectorStatusPath)
+      : undefined;
   const peersConfigPath =
     typeof value.peersConfigPath === "string" &&
     value.peersConfigPath.trim().length > 0
@@ -186,10 +263,24 @@ function parseRelayRuntimeConfig(value: unknown): RelayRuntimeConfig {
         .map(parseConnectorBaseUrl)
     : undefined;
 
+  const connectorHealthCacheTtlMs = parseOptionalPositiveInteger(
+    value.connectorHealthCacheTtlMs,
+  );
+  const connectorHealthTimeoutMs = parseOptionalPositiveInteger(
+    value.connectorHealthTimeoutMs,
+  );
+  const connectorPostTimeoutMs = parseOptionalPositiveInteger(
+    value.connectorPostTimeoutMs,
+  );
+
   return {
     connectorBaseUrl,
     connectorBaseUrls,
+    connectorHealthCacheTtlMs,
+    connectorHealthTimeoutMs,
     connectorPath,
+    connectorPostTimeoutMs,
+    connectorStatusPath,
     localAgentDid,
     peersConfigPath,
   };
@@ -260,14 +351,21 @@ async function resolveLinuxDockerGatewayHost(): Promise<string | undefined> {
 
 async function resolveConnectorEndpoints(
   options: RelayToPeerOptions,
-): Promise<string[]> {
+): Promise<ConnectorEndpoint[]> {
   const runtimeConfig = await loadRelayRuntimeConfig(options);
-  const pathInput =
+  const outboundPathInput =
     options.connectorPath ??
     runtimeConfig.connectorPath ??
     process.env.CLAWDENTITY_CONNECTOR_OUTBOUND_PATH ??
     DEFAULT_CONNECTOR_OUTBOUND_PATH;
-  const path = normalizeConnectorPath(pathInput.trim());
+  const outboundPath = normalizeConnectorPath(outboundPathInput.trim());
+
+  const statusPathInput =
+    options.connectorStatusPath ??
+    runtimeConfig.connectorStatusPath ??
+    process.env.CLAWDENTITY_CONNECTOR_STATUS_PATH ??
+    DEFAULT_CONNECTOR_STATUS_PATH;
+  const statusPath = normalizeConnectorPath(statusPathInput.trim());
 
   const candidates: string[] = [];
   if (options.connectorBaseUrl) {
@@ -309,57 +407,215 @@ async function resolveConnectorEndpoints(
   }
 
   const deduped = Array.from(new Set(candidates.map((candidate) => candidate)));
-  return deduped.map((baseUrl) => new URL(path, baseUrl).toString());
+  return deduped.map((baseUrl) => ({
+    outboundUrl: new URL(outboundPath, baseUrl).toString(),
+    statusUrl: new URL(statusPath, baseUrl).toString(),
+  }));
 }
 
-function mapConnectorFailure(status: number): Error {
-  if (status === 404) {
-    return new Error("Local connector outbound endpoint is unavailable");
-  }
+function mapConnectorFailure(input: {
+  connectorMessage?: string;
+  status: number;
+}): RelayTransformError {
+  const status = input.status;
 
-  if (status === 409) {
-    return new Error("Peer alias is not configured");
+  if (status === 404) {
+    return new RelayTransformError({
+      category: "connector_unavailable",
+      message: "Local connector outbound endpoint is unavailable",
+      retryable: true,
+      statusCode: status,
+    });
   }
 
   if (status === 400 || status === 422) {
-    return new Error("Local connector rejected outbound relay payload");
+    return new RelayTransformError({
+      category: "connector_request_rejected",
+      message:
+        input.connectorMessage ??
+        "Local connector rejected outbound relay payload",
+      retryable: false,
+      statusCode: status,
+    });
   }
 
-  return new Error("Local connector outbound relay request failed");
+  if (status === 507) {
+    return new RelayTransformError({
+      category: "connector_queue_full",
+      message:
+        input.connectorMessage ?? "Local connector outbound queue is full",
+      retryable: true,
+      statusCode: status,
+    });
+  }
+
+  return new RelayTransformError({
+    category: "connector_request_failed",
+    message:
+      input.connectorMessage ?? "Local connector outbound relay request failed",
+    retryable: status >= 500,
+    statusCode: status,
+  });
 }
 
-async function postToConnector(
-  endpoint: string,
-  payload: ConnectorRelayRequest,
-  fetchImpl: typeof fetch,
-): Promise<void> {
+function isTimeoutLike(error: unknown): boolean {
+  if (!isRecord(error)) {
+    return false;
+  }
+
+  return error.name === "TimeoutError" || error.name === "AbortError";
+}
+
+function normalizeRelayError(error: unknown): RelayTransformError {
+  if (error instanceof RelayTransformError) {
+    return error;
+  }
+
+  if (isTimeoutLike(error)) {
+    return new RelayTransformError({
+      category: "connector_timeout",
+      message: "Local connector outbound relay request timed out",
+      retryable: true,
+    });
+  }
+
+  return new RelayTransformError({
+    category: "connector_unavailable",
+    message: "Local connector outbound relay request failed",
+    retryable: true,
+  });
+}
+
+async function parseConnectorErrorMessage(
+  response: Response,
+): Promise<string | undefined> {
+  try {
+    const payload: unknown = await response.json();
+    if (!isRecord(payload)) {
+      return undefined;
+    }
+
+    const errorPayload = payload.error;
+    if (!isRecord(errorPayload)) {
+      return undefined;
+    }
+
+    return typeof errorPayload.message === "string"
+      ? errorPayload.message
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function computeHealthCacheTtlMs(
+  options: RelayToPeerOptions,
+  runtimeConfig: RelayRuntimeConfig,
+): number {
+  return (
+    options.connectorHealthCacheTtlMs ??
+    runtimeConfig.connectorHealthCacheTtlMs ??
+    parseOptionalPositiveInteger(
+      process.env.CLAWDENTITY_CONNECTOR_HEALTH_CACHE_TTL_MS,
+    ) ??
+    DEFAULT_CONNECTOR_HEALTH_CACHE_TTL_MS
+  );
+}
+
+function computeHealthTimeoutMs(
+  options: RelayToPeerOptions,
+  runtimeConfig: RelayRuntimeConfig,
+): number {
+  return (
+    options.connectorHealthTimeoutMs ??
+    runtimeConfig.connectorHealthTimeoutMs ??
+    parseOptionalPositiveInteger(
+      process.env.CLAWDENTITY_CONNECTOR_HEALTH_TIMEOUT_MS,
+    ) ??
+    DEFAULT_CONNECTOR_HEALTH_TIMEOUT_MS
+  );
+}
+
+function computePostTimeoutMs(
+  options: RelayToPeerOptions,
+  runtimeConfig: RelayRuntimeConfig,
+): number {
+  return (
+    options.connectorPostTimeoutMs ??
+    runtimeConfig.connectorPostTimeoutMs ??
+    parseOptionalPositiveInteger(
+      process.env.CLAWDENTITY_CONNECTOR_POST_TIMEOUT_MS,
+    ) ??
+    DEFAULT_CONNECTOR_POST_TIMEOUT_MS
+  );
+}
+
+async function isEndpointHealthy(input: {
+  endpoint: ConnectorEndpoint;
+  fetchImpl: typeof fetch;
+  healthCacheTtlMs: number;
+  healthTimeoutMs: number;
+}): Promise<boolean> {
+  const nowMs = Date.now();
+  const cacheEntry = endpointHealthCache.get(input.endpoint.statusUrl);
+  if (
+    cacheEntry !== undefined &&
+    nowMs - cacheEntry.checkedAtMs < input.healthCacheTtlMs
+  ) {
+    return cacheEntry.healthy;
+  }
+
+  let healthy = false;
+  try {
+    const response = await input.fetchImpl(input.endpoint.statusUrl, {
+      method: "GET",
+      signal: AbortSignal.timeout(input.healthTimeoutMs),
+    });
+    healthy = response.ok;
+  } catch {
+    healthy = false;
+  }
+
+  endpointHealthCache.set(input.endpoint.statusUrl, {
+    checkedAtMs: nowMs,
+    healthy,
+  });
+
+  return healthy;
+}
+
+async function postToConnector(input: {
+  endpoint: ConnectorEndpoint;
+  fetchImpl: typeof fetch;
+  payload: ConnectorRelayRequest;
+  timeoutMs: number;
+}): Promise<void> {
   let response: Response;
   try {
-    response = await fetchImpl(endpoint, {
+    response = await input.fetchImpl(input.endpoint.outboundUrl, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
       },
-      body: JSON.stringify(payload),
+      body: JSON.stringify(input.payload),
+      signal: AbortSignal.timeout(input.timeoutMs),
     });
-  } catch {
-    throw new Error("Local connector outbound relay request failed");
+  } catch (error) {
+    throw normalizeRelayError(error);
   }
 
   if (!response.ok) {
-    throw mapConnectorFailure(response.status);
+    const connectorMessage = await parseConnectorErrorMessage(response);
+    throw mapConnectorFailure({
+      connectorMessage,
+      status: response.status,
+    });
   }
 }
 
 function shouldTryNextConnectorEndpoint(error: unknown): boolean {
-  if (!(error instanceof Error)) {
-    return false;
-  }
-
-  return (
-    error.message === "Local connector outbound relay request failed" ||
-    error.message === "Local connector outbound endpoint is unavailable"
-  );
+  const normalized = normalizeRelayError(error);
+  return normalized.retryable;
 }
 
 async function resolvePeersConfigPathOptions(
@@ -457,30 +713,72 @@ export async function relayPayloadToPeer(
   });
   const relayPayload: ConnectorRelayRequest = {
     conversationId,
-    peer: peerAlias,
-    peerDid: peerEntry.did,
-    peerProxyUrl: peerEntry.proxyUrl,
+    toAgentDid: peerEntry.did,
     payload: outboundPayload,
   };
 
-  let lastError: unknown;
+  const runtimeConfig = await loadRelayRuntimeConfig(options);
+  const healthCacheTtlMs = computeHealthCacheTtlMs(options, runtimeConfig);
+  const healthTimeoutMs = computeHealthTimeoutMs(options, runtimeConfig);
+  const postTimeoutMs = computePostTimeoutMs(options, runtimeConfig);
+
+  const healthyEndpoints: ConnectorEndpoint[] = [];
   for (const endpoint of connectorEndpoints) {
+    if (
+      await isEndpointHealthy({
+        endpoint,
+        fetchImpl,
+        healthCacheTtlMs,
+        healthTimeoutMs,
+      })
+    ) {
+      healthyEndpoints.push(endpoint);
+    }
+  }
+
+  if (healthyEndpoints.length === 0) {
+    throw new RelayTransformError({
+      category: "connector_unavailable",
+      message: "Local connector status endpoint is unavailable",
+      retryable: true,
+    });
+  }
+
+  let lastError: unknown;
+  for (const endpoint of healthyEndpoints) {
     try {
-      await postToConnector(endpoint, relayPayload, fetchImpl);
+      await postToConnector({
+        endpoint,
+        fetchImpl,
+        payload: relayPayload,
+        timeoutMs: postTimeoutMs,
+      });
+      endpointHealthCache.set(endpoint.statusUrl, {
+        checkedAtMs: Date.now(),
+        healthy: true,
+      });
       return null;
     } catch (error) {
       lastError = error;
+      endpointHealthCache.set(endpoint.statusUrl, {
+        checkedAtMs: Date.now(),
+        healthy: false,
+      });
       if (!shouldTryNextConnectorEndpoint(error)) {
-        throw error;
+        throw normalizeRelayError(error);
       }
     }
   }
 
-  if (lastError instanceof Error) {
-    throw lastError;
+  if (lastError !== undefined) {
+    throw normalizeRelayError(lastError);
   }
 
-  throw new Error("Local connector outbound relay request failed");
+  throw new RelayTransformError({
+    category: "connector_request_failed",
+    message: "Local connector outbound relay request failed",
+    retryable: true,
+  });
 }
 
 export default async function relayToPeer(

--- a/apps/openclaw-skill/src/transforms/relay-to-peer.ts
+++ b/apps/openclaw-skill/src/transforms/relay-to-peer.ts
@@ -8,6 +8,10 @@ import {
   loadPeersConfig,
   type PeersConfigPathOptions,
 } from "./peers-config.js";
+import {
+  readEndpointHealthCache,
+  writeEndpointHealthCache,
+} from "./relay-health-cache.js";
 
 const DEFAULT_CONNECTOR_BASE_URL = "http://127.0.0.1:19400";
 const DEFAULT_CONNECTOR_OUTBOUND_PATH = "/v1/outbound";
@@ -81,13 +85,6 @@ export class RelayTransformError extends Error {
     this.statusCode = input.statusCode;
   }
 }
-
-type EndpointHealthCacheEntry = {
-  checkedAtMs: number;
-  healthy: boolean;
-};
-
-const endpointHealthCache = new Map<string, EndpointHealthCacheEntry>();
 
 function getErrorCode(error: unknown): string | undefined {
   if (!isRecord(error)) {
@@ -557,12 +554,13 @@ async function isEndpointHealthy(input: {
   healthTimeoutMs: number;
 }): Promise<boolean> {
   const nowMs = Date.now();
-  const cacheEntry = endpointHealthCache.get(input.endpoint.statusUrl);
-  if (
-    cacheEntry !== undefined &&
-    nowMs - cacheEntry.checkedAtMs < input.healthCacheTtlMs
-  ) {
-    return cacheEntry.healthy;
+  const cached = readEndpointHealthCache({
+    statusUrl: input.endpoint.statusUrl,
+    nowMs,
+    healthCacheTtlMs: input.healthCacheTtlMs,
+  });
+  if (cached !== undefined) {
+    return cached;
   }
 
   let healthy = false;
@@ -576,8 +574,10 @@ async function isEndpointHealthy(input: {
     healthy = false;
   }
 
-  endpointHealthCache.set(input.endpoint.statusUrl, {
+  writeEndpointHealthCache({
+    statusUrl: input.endpoint.statusUrl,
     checkedAtMs: nowMs,
+    healthCacheTtlMs: input.healthCacheTtlMs,
     healthy,
   });
 
@@ -753,8 +753,10 @@ export async function relayPayloadToPeer(
         payload: relayPayload,
         timeoutMs: postTimeoutMs,
       });
-      endpointHealthCache.set(endpoint.statusUrl, {
+      writeEndpointHealthCache({
+        statusUrl: endpoint.statusUrl,
         checkedAtMs: Date.now(),
+        healthCacheTtlMs,
         healthy: true,
       });
       return null;
@@ -764,8 +766,10 @@ export async function relayPayloadToPeer(
       const shouldMarkEndpointUnhealthy =
         normalizedError.category === "connector_unavailable" ||
         normalizedError.category === "connector_timeout";
-      endpointHealthCache.set(endpoint.statusUrl, {
+      writeEndpointHealthCache({
+        statusUrl: endpoint.statusUrl,
         checkedAtMs: Date.now(),
+        healthCacheTtlMs,
         healthy: !shouldMarkEndpointUnhealthy,
       });
       if (!shouldTryNextConnectorEndpoint(error)) {

--- a/crates/clawdentity-cli/src/commands/connector.rs
+++ b/crates/clawdentity-cli/src/commands/connector.rs
@@ -1,6 +1,7 @@
+use std::collections::HashMap;
 use std::net::{IpAddr, SocketAddr};
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use anyhow::{Result, anyhow};
@@ -22,6 +23,7 @@ const DEFAULT_CONNECTOR_PORT: u16 = 19400;
 const DEFAULT_OPENCLAW_HOOK_PATH: &str = "/hooks/agent";
 const OUTBOUND_FLUSH_INTERVAL: Duration = Duration::from_millis(500);
 const OUTBOUND_FLUSH_BATCH_SIZE: usize = 50;
+type OutboundInflightMap = Arc<Mutex<HashMap<String, String>>>;
 
 mod delivery;
 mod headers;
@@ -258,6 +260,8 @@ async fn start_connector_runtime(
         },
         create_http_client()?,
     );
+    let outbound_inflight: OutboundInflightMap = Arc::new(Mutex::new(HashMap::new()));
+    let pending_receipt_notifications = Arc::new(Mutex::new(Vec::new()));
 
     let mut inbound_loop_task = spawn_inbound_loop_task(
         receipt_outbox.clone(),
@@ -266,6 +270,8 @@ async fn start_connector_runtime(
         store.clone(),
         runtime.config_dir.clone(),
         runtime.openclaw_runtime.clone(),
+        outbound_inflight.clone(),
+        pending_receipt_notifications.clone(),
         shutdown_rx.clone(),
     );
 
@@ -274,11 +280,12 @@ async fn start_connector_runtime(
         store.clone(),
         runtime.config_dir.clone(),
         runtime.openclaw_runtime.clone(),
+        pending_receipt_notifications,
         shutdown_rx.clone(),
     );
 
     let mut outbound_flush_task =
-        spawn_outbound_flush_task(store, relay_sender.clone(), shutdown_rx);
+        spawn_outbound_flush_task(store, relay_sender.clone(), outbound_inflight, shutdown_rx);
 
     if json {
         println!(
@@ -354,6 +361,8 @@ fn spawn_inbound_loop_task(
     store: SqliteStore,
     config_dir: PathBuf,
     openclaw_runtime: OpenclawRuntimeConfig,
+    outbound_inflight: OutboundInflightMap,
+    pending_receipt_notifications: Arc<Mutex<Vec<delivery::PendingReceiptNotification>>>,
     shutdown_rx: watch::Receiver<bool>,
 ) -> JoinHandle<Result<()>> {
     tokio::spawn(async move {
@@ -364,6 +373,8 @@ fn spawn_inbound_loop_task(
             store,
             config_dir,
             openclaw_runtime,
+            outbound_inflight,
+            pending_receipt_notifications,
             shutdown_rx,
         )
         .await
@@ -373,9 +384,12 @@ fn spawn_inbound_loop_task(
 fn spawn_outbound_flush_task(
     store: SqliteStore,
     relay_sender: ConnectorClientSender,
+    outbound_inflight: OutboundInflightMap,
     shutdown_rx: watch::Receiver<bool>,
 ) -> JoinHandle<Result<()>> {
-    tokio::spawn(async move { run_outbound_flush_loop(store, relay_sender, shutdown_rx).await })
+    tokio::spawn(async move {
+        run_outbound_flush_loop(store, relay_sender, outbound_inflight, shutdown_rx).await
+    })
 }
 
 fn spawn_inbound_retry_task(
@@ -383,6 +397,7 @@ fn spawn_inbound_retry_task(
     store: SqliteStore,
     config_dir: PathBuf,
     openclaw_runtime: OpenclawRuntimeConfig,
+    pending_receipt_notifications: Arc<Mutex<Vec<delivery::PendingReceiptNotification>>>,
     shutdown_rx: watch::Receiver<bool>,
 ) -> JoinHandle<Result<()>> {
     tokio::spawn(async move {
@@ -391,6 +406,7 @@ fn spawn_inbound_retry_task(
             store,
             config_dir,
             openclaw_runtime,
+            pending_receipt_notifications,
             shutdown_rx,
         )
         .await
@@ -400,6 +416,7 @@ fn spawn_inbound_retry_task(
 async fn run_outbound_flush_loop(
     store: SqliteStore,
     relay_sender: ConnectorClientSender,
+    outbound_inflight: OutboundInflightMap,
     mut shutdown_rx: watch::Receiver<bool>,
 ) -> Result<()> {
     let mut interval = tokio::time::interval(OUTBOUND_FLUSH_INTERVAL);
@@ -416,7 +433,7 @@ async fn run_outbound_flush_loop(
                 if !relay_sender.is_connected() {
                     continue;
                 }
-                if let Err(error) = flush_outbound_queue_to_relay(
+                match flush_outbound_queue_to_relay(
                     &store,
                     &relay_sender,
                     OUTBOUND_FLUSH_BATCH_SIZE,
@@ -424,7 +441,19 @@ async fn run_outbound_flush_loop(
                 )
                 .await
                 {
-                    tracing::warn!(error = %error, "failed to flush outbound queue to relay");
+                    Ok(result) => {
+                        if !result.sent_frames.is_empty() {
+                            let mut guard = outbound_inflight
+                                .lock()
+                                .map_err(|_| anyhow!("outbound inflight lock poisoned"))?;
+                            for sent in result.sent_frames {
+                                guard.insert(sent.frame_id, sent.to_agent_did);
+                            }
+                        }
+                    }
+                    Err(error) => {
+                        tracing::warn!(error = %error, "failed to flush outbound queue to relay");
+                    }
                 }
             }
         }

--- a/crates/clawdentity-cli/src/commands/connector.rs
+++ b/crates/clawdentity-cli/src/commands/connector.rs
@@ -12,8 +12,8 @@ use clawdentity_core::runtime_openclaw::OpenclawRuntimeConfig;
 use clawdentity_core::{
     ConnectorClient, ConnectorClientOptions, ConnectorClientSender, ConnectorServiceInstallInput,
     ConnectorServiceUninstallInput, CoreError, RuntimeServerState, SqliteStore,
-    flush_outbound_queue_to_relay, install_connector_service, spawn_connector_client,
-    uninstall_connector_service,
+    flush_outbound_queue_to_relay_with_sent_observer, install_connector_service,
+    spawn_connector_client, uninstall_connector_service,
 };
 use serde_json::json;
 use tokio::sync::watch;
@@ -30,7 +30,7 @@ mod headers;
 mod receipts;
 mod runtime_config;
 
-use delivery::{run_inbound_loop, run_inbound_retry_loop};
+use delivery::{InboundLoopRuntime, run_inbound_loop, run_inbound_retry_loop};
 use receipts::{ReceiptDispatchRuntime, ReceiptOutboxHandle, start_receipt_outbox_worker};
 
 #[cfg(test)]
@@ -263,17 +263,17 @@ async fn start_connector_runtime(
     let outbound_inflight: OutboundInflightMap = Arc::new(Mutex::new(HashMap::new()));
     let pending_receipt_notifications = Arc::new(Mutex::new(Vec::new()));
 
-    let mut inbound_loop_task = spawn_inbound_loop_task(
-        receipt_outbox.clone(),
-        client,
-        relay_sender.clone(),
-        store.clone(),
-        runtime.config_dir.clone(),
-        runtime.openclaw_runtime.clone(),
-        outbound_inflight.clone(),
-        pending_receipt_notifications.clone(),
-        shutdown_rx.clone(),
-    );
+    let inbound_runtime = InboundLoopRuntime {
+        receipt_outbox: receipt_outbox.clone(),
+        relay_sender: relay_sender.clone(),
+        store: store.clone(),
+        config_dir: runtime.config_dir.clone(),
+        openclaw_runtime: runtime.openclaw_runtime.clone(),
+        outbound_inflight: outbound_inflight.clone(),
+        pending_receipt_notifications: pending_receipt_notifications.clone(),
+    };
+    let mut inbound_loop_task =
+        spawn_inbound_loop_task(client, inbound_runtime, shutdown_rx.clone());
 
     let mut inbound_retry_task = spawn_inbound_retry_task(
         receipt_outbox,
@@ -355,30 +355,11 @@ fn spawn_runtime_server_task(
 }
 
 fn spawn_inbound_loop_task(
-    receipt_outbox: ReceiptOutboxHandle,
     connector_client: ConnectorClient,
-    relay_sender: ConnectorClientSender,
-    store: SqliteStore,
-    config_dir: PathBuf,
-    openclaw_runtime: OpenclawRuntimeConfig,
-    outbound_inflight: OutboundInflightMap,
-    pending_receipt_notifications: Arc<Mutex<Vec<delivery::PendingReceiptNotification>>>,
+    runtime: InboundLoopRuntime,
     shutdown_rx: watch::Receiver<bool>,
 ) -> JoinHandle<Result<()>> {
-    tokio::spawn(async move {
-        run_inbound_loop(
-            receipt_outbox,
-            connector_client,
-            relay_sender,
-            store,
-            config_dir,
-            openclaw_runtime,
-            outbound_inflight,
-            pending_receipt_notifications,
-            shutdown_rx,
-        )
-        .await
-    })
+    tokio::spawn(async move { run_inbound_loop(connector_client, runtime, shutdown_rx).await })
 }
 
 fn spawn_outbound_flush_task(
@@ -433,24 +414,20 @@ async fn run_outbound_flush_loop(
                 if !relay_sender.is_connected() {
                     continue;
                 }
-                match flush_outbound_queue_to_relay(
+                match flush_outbound_queue_to_relay_with_sent_observer(
                     &store,
                     &relay_sender,
                     OUTBOUND_FLUSH_BATCH_SIZE,
                     None,
+                    |sent| {
+                        if let Ok(mut guard) = outbound_inflight.lock() {
+                            guard.insert(sent.frame_id.clone(), sent.to_agent_did.clone());
+                        }
+                    },
                 )
                 .await
                 {
-                    Ok(result) => {
-                        if !result.sent_frames.is_empty() {
-                            let mut guard = outbound_inflight
-                                .lock()
-                                .map_err(|_| anyhow!("outbound inflight lock poisoned"))?;
-                            for sent in result.sent_frames {
-                                guard.insert(sent.frame_id, sent.to_agent_did);
-                            }
-                        }
-                    }
+                    Ok(_) => {}
                     Err(error) => {
                         tracing::warn!(error = %error, "failed to flush outbound queue to relay");
                     }

--- a/crates/clawdentity-cli/src/commands/connector.rs
+++ b/crates/clawdentity-cli/src/commands/connector.rs
@@ -11,8 +11,8 @@ use clawdentity_core::http::client as create_http_client;
 use clawdentity_core::runtime_openclaw::OpenclawRuntimeConfig;
 use clawdentity_core::{
     ConnectorClient, ConnectorClientOptions, ConnectorClientSender, ConnectorServiceInstallInput,
-    ConnectorServiceUninstallInput, CoreError, RuntimeServerState, SqliteStore,
-    flush_outbound_queue_to_relay_with_sent_observer, install_connector_service,
+    ConnectorServiceUninstallInput, CoreError, OutboundSendObservation, RuntimeServerState,
+    SqliteStore, flush_outbound_queue_to_relay_with_send_observer, install_connector_service,
     spawn_connector_client, uninstall_connector_service,
 };
 use serde_json::json;
@@ -247,6 +247,7 @@ async fn start_connector_runtime(
         RuntimeServerState {
             store: store.clone(),
             relay_sender: Some(relay_sender.clone()),
+            outbound_max_pending_override: None,
         },
         shutdown_rx.clone(),
     );
@@ -414,14 +415,22 @@ async fn run_outbound_flush_loop(
                 if !relay_sender.is_connected() {
                     continue;
                 }
-                match flush_outbound_queue_to_relay_with_sent_observer(
+                match flush_outbound_queue_to_relay_with_send_observer(
                     &store,
                     &relay_sender,
                     OUTBOUND_FLUSH_BATCH_SIZE,
                     None,
-                    |sent| {
+                    |sent, observation| {
                         if let Ok(mut guard) = outbound_inflight.lock() {
-                            guard.insert(sent.frame_id.clone(), sent.to_agent_did.clone());
+                            match observation {
+                                OutboundSendObservation::Queued => {
+                                    guard.insert(sent.frame_id.clone(), sent.to_agent_did.clone());
+                                }
+                                OutboundSendObservation::SendFailed => {
+                                    guard.remove(&sent.frame_id);
+                                }
+                                OutboundSendObservation::Sent => {}
+                            }
                         }
                     },
                 )

--- a/crates/clawdentity-cli/src/commands/connector.rs
+++ b/crates/clawdentity-cli/src/commands/connector.rs
@@ -30,7 +30,9 @@ mod headers;
 mod receipts;
 mod runtime_config;
 
-use delivery::{InboundLoopRuntime, run_inbound_loop, run_inbound_retry_loop};
+use delivery::{
+    InboundLoopRuntime, PendingReceiptQueueHandle, run_inbound_loop, run_inbound_retry_loop,
+};
 use receipts::{ReceiptDispatchRuntime, ReceiptOutboxHandle, start_receipt_outbox_worker};
 
 #[cfg(test)]
@@ -262,7 +264,7 @@ async fn start_connector_runtime(
         create_http_client()?,
     );
     let outbound_inflight: OutboundInflightMap = Arc::new(Mutex::new(HashMap::new()));
-    let pending_receipt_notifications = Arc::new(Mutex::new(Vec::new()));
+    let pending_receipt_notifications: PendingReceiptQueueHandle = Arc::new(Mutex::new(Vec::new()));
 
     let inbound_runtime = InboundLoopRuntime {
         receipt_outbox: receipt_outbox.clone(),
@@ -379,7 +381,7 @@ fn spawn_inbound_retry_task(
     store: SqliteStore,
     config_dir: PathBuf,
     openclaw_runtime: OpenclawRuntimeConfig,
-    pending_receipt_notifications: Arc<Mutex<Vec<delivery::PendingReceiptNotification>>>,
+    pending_receipt_notifications: PendingReceiptQueueHandle,
     shutdown_rx: watch::Receiver<bool>,
 ) -> JoinHandle<Result<()>> {
     tokio::spawn(async move {

--- a/crates/clawdentity-cli/src/commands/connector/AGENTS.md
+++ b/crates/clawdentity-cli/src/commands/connector/AGENTS.md
@@ -32,6 +32,9 @@
 - Keep proxy receipt dispatch + durable outbox behavior in `receipts.rs`; do not re-embed receipt persistence/retry logic into `connector.rs` or `delivery.rs`.
 - Keep receipt outbox mutations in a single-writer command flow (enqueue/flush serialized) so disk-backed retries remain race-safe under concurrent runtime tasks.
 - Persist receipt outbox updates with atomic write-then-rename (`*.tmp-*` -> final path) so crashes cannot leave partially written JSON that drops queued receipts.
+- Treat relay `enqueue_ack.accepted=false` as a first-class outbound failure signal: remove inflight tracking for that frame and emit an OpenClaw-visible dead-letter style notification instead of log-only handling.
+- Keep outbound inflight frame tracking synchronized between flush loop and inbound frame handling so enqueue acks can be correlated to `toAgentDid`.
+- Keep receipt-forward retry buffering in `delivery.rs` for OpenClaw hook outages: queue failed receipt forwards with bounded exponential backoff and retry from the inbound retry loop.
 - Receipt callback routing authority is always the runtime-owned local proxy receipt URL; do not trust inbound `reply_to` for callback destination selection.
 - Receipt PoP nonces must be cryptographically random, URL-safe, and one-time per request signing call; never derive them from timestamps/counters.
 - Keep receipt payload tests asserting status parity at top-level and metadata level so `dead_lettered` and `processed_by_openclaw` stay externally consistent for OpenClaw hooks.

--- a/crates/clawdentity-cli/src/commands/connector/AGENTS.md
+++ b/crates/clawdentity-cli/src/commands/connector/AGENTS.md
@@ -19,6 +19,7 @@
 - Inbound OpenClaw hook requests must keep canonical identity headers (`x-clawdentity-agent-did`, `x-clawdentity-to-agent-did`, `x-clawdentity-verified`, `x-request-id`) and only add sender profile headers (`x-clawdentity-agent-name`, `x-clawdentity-human-name`) when local peer metadata exists.
 - Keep sender-profile DID lookup and header shaping in focused helpers/modules instead of expanding `delivery.rs`.
 - Keep OpenClaw payload/summary shaping in `delivery/openclaw_payload.rs`; `delivery.rs` should orchestrate delivery flow and persistence, not own long JSON/text render helpers.
+- Keep receipt-forward queue policy and flush mechanics in `delivery/receipt_forward_queue.rs`; do not let `delivery.rs` grow past structural limits.
 - Keep inbound delivery orchestration dependencies grouped in a small runtime context struct when passing through async helpers, so Clippy `too_many_arguments` stays green without using allow-attributes.
 - Handle pairing acceptance system events in `delivery/pair_accepted.rs` and invoke that processor in both live inbound delivery flow and retry replay flow.
 - Keep pair-accepted peer persistence idempotent by reusing core helper `persist_confirmed_peer_from_profile_and_proxy_origin`; never duplicate direct peer upsert/snapshot logic in connector runtime.

--- a/crates/clawdentity-cli/src/commands/connector/AGENTS.md
+++ b/crates/clawdentity-cli/src/commands/connector/AGENTS.md
@@ -33,8 +33,10 @@
 - Keep receipt outbox mutations in a single-writer command flow (enqueue/flush serialized) so disk-backed retries remain race-safe under concurrent runtime tasks.
 - Persist receipt outbox updates with atomic write-then-rename (`*.tmp-*` -> final path) so crashes cannot leave partially written JSON that drops queued receipts.
 - Treat relay `enqueue_ack.accepted=false` as a first-class outbound failure signal: remove inflight tracking for that frame and emit an OpenClaw-visible dead-letter style notification instead of log-only handling.
-- Keep outbound inflight frame tracking synchronized between flush loop and inbound frame handling so enqueue acks can be correlated to `toAgentDid`.
+- Keep outbound inflight frame tracking synchronized between flush loop and inbound frame handling so enqueue acks can be correlated to `toAgentDid`, and record inflight correlation at queue/send time (not post-flush) to avoid ack races.
+- Never synthesize a production-looking fallback DID when enqueue-ack correlation is missing; drop and log unknown-ack failures to avoid misrouting receipts to real agents.
 - Keep receipt-forward retry buffering in `delivery.rs` for OpenClaw hook outages: queue failed receipt forwards with bounded exponential backoff and retry from the inbound retry loop.
+- Keep in-memory receipt-forward retry queues bounded by max pending, max attempts, and max age so connector processes cannot leak memory during prolonged hook outages.
 - Receipt callback routing authority is always the runtime-owned local proxy receipt URL; do not trust inbound `reply_to` for callback destination selection.
 - Receipt PoP nonces must be cryptographically random, URL-safe, and one-time per request signing call; never derive them from timestamps/counters.
 - Keep receipt payload tests asserting status parity at top-level and metadata level so `dead_lettered` and `processed_by_openclaw` stay externally consistent for OpenClaw hooks.

--- a/crates/clawdentity-cli/src/commands/connector/delivery.rs
+++ b/crates/clawdentity-cli/src/commands/connector/delivery.rs
@@ -1,4 +1,6 @@
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use anyhow::{Result, anyhow};
@@ -11,8 +13,8 @@ use clawdentity_core::http::client as create_http_client;
 use clawdentity_core::runtime_openclaw::OpenclawRuntimeConfig;
 use clawdentity_core::{
     CONNECTOR_FRAME_VERSION, ConnectorClient, ConnectorClientSender, ConnectorFrame,
-    DeliverAckFrame, DeliverFrame, EnqueueAckFrame, ReceiptFrame, SqliteStore, new_frame_id,
-    now_iso,
+    DeliverAckFrame, DeliverFrame, EnqueueAckFrame, ReceiptFrame, ReceiptStatus, SqliteStore,
+    new_frame_id, now_iso,
 };
 use serde_json::{Value, json};
 use tokio::sync::watch;
@@ -31,6 +33,20 @@ const CONNECTOR_RETRY_DELAY_MS: i64 = 5_000;
 const INBOUND_RETRY_INTERVAL: Duration = Duration::from_secs(1);
 const INBOUND_RETRY_BATCH_SIZE: usize = 50;
 const INBOUND_MAX_ATTEMPTS: i64 = 3;
+const RECEIPT_FORWARD_RETRY_INITIAL_DELAY_MS: i64 = 1_000;
+const RECEIPT_FORWARD_RETRY_MAX_DELAY_MS: i64 = 60_000;
+const RECEIPT_FORWARD_RETRY_BACKOFF_FACTOR: i64 = 2;
+const FALLBACK_UNKNOWN_AGENT_DID: &str =
+    "did:cdi:registry.clawdentity.com:agent:01HF7YAT00W6W7CM7N3W5FDXT4";
+
+pub(super) type OutboundInflightMap = Arc<Mutex<HashMap<String, String>>>;
+
+#[derive(Clone, Debug)]
+pub(super) struct PendingReceiptNotification {
+    pub attempt_count: i64,
+    pub next_attempt_at_ms: i64,
+    pub receipt: ReceiptFrame,
+}
 
 struct InboundRuntimeContext<'a> {
     store: &'a SqliteStore,
@@ -40,6 +56,8 @@ struct InboundRuntimeContext<'a> {
     hook_url: &'a str,
     openclaw_runtime: &'a OpenclawRuntimeConfig,
     receipt_outbox: &'a ReceiptOutboxHandle,
+    outbound_inflight: &'a OutboundInflightMap,
+    pending_receipt_notifications: &'a Arc<Mutex<Vec<PendingReceiptNotification>>>,
 }
 
 pub(super) async fn run_inbound_loop(
@@ -49,6 +67,8 @@ pub(super) async fn run_inbound_loop(
     store: SqliteStore,
     config_dir: PathBuf,
     openclaw_runtime: OpenclawRuntimeConfig,
+    outbound_inflight: OutboundInflightMap,
+    pending_receipt_notifications: Arc<Mutex<Vec<PendingReceiptNotification>>>,
     mut shutdown_rx: watch::Receiver<bool>,
 ) -> Result<()> {
     let hook_url = openclaw_runtime.hook_url()?;
@@ -61,6 +81,8 @@ pub(super) async fn run_inbound_loop(
         hook_url: &hook_url,
         openclaw_runtime: &openclaw_runtime,
         receipt_outbox: &receipt_outbox,
+        outbound_inflight: &outbound_inflight,
+        pending_receipt_notifications: &pending_receipt_notifications,
     };
 
     loop {
@@ -86,39 +108,76 @@ async fn handle_connector_frame(frame: ConnectorFrame, context: &InboundRuntimeC
             handle_deliver_frame(context, deliver).await;
         }
         ConnectorFrame::Receipt(receipt) => {
-            if let Err(error) = forward_receipt_to_openclaw(
+            enqueue_pending_receipt_notification(
+                context.pending_receipt_notifications,
+                PendingReceiptNotification {
+                    attempt_count: 0,
+                    next_attempt_at_ms: now_utc_ms(),
+                    receipt,
+                },
+            );
+            flush_pending_receipt_notifications(
                 context.http_client,
                 context.hook_url,
                 context.openclaw_runtime,
-                &receipt,
+                context.pending_receipt_notifications,
             )
-            .await
-            {
-                tracing::warn!(
-                    error = %error,
-                    request_id = %receipt.original_frame_id,
-                    status = ?receipt.status,
-                    "failed to forward receipt payload to OpenClaw hook"
-                );
-            }
+            .await;
         }
-        ConnectorFrame::EnqueueAck(ack) => log_enqueue_ack(&ack),
+        ConnectorFrame::EnqueueAck(ack) => {
+            handle_enqueue_ack(context, ack).await;
+        }
         _ => {}
     }
 }
 
-fn log_enqueue_ack(ack: &EnqueueAckFrame) {
+async fn handle_enqueue_ack(context: &InboundRuntimeContext<'_>, ack: EnqueueAckFrame) {
     if ack.accepted {
+        if let Ok(mut inflight) = context.outbound_inflight.lock() {
+            inflight.remove(&ack.ack_id);
+        }
         tracing::debug!(ack_id = %ack.ack_id, "relay accepted outbound enqueue frame");
         return;
     }
 
     let reason = ack.reason.as_deref().unwrap_or("unknown");
+    let to_agent_did = context
+        .outbound_inflight
+        .lock()
+        .ok()
+        .and_then(|mut inflight| inflight.remove(&ack.ack_id))
+        .unwrap_or_else(|| FALLBACK_UNKNOWN_AGENT_DID.to_string());
+
     tracing::warn!(
         ack_id = %ack.ack_id,
         reason,
         "relay rejected outbound enqueue frame"
     );
+
+    let receipt = ReceiptFrame {
+        v: CONNECTOR_FRAME_VERSION,
+        id: new_frame_id(),
+        ts: now_iso(),
+        original_frame_id: ack.ack_id,
+        to_agent_did,
+        status: ReceiptStatus::DeadLettered,
+        reason: Some(format!("relay rejected outbound enqueue frame: {reason}")),
+    };
+    enqueue_pending_receipt_notification(
+        context.pending_receipt_notifications,
+        PendingReceiptNotification {
+            attempt_count: 0,
+            next_attempt_at_ms: now_utc_ms(),
+            receipt,
+        },
+    );
+    flush_pending_receipt_notifications(
+        context.http_client,
+        context.hook_url,
+        context.openclaw_runtime,
+        context.pending_receipt_notifications,
+    )
+    .await;
 }
 
 pub(super) async fn run_inbound_retry_loop(
@@ -126,6 +185,7 @@ pub(super) async fn run_inbound_retry_loop(
     store: SqliteStore,
     config_dir: PathBuf,
     openclaw_runtime: OpenclawRuntimeConfig,
+    pending_receipt_notifications: Arc<Mutex<Vec<PendingReceiptNotification>>>,
     mut shutdown_rx: watch::Receiver<bool>,
 ) -> Result<()> {
     let hook_url = openclaw_runtime.hook_url()?;
@@ -151,7 +211,94 @@ pub(super) async fn run_inbound_retry_loop(
                     &receipt_outbox,
                 )
                 .await;
+                flush_pending_receipt_notifications(
+                    &http_client,
+                    &hook_url,
+                    &openclaw_runtime,
+                    &pending_receipt_notifications,
+                )
+                .await;
             }
+        }
+    }
+}
+
+fn enqueue_pending_receipt_notification(
+    queue: &Arc<Mutex<Vec<PendingReceiptNotification>>>,
+    notification: PendingReceiptNotification,
+) {
+    if let Ok(mut pending) = queue.lock() {
+        pending.push(notification);
+    } else {
+        tracing::warn!("failed to queue pending receipt notification: lock poisoned");
+    }
+}
+
+fn compute_receipt_retry_delay_ms(attempt_count: i64) -> i64 {
+    let exponent = attempt_count.saturating_sub(1) as u32;
+    let factor = RECEIPT_FORWARD_RETRY_BACKOFF_FACTOR.saturating_pow(exponent);
+    (RECEIPT_FORWARD_RETRY_INITIAL_DELAY_MS.saturating_mul(factor))
+        .clamp(1, RECEIPT_FORWARD_RETRY_MAX_DELAY_MS)
+}
+
+async fn flush_pending_receipt_notifications(
+    http_client: &reqwest::Client,
+    hook_url: &str,
+    openclaw_runtime: &OpenclawRuntimeConfig,
+    queue: &Arc<Mutex<Vec<PendingReceiptNotification>>>,
+) {
+    let now_ms = now_utc_ms();
+    let due_notifications: Vec<PendingReceiptNotification> = {
+        let Ok(mut pending) = queue.lock() else {
+            tracing::warn!("failed to flush pending receipt notifications: lock poisoned");
+            return;
+        };
+        let mut due = Vec::new();
+        let mut future = Vec::new();
+        for notification in pending.drain(..) {
+            if notification.next_attempt_at_ms <= now_ms {
+                due.push(notification);
+            } else {
+                future.push(notification);
+            }
+        }
+        *pending = future;
+        due
+    };
+
+    if due_notifications.is_empty() {
+        return;
+    }
+
+    let mut retry_notifications: Vec<PendingReceiptNotification> = Vec::new();
+    for mut notification in due_notifications {
+        if let Err(error) = forward_receipt_to_openclaw(
+            http_client,
+            hook_url,
+            openclaw_runtime,
+            &notification.receipt,
+        )
+        .await
+        {
+            notification.attempt_count += 1;
+            let delay_ms = compute_receipt_retry_delay_ms(notification.attempt_count);
+            notification.next_attempt_at_ms = now_utc_ms() + delay_ms;
+            tracing::warn!(
+                error = %error,
+                request_id = %notification.receipt.original_frame_id,
+                status = ?notification.receipt.status,
+                next_attempt_at_ms = notification.next_attempt_at_ms,
+                "failed to forward receipt payload to OpenClaw hook; queued for retry"
+            );
+            retry_notifications.push(notification);
+        }
+    }
+
+    if !retry_notifications.is_empty() {
+        if let Ok(mut pending) = queue.lock() {
+            pending.extend(retry_notifications);
+        } else {
+            tracing::warn!("failed to requeue pending receipt notifications: lock poisoned");
         }
     }
 }

--- a/crates/clawdentity-cli/src/commands/connector/delivery.rs
+++ b/crates/clawdentity-cli/src/commands/connector/delivery.rs
@@ -36,14 +36,16 @@ const INBOUND_MAX_ATTEMPTS: i64 = 3;
 const RECEIPT_FORWARD_RETRY_INITIAL_DELAY_MS: i64 = 1_000;
 const RECEIPT_FORWARD_RETRY_MAX_DELAY_MS: i64 = 60_000;
 const RECEIPT_FORWARD_RETRY_BACKOFF_FACTOR: i64 = 2;
-const FALLBACK_UNKNOWN_AGENT_DID: &str =
-    "did:cdi:registry.clawdentity.com:agent:01HF7YAT00W6W7CM7N3W5FDXT4";
+const RECEIPT_FORWARD_MAX_ATTEMPTS: i64 = 30;
+const RECEIPT_FORWARD_MAX_AGE_MS: i64 = 24 * 60 * 60 * 1_000;
+const RECEIPT_FORWARD_MAX_PENDING: usize = 10_000;
 
 pub(super) type OutboundInflightMap = Arc<Mutex<HashMap<String, String>>>;
 
 #[derive(Clone, Debug)]
 pub(super) struct PendingReceiptNotification {
     pub attempt_count: i64,
+    pub created_at_ms: i64,
     pub next_attempt_at_ms: i64,
     pub receipt: ReceiptFrame,
 }
@@ -116,6 +118,7 @@ async fn handle_connector_frame(frame: ConnectorFrame, context: &InboundRuntimeC
                 context.pending_receipt_notifications,
                 PendingReceiptNotification {
                     attempt_count: 0,
+                    created_at_ms: now_utc_ms(),
                     next_attempt_at_ms: now_utc_ms(),
                     receipt,
                 },
@@ -145,12 +148,19 @@ async fn handle_enqueue_ack(context: &InboundRuntimeContext<'_>, ack: EnqueueAck
     }
 
     let reason = ack.reason.as_deref().unwrap_or("unknown");
-    let to_agent_did = context
+    let Some(to_agent_did) = context
         .outbound_inflight
         .lock()
         .ok()
         .and_then(|mut inflight| inflight.remove(&ack.ack_id))
-        .unwrap_or_else(|| FALLBACK_UNKNOWN_AGENT_DID.to_string());
+    else {
+        tracing::warn!(
+            ack_id = %ack.ack_id,
+            reason,
+            "relay rejected outbound enqueue frame but no inflight mapping was found; dropping receipt to avoid misrouting"
+        );
+        return;
+    };
 
     tracing::warn!(
         ack_id = %ack.ack_id,
@@ -171,6 +181,7 @@ async fn handle_enqueue_ack(context: &InboundRuntimeContext<'_>, ack: EnqueueAck
         context.pending_receipt_notifications,
         PendingReceiptNotification {
             attempt_count: 0,
+            created_at_ms: now_utc_ms(),
             next_attempt_at_ms: now_utc_ms(),
             receipt,
         },
@@ -232,6 +243,18 @@ fn enqueue_pending_receipt_notification(
     notification: PendingReceiptNotification,
 ) {
     if let Ok(mut pending) = queue.lock() {
+        let now_ms = now_utc_ms();
+        pending.retain(|item| {
+            item.attempt_count < RECEIPT_FORWARD_MAX_ATTEMPTS
+                && now_ms.saturating_sub(item.created_at_ms) <= RECEIPT_FORWARD_MAX_AGE_MS
+        });
+        if pending.len() >= RECEIPT_FORWARD_MAX_PENDING {
+            tracing::warn!(
+                max_pending = RECEIPT_FORWARD_MAX_PENDING,
+                "dropping pending receipt notification because queue is full"
+            );
+            return;
+        }
         pending.push(notification);
     } else {
         tracing::warn!("failed to queue pending receipt notification: lock poisoned");
@@ -276,6 +299,24 @@ async fn flush_pending_receipt_notifications(
 
     let mut retry_notifications: Vec<PendingReceiptNotification> = Vec::new();
     for mut notification in due_notifications {
+        if notification.attempt_count >= RECEIPT_FORWARD_MAX_ATTEMPTS {
+            tracing::warn!(
+                request_id = %notification.receipt.original_frame_id,
+                status = ?notification.receipt.status,
+                attempt_count = notification.attempt_count,
+                "dropping pending receipt notification after max retry attempts"
+            );
+            continue;
+        }
+        if now_ms.saturating_sub(notification.created_at_ms) > RECEIPT_FORWARD_MAX_AGE_MS {
+            tracing::warn!(
+                request_id = %notification.receipt.original_frame_id,
+                status = ?notification.receipt.status,
+                age_ms = now_ms.saturating_sub(notification.created_at_ms),
+                "dropping pending receipt notification after max age"
+            );
+            continue;
+        }
         if let Err(error) = forward_receipt_to_openclaw(
             http_client,
             hook_url,
@@ -300,6 +341,15 @@ async fn flush_pending_receipt_notifications(
 
     if !retry_notifications.is_empty() {
         if let Ok(mut pending) = queue.lock() {
+            let capacity = RECEIPT_FORWARD_MAX_PENDING.saturating_sub(pending.len());
+            if retry_notifications.len() > capacity {
+                tracing::warn!(
+                    dropped = retry_notifications.len() - capacity,
+                    max_pending = RECEIPT_FORWARD_MAX_PENDING,
+                    "dropping pending receipt retries because queue is full"
+                );
+                retry_notifications.truncate(capacity);
+            }
             pending.extend(retry_notifications);
         } else {
             tracing::warn!("failed to requeue pending receipt notifications: lock poisoned");

--- a/crates/clawdentity-cli/src/commands/connector/delivery.rs
+++ b/crates/clawdentity-cli/src/commands/connector/delivery.rs
@@ -25,30 +25,22 @@ use super::headers::{
 use super::receipts::{DeliveryReceiptPayload, DeliveryReceiptStatus, ReceiptOutboxHandle};
 pub(super) use openclaw_payload::{build_openclaw_hook_payload, build_openclaw_receipt_payload};
 use pair_accepted::{apply_pair_accepted_system_delivery, is_trusted_pair_accepted_delivery};
+use receipt_forward_queue::{
+    PendingReceiptNotification, PendingReceiptQueue, enqueue_pending_receipt_notification,
+    flush_pending_receipt_notifications,
+};
 
 mod openclaw_payload;
 mod pair_accepted;
+mod receipt_forward_queue;
 
 const CONNECTOR_RETRY_DELAY_MS: i64 = 5_000;
 const INBOUND_RETRY_INTERVAL: Duration = Duration::from_secs(1);
 const INBOUND_RETRY_BATCH_SIZE: usize = 50;
 const INBOUND_MAX_ATTEMPTS: i64 = 3;
-const RECEIPT_FORWARD_RETRY_INITIAL_DELAY_MS: i64 = 1_000;
-const RECEIPT_FORWARD_RETRY_MAX_DELAY_MS: i64 = 60_000;
-const RECEIPT_FORWARD_RETRY_BACKOFF_FACTOR: i64 = 2;
-const RECEIPT_FORWARD_MAX_ATTEMPTS: i64 = 30;
-const RECEIPT_FORWARD_MAX_AGE_MS: i64 = 24 * 60 * 60 * 1_000;
-const RECEIPT_FORWARD_MAX_PENDING: usize = 10_000;
 
 pub(super) type OutboundInflightMap = Arc<Mutex<HashMap<String, String>>>;
-
-#[derive(Clone, Debug)]
-pub(super) struct PendingReceiptNotification {
-    pub attempt_count: i64,
-    pub created_at_ms: i64,
-    pub next_attempt_at_ms: i64,
-    pub receipt: ReceiptFrame,
-}
+pub(super) type PendingReceiptQueueHandle = PendingReceiptQueue;
 
 pub(super) struct InboundLoopRuntime {
     pub receipt_outbox: ReceiptOutboxHandle,
@@ -57,7 +49,7 @@ pub(super) struct InboundLoopRuntime {
     pub config_dir: PathBuf,
     pub openclaw_runtime: OpenclawRuntimeConfig,
     pub outbound_inflight: OutboundInflightMap,
-    pub pending_receipt_notifications: Arc<Mutex<Vec<PendingReceiptNotification>>>,
+    pub pending_receipt_notifications: PendingReceiptQueueHandle,
 }
 
 struct InboundRuntimeContext<'a> {
@@ -69,7 +61,7 @@ struct InboundRuntimeContext<'a> {
     openclaw_runtime: &'a OpenclawRuntimeConfig,
     receipt_outbox: &'a ReceiptOutboxHandle,
     outbound_inflight: &'a OutboundInflightMap,
-    pending_receipt_notifications: &'a Arc<Mutex<Vec<PendingReceiptNotification>>>,
+    pending_receipt_notifications: &'a PendingReceiptQueueHandle,
 }
 
 pub(super) async fn run_inbound_loop(
@@ -116,12 +108,7 @@ async fn handle_connector_frame(frame: ConnectorFrame, context: &InboundRuntimeC
         ConnectorFrame::Receipt(receipt) => {
             enqueue_pending_receipt_notification(
                 context.pending_receipt_notifications,
-                PendingReceiptNotification {
-                    attempt_count: 0,
-                    created_at_ms: now_utc_ms(),
-                    next_attempt_at_ms: now_utc_ms(),
-                    receipt,
-                },
+                PendingReceiptNotification::new(receipt),
             );
             flush_pending_receipt_notifications(
                 context.http_client,
@@ -140,19 +127,13 @@ async fn handle_connector_frame(frame: ConnectorFrame, context: &InboundRuntimeC
 
 async fn handle_enqueue_ack(context: &InboundRuntimeContext<'_>, ack: EnqueueAckFrame) {
     if ack.accepted {
-        if let Ok(mut inflight) = context.outbound_inflight.lock() {
-            inflight.remove(&ack.ack_id);
-        }
+        let _ = take_inflight_to_agent_did(context.outbound_inflight, &ack.ack_id);
         tracing::debug!(ack_id = %ack.ack_id, "relay accepted outbound enqueue frame");
         return;
     }
 
     let reason = ack.reason.as_deref().unwrap_or("unknown");
-    let Some(to_agent_did) = context
-        .outbound_inflight
-        .lock()
-        .ok()
-        .and_then(|mut inflight| inflight.remove(&ack.ack_id))
+    let Some(to_agent_did) = take_inflight_to_agent_did(context.outbound_inflight, &ack.ack_id)
     else {
         tracing::warn!(
             ack_id = %ack.ack_id,
@@ -168,23 +149,10 @@ async fn handle_enqueue_ack(context: &InboundRuntimeContext<'_>, ack: EnqueueAck
         "relay rejected outbound enqueue frame"
     );
 
-    let receipt = ReceiptFrame {
-        v: CONNECTOR_FRAME_VERSION,
-        id: new_frame_id(),
-        ts: now_iso(),
-        original_frame_id: ack.ack_id,
-        to_agent_did,
-        status: ReceiptStatus::DeadLettered,
-        reason: Some(format!("relay rejected outbound enqueue frame: {reason}")),
-    };
+    let receipt = build_enqueue_rejected_receipt(ack.ack_id, to_agent_did, reason);
     enqueue_pending_receipt_notification(
         context.pending_receipt_notifications,
-        PendingReceiptNotification {
-            attempt_count: 0,
-            created_at_ms: now_utc_ms(),
-            next_attempt_at_ms: now_utc_ms(),
-            receipt,
-        },
+        PendingReceiptNotification::new(receipt),
     );
     flush_pending_receipt_notifications(
         context.http_client,
@@ -195,12 +163,38 @@ async fn handle_enqueue_ack(context: &InboundRuntimeContext<'_>, ack: EnqueueAck
     .await;
 }
 
+fn take_inflight_to_agent_did(
+    outbound_inflight: &OutboundInflightMap,
+    ack_id: &str,
+) -> Option<String> {
+    outbound_inflight
+        .lock()
+        .ok()
+        .and_then(|mut inflight| inflight.remove(ack_id))
+}
+
+fn build_enqueue_rejected_receipt(
+    ack_id: String,
+    to_agent_did: String,
+    reason: &str,
+) -> ReceiptFrame {
+    ReceiptFrame {
+        v: CONNECTOR_FRAME_VERSION,
+        id: new_frame_id(),
+        ts: now_iso(),
+        original_frame_id: ack_id,
+        to_agent_did,
+        status: ReceiptStatus::DeadLettered,
+        reason: Some(format!("relay rejected outbound enqueue frame: {reason}")),
+    }
+}
+
 pub(super) async fn run_inbound_retry_loop(
     receipt_outbox: ReceiptOutboxHandle,
     store: SqliteStore,
     config_dir: PathBuf,
     openclaw_runtime: OpenclawRuntimeConfig,
-    pending_receipt_notifications: Arc<Mutex<Vec<PendingReceiptNotification>>>,
+    pending_receipt_notifications: PendingReceiptQueueHandle,
     mut shutdown_rx: watch::Receiver<bool>,
 ) -> Result<()> {
     let hook_url = openclaw_runtime.hook_url()?;
@@ -234,125 +228,6 @@ pub(super) async fn run_inbound_retry_loop(
                 )
                 .await;
             }
-        }
-    }
-}
-
-fn enqueue_pending_receipt_notification(
-    queue: &Arc<Mutex<Vec<PendingReceiptNotification>>>,
-    notification: PendingReceiptNotification,
-) {
-    if let Ok(mut pending) = queue.lock() {
-        let now_ms = now_utc_ms();
-        pending.retain(|item| {
-            item.attempt_count < RECEIPT_FORWARD_MAX_ATTEMPTS
-                && now_ms.saturating_sub(item.created_at_ms) <= RECEIPT_FORWARD_MAX_AGE_MS
-        });
-        if pending.len() >= RECEIPT_FORWARD_MAX_PENDING {
-            tracing::warn!(
-                max_pending = RECEIPT_FORWARD_MAX_PENDING,
-                "dropping pending receipt notification because queue is full"
-            );
-            return;
-        }
-        pending.push(notification);
-    } else {
-        tracing::warn!("failed to queue pending receipt notification: lock poisoned");
-    }
-}
-
-fn compute_receipt_retry_delay_ms(attempt_count: i64) -> i64 {
-    let exponent = attempt_count.saturating_sub(1) as u32;
-    let factor = RECEIPT_FORWARD_RETRY_BACKOFF_FACTOR.saturating_pow(exponent);
-    (RECEIPT_FORWARD_RETRY_INITIAL_DELAY_MS.saturating_mul(factor))
-        .clamp(1, RECEIPT_FORWARD_RETRY_MAX_DELAY_MS)
-}
-
-async fn flush_pending_receipt_notifications(
-    http_client: &reqwest::Client,
-    hook_url: &str,
-    openclaw_runtime: &OpenclawRuntimeConfig,
-    queue: &Arc<Mutex<Vec<PendingReceiptNotification>>>,
-) {
-    let now_ms = now_utc_ms();
-    let due_notifications: Vec<PendingReceiptNotification> = {
-        let Ok(mut pending) = queue.lock() else {
-            tracing::warn!("failed to flush pending receipt notifications: lock poisoned");
-            return;
-        };
-        let mut due = Vec::new();
-        let mut future = Vec::new();
-        for notification in pending.drain(..) {
-            if notification.next_attempt_at_ms <= now_ms {
-                due.push(notification);
-            } else {
-                future.push(notification);
-            }
-        }
-        *pending = future;
-        due
-    };
-
-    if due_notifications.is_empty() {
-        return;
-    }
-
-    let mut retry_notifications: Vec<PendingReceiptNotification> = Vec::new();
-    for mut notification in due_notifications {
-        if notification.attempt_count >= RECEIPT_FORWARD_MAX_ATTEMPTS {
-            tracing::warn!(
-                request_id = %notification.receipt.original_frame_id,
-                status = ?notification.receipt.status,
-                attempt_count = notification.attempt_count,
-                "dropping pending receipt notification after max retry attempts"
-            );
-            continue;
-        }
-        if now_ms.saturating_sub(notification.created_at_ms) > RECEIPT_FORWARD_MAX_AGE_MS {
-            tracing::warn!(
-                request_id = %notification.receipt.original_frame_id,
-                status = ?notification.receipt.status,
-                age_ms = now_ms.saturating_sub(notification.created_at_ms),
-                "dropping pending receipt notification after max age"
-            );
-            continue;
-        }
-        if let Err(error) = forward_receipt_to_openclaw(
-            http_client,
-            hook_url,
-            openclaw_runtime,
-            &notification.receipt,
-        )
-        .await
-        {
-            notification.attempt_count += 1;
-            let delay_ms = compute_receipt_retry_delay_ms(notification.attempt_count);
-            notification.next_attempt_at_ms = now_utc_ms() + delay_ms;
-            tracing::warn!(
-                error = %error,
-                request_id = %notification.receipt.original_frame_id,
-                status = ?notification.receipt.status,
-                next_attempt_at_ms = notification.next_attempt_at_ms,
-                "failed to forward receipt payload to OpenClaw hook; queued for retry"
-            );
-            retry_notifications.push(notification);
-        }
-    }
-
-    if !retry_notifications.is_empty() {
-        if let Ok(mut pending) = queue.lock() {
-            let capacity = RECEIPT_FORWARD_MAX_PENDING.saturating_sub(pending.len());
-            if retry_notifications.len() > capacity {
-                tracing::warn!(
-                    dropped = retry_notifications.len() - capacity,
-                    max_pending = RECEIPT_FORWARD_MAX_PENDING,
-                    "dropping pending receipt retries because queue is full"
-                );
-                retry_notifications.truncate(capacity);
-            }
-            pending.extend(retry_notifications);
-        } else {
-            tracing::warn!("failed to requeue pending receipt notifications: lock poisoned");
         }
     }
 }
@@ -691,50 +566,6 @@ pub(super) async fn forward_deliver_to_openclaw(
         .map_err(|error| anyhow!("openclaw hook request failed: {error}"))?;
     if !response.status().is_success() {
         return Err(anyhow!("openclaw hook returned HTTP {}", response.status()));
-    }
-    Ok(())
-}
-
-async fn forward_receipt_to_openclaw(
-    http_client: &reqwest::Client,
-    hook_url: &str,
-    openclaw_runtime: &OpenclawRuntimeConfig,
-    receipt: &ReceiptFrame,
-) -> Result<()> {
-    let mut request = http_client
-        .post(hook_url)
-        .header("content-type", "application/json")
-        .header(
-            "x-clawdentity-content-type",
-            "application/vnd.clawdentity.receipt+json",
-        )
-        .header("x-clawdentity-to-agent-did", &receipt.to_agent_did)
-        .header("x-clawdentity-verified", "true")
-        .header("x-request-id", &receipt.original_frame_id)
-        .json(&build_openclaw_receipt_payload(
-            &openclaw_runtime.hook_path,
-            receipt,
-            openclaw_runtime.target_agent_id.as_deref(),
-        ));
-
-    if let Some(token) = openclaw_runtime
-        .hook_token
-        .as_deref()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-    {
-        request = request.header("x-openclaw-token", token);
-    }
-
-    let response = request
-        .send()
-        .await
-        .map_err(|error| anyhow!("openclaw receipt hook request failed: {error}"))?;
-    if !response.status().is_success() {
-        return Err(anyhow!(
-            "openclaw receipt hook returned HTTP {}",
-            response.status()
-        ));
     }
     Ok(())
 }

--- a/crates/clawdentity-cli/src/commands/connector/delivery.rs
+++ b/crates/clawdentity-cli/src/commands/connector/delivery.rs
@@ -48,6 +48,16 @@ pub(super) struct PendingReceiptNotification {
     pub receipt: ReceiptFrame,
 }
 
+pub(super) struct InboundLoopRuntime {
+    pub receipt_outbox: ReceiptOutboxHandle,
+    pub relay_sender: ConnectorClientSender,
+    pub store: SqliteStore,
+    pub config_dir: PathBuf,
+    pub openclaw_runtime: OpenclawRuntimeConfig,
+    pub outbound_inflight: OutboundInflightMap,
+    pub pending_receipt_notifications: Arc<Mutex<Vec<PendingReceiptNotification>>>,
+}
+
 struct InboundRuntimeContext<'a> {
     store: &'a SqliteStore,
     config_dir: &'a Path,
@@ -61,28 +71,22 @@ struct InboundRuntimeContext<'a> {
 }
 
 pub(super) async fn run_inbound_loop(
-    receipt_outbox: ReceiptOutboxHandle,
     mut connector_client: ConnectorClient,
-    relay_sender: ConnectorClientSender,
-    store: SqliteStore,
-    config_dir: PathBuf,
-    openclaw_runtime: OpenclawRuntimeConfig,
-    outbound_inflight: OutboundInflightMap,
-    pending_receipt_notifications: Arc<Mutex<Vec<PendingReceiptNotification>>>,
+    runtime: InboundLoopRuntime,
     mut shutdown_rx: watch::Receiver<bool>,
 ) -> Result<()> {
-    let hook_url = openclaw_runtime.hook_url()?;
+    let hook_url = runtime.openclaw_runtime.hook_url()?;
     let http_client = create_http_client()?;
     let context = InboundRuntimeContext {
-        store: &store,
-        config_dir: config_dir.as_path(),
-        relay_sender: &relay_sender,
+        store: &runtime.store,
+        config_dir: runtime.config_dir.as_path(),
+        relay_sender: &runtime.relay_sender,
         http_client: &http_client,
         hook_url: &hook_url,
-        openclaw_runtime: &openclaw_runtime,
-        receipt_outbox: &receipt_outbox,
-        outbound_inflight: &outbound_inflight,
-        pending_receipt_notifications: &pending_receipt_notifications,
+        openclaw_runtime: &runtime.openclaw_runtime,
+        receipt_outbox: &runtime.receipt_outbox,
+        outbound_inflight: &runtime.outbound_inflight,
+        pending_receipt_notifications: &runtime.pending_receipt_notifications,
     };
 
     loop {

--- a/crates/clawdentity-cli/src/commands/connector/delivery/pair_accepted.rs
+++ b/crates/clawdentity-cli/src/commands/connector/delivery/pair_accepted.rs
@@ -59,9 +59,7 @@ fn reconcile_onboarding_session_object(session_object: &mut Map<String, Value>, 
     }
     session_object.insert("updatedAt".to_string(), json!(clawdentity_core::now_iso()));
 
-    let pairing = session_object
-        .entry("pairing")
-        .or_insert_with(|| json!({}));
+    let pairing = session_object.entry("pairing").or_insert_with(|| json!({}));
     if !pairing.is_object() {
         *pairing = json!({});
     }
@@ -554,7 +552,10 @@ mod tests {
         let raw = std::fs::read_to_string(temp.path().join("onboarding-session.json"))
             .expect("read onboarding session");
         let session: serde_json::Value = serde_json::from_str(&raw).expect("parse session");
-        assert_eq!(session.get("state").and_then(Value::as_str), Some("messaging_ready"));
+        assert_eq!(
+            session.get("state").and_then(Value::as_str),
+            Some("messaging_ready")
+        );
         assert_eq!(
             session
                 .get("pairing")

--- a/crates/clawdentity-cli/src/commands/connector/delivery/receipt_forward_queue.rs
+++ b/crates/clawdentity-cli/src/commands/connector/delivery/receipt_forward_queue.rs
@@ -1,0 +1,224 @@
+use std::sync::{Arc, Mutex};
+
+use anyhow::{Result, anyhow};
+use clawdentity_core::ReceiptFrame;
+use clawdentity_core::db::now_utc_ms;
+use clawdentity_core::runtime_openclaw::OpenclawRuntimeConfig;
+
+use super::build_openclaw_receipt_payload;
+
+const RECEIPT_FORWARD_RETRY_INITIAL_DELAY_MS: i64 = 1_000;
+const RECEIPT_FORWARD_RETRY_MAX_DELAY_MS: i64 = 60_000;
+const RECEIPT_FORWARD_RETRY_BACKOFF_FACTOR: i64 = 2;
+const RECEIPT_FORWARD_MAX_ATTEMPTS: i64 = 30;
+const RECEIPT_FORWARD_MAX_AGE_MS: i64 = 24 * 60 * 60 * 1_000;
+const RECEIPT_FORWARD_MAX_PENDING: usize = 10_000;
+
+pub(in crate::commands::connector) type PendingReceiptQueue =
+    Arc<Mutex<Vec<PendingReceiptNotification>>>;
+
+#[derive(Clone, Debug)]
+pub(in crate::commands::connector) struct PendingReceiptNotification {
+    pub attempt_count: i64,
+    pub created_at_ms: i64,
+    pub next_attempt_at_ms: i64,
+    pub receipt: ReceiptFrame,
+}
+
+impl PendingReceiptNotification {
+    pub(in crate::commands::connector) fn new(receipt: ReceiptFrame) -> Self {
+        let now_ms = now_utc_ms();
+        Self {
+            attempt_count: 0,
+            created_at_ms: now_ms,
+            next_attempt_at_ms: now_ms,
+            receipt,
+        }
+    }
+}
+
+pub(in crate::commands::connector) fn enqueue_pending_receipt_notification(
+    queue: &PendingReceiptQueue,
+    notification: PendingReceiptNotification,
+) {
+    if let Ok(mut pending) = queue.lock() {
+        prune_pending_queue(&mut pending, now_utc_ms());
+        if pending.len() >= RECEIPT_FORWARD_MAX_PENDING {
+            tracing::warn!(
+                max_pending = RECEIPT_FORWARD_MAX_PENDING,
+                "dropping pending receipt notification because queue is full"
+            );
+            return;
+        }
+        pending.push(notification);
+    } else {
+        tracing::warn!("failed to queue pending receipt notification: lock poisoned");
+    }
+}
+
+pub(in crate::commands::connector) async fn flush_pending_receipt_notifications(
+    http_client: &reqwest::Client,
+    hook_url: &str,
+    openclaw_runtime: &OpenclawRuntimeConfig,
+    queue: &PendingReceiptQueue,
+) {
+    let now_ms = now_utc_ms();
+    let Some(due_notifications) = take_due_notifications(queue, now_ms) else {
+        return;
+    };
+
+    let mut retry_notifications: Vec<PendingReceiptNotification> = Vec::new();
+    for mut notification in due_notifications {
+        if should_drop_notification(&notification, now_ms) {
+            continue;
+        }
+        if let Err(error) = forward_receipt_to_openclaw(
+            http_client,
+            hook_url,
+            openclaw_runtime,
+            &notification.receipt,
+        )
+        .await
+        {
+            notification.attempt_count += 1;
+            notification.next_attempt_at_ms =
+                now_utc_ms() + compute_receipt_retry_delay_ms(notification.attempt_count);
+            tracing::warn!(
+                error = %error,
+                request_id = %notification.receipt.original_frame_id,
+                status = ?notification.receipt.status,
+                next_attempt_at_ms = notification.next_attempt_at_ms,
+                "failed to forward receipt payload to OpenClaw hook; queued for retry"
+            );
+            retry_notifications.push(notification);
+        }
+    }
+
+    requeue_notifications(queue, retry_notifications);
+}
+
+fn prune_pending_queue(pending: &mut Vec<PendingReceiptNotification>, now_ms: i64) {
+    pending.retain(|item| {
+        item.attempt_count < RECEIPT_FORWARD_MAX_ATTEMPTS
+            && now_ms.saturating_sub(item.created_at_ms) <= RECEIPT_FORWARD_MAX_AGE_MS
+    });
+}
+
+fn take_due_notifications(
+    queue: &PendingReceiptQueue,
+    now_ms: i64,
+) -> Option<Vec<PendingReceiptNotification>> {
+    let Ok(mut pending) = queue.lock() else {
+        tracing::warn!("failed to flush pending receipt notifications: lock poisoned");
+        return None;
+    };
+
+    let mut due = Vec::new();
+    let mut future = Vec::new();
+    for notification in pending.drain(..) {
+        if notification.next_attempt_at_ms <= now_ms {
+            due.push(notification);
+        } else {
+            future.push(notification);
+        }
+    }
+    *pending = future;
+
+    if due.is_empty() { None } else { Some(due) }
+}
+
+fn should_drop_notification(notification: &PendingReceiptNotification, now_ms: i64) -> bool {
+    if notification.attempt_count >= RECEIPT_FORWARD_MAX_ATTEMPTS {
+        tracing::warn!(
+            request_id = %notification.receipt.original_frame_id,
+            status = ?notification.receipt.status,
+            attempt_count = notification.attempt_count,
+            "dropping pending receipt notification after max retry attempts"
+        );
+        return true;
+    }
+    if now_ms.saturating_sub(notification.created_at_ms) > RECEIPT_FORWARD_MAX_AGE_MS {
+        tracing::warn!(
+            request_id = %notification.receipt.original_frame_id,
+            status = ?notification.receipt.status,
+            age_ms = now_ms.saturating_sub(notification.created_at_ms),
+            "dropping pending receipt notification after max age"
+        );
+        return true;
+    }
+    false
+}
+
+fn requeue_notifications(
+    queue: &PendingReceiptQueue,
+    mut retry_notifications: Vec<PendingReceiptNotification>,
+) {
+    if retry_notifications.is_empty() {
+        return;
+    }
+    if let Ok(mut pending) = queue.lock() {
+        let capacity = RECEIPT_FORWARD_MAX_PENDING.saturating_sub(pending.len());
+        if retry_notifications.len() > capacity {
+            tracing::warn!(
+                dropped = retry_notifications.len() - capacity,
+                max_pending = RECEIPT_FORWARD_MAX_PENDING,
+                "dropping pending receipt retries because queue is full"
+            );
+            retry_notifications.truncate(capacity);
+        }
+        pending.extend(retry_notifications);
+    } else {
+        tracing::warn!("failed to requeue pending receipt notifications: lock poisoned");
+    }
+}
+
+fn compute_receipt_retry_delay_ms(attempt_count: i64) -> i64 {
+    let exponent = attempt_count.saturating_sub(1) as u32;
+    let factor = RECEIPT_FORWARD_RETRY_BACKOFF_FACTOR.saturating_pow(exponent);
+    (RECEIPT_FORWARD_RETRY_INITIAL_DELAY_MS.saturating_mul(factor))
+        .clamp(1, RECEIPT_FORWARD_RETRY_MAX_DELAY_MS)
+}
+
+async fn forward_receipt_to_openclaw(
+    http_client: &reqwest::Client,
+    hook_url: &str,
+    openclaw_runtime: &OpenclawRuntimeConfig,
+    receipt: &ReceiptFrame,
+) -> Result<()> {
+    let mut request = http_client
+        .post(hook_url)
+        .header("content-type", "application/json")
+        .header(
+            "x-clawdentity-content-type",
+            "application/vnd.clawdentity.receipt+json",
+        )
+        .header("x-clawdentity-to-agent-did", &receipt.to_agent_did)
+        .header("x-clawdentity-verified", "true")
+        .header("x-request-id", &receipt.original_frame_id)
+        .json(&build_openclaw_receipt_payload(
+            &openclaw_runtime.hook_path,
+            receipt,
+            openclaw_runtime.target_agent_id.as_deref(),
+        ));
+
+    if let Some(token) = openclaw_runtime
+        .hook_token
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        request = request.header("x-openclaw-token", token);
+    }
+
+    let response = request
+        .send()
+        .await
+        .map_err(|error| anyhow!("openclaw receipt hook request failed: {error}"))?;
+    if !response.status().is_success() {
+        return Err(anyhow!(
+            "openclaw receipt hook returned HTTP {}",
+            response.status()
+        ));
+    }
+    Ok(())
+}

--- a/crates/clawdentity-core/assets/openclaw-skill/transform/relay-to-peer.mjs
+++ b/crates/clawdentity-core/assets/openclaw-skill/transform/relay-to-peer.mjs
@@ -14458,6 +14458,42 @@ async function loadPeersConfig(options = {}) {
   return parsePeersConfig(parsed, configPath);
 }
 
+// src/transforms/relay-health-cache.ts
+var endpointHealthCache = /* @__PURE__ */ new Map();
+var MAX_CONNECTOR_HEALTH_CACHE_ENTRIES = 256;
+function pruneEndpointHealthCache(nowMs, healthCacheTtlMs) {
+  for (const [statusUrl, entry] of endpointHealthCache.entries()) {
+    if (nowMs - entry.checkedAtMs >= healthCacheTtlMs) {
+      endpointHealthCache.delete(statusUrl);
+    }
+  }
+  if (endpointHealthCache.size <= MAX_CONNECTOR_HEALTH_CACHE_ENTRIES) {
+    return;
+  }
+  const sortedByAge = [...endpointHealthCache.entries()].sort(
+    (a, b) => a[1].checkedAtMs - b[1].checkedAtMs
+  );
+  const overflowCount = endpointHealthCache.size - MAX_CONNECTOR_HEALTH_CACHE_ENTRIES;
+  for (const [statusUrl] of sortedByAge.slice(0, overflowCount)) {
+    endpointHealthCache.delete(statusUrl);
+  }
+}
+function readEndpointHealthCache(input) {
+  pruneEndpointHealthCache(input.nowMs, input.healthCacheTtlMs);
+  const cacheEntry = endpointHealthCache.get(input.statusUrl);
+  if (cacheEntry !== void 0 && input.nowMs - cacheEntry.checkedAtMs < input.healthCacheTtlMs) {
+    return cacheEntry.healthy;
+  }
+  return void 0;
+}
+function writeEndpointHealthCache(input) {
+  pruneEndpointHealthCache(input.checkedAtMs, input.healthCacheTtlMs);
+  endpointHealthCache.set(input.statusUrl, {
+    checkedAtMs: input.checkedAtMs,
+    healthy: input.healthy
+  });
+}
+
 // src/transforms/relay-to-peer.ts
 var DEFAULT_CONNECTOR_BASE_URL = "http://127.0.0.1:19400";
 var DEFAULT_CONNECTOR_OUTBOUND_PATH = "/v1/outbound";
@@ -14479,7 +14515,6 @@ var RelayTransformError = class extends Error {
     this.statusCode = input.statusCode;
   }
 };
-var endpointHealthCache = /* @__PURE__ */ new Map();
 function getErrorCode2(error48) {
   if (!isRecord(error48)) {
     return void 0;
@@ -14516,7 +14551,9 @@ function parseOptionalPositiveInteger(value) {
   }
   const parsed = Number.parseInt(trimmed, 10);
   if (!Number.isFinite(parsed) || parsed <= 0) {
-    throw new Error("Relay runtime config timeout values must be positive integers");
+    throw new Error(
+      "Relay runtime config timeout values must be positive integers"
+    );
   }
   return parsed;
 }
@@ -14783,13 +14820,19 @@ function computeHealthTimeoutMs(options, runtimeConfig) {
   ) ?? DEFAULT_CONNECTOR_HEALTH_TIMEOUT_MS;
 }
 function computePostTimeoutMs(options, runtimeConfig) {
-  return options.connectorPostTimeoutMs ?? runtimeConfig.connectorPostTimeoutMs ?? parseOptionalPositiveInteger(process.env.CLAWDENTITY_CONNECTOR_POST_TIMEOUT_MS) ?? DEFAULT_CONNECTOR_POST_TIMEOUT_MS;
+  return options.connectorPostTimeoutMs ?? runtimeConfig.connectorPostTimeoutMs ?? parseOptionalPositiveInteger(
+    process.env.CLAWDENTITY_CONNECTOR_POST_TIMEOUT_MS
+  ) ?? DEFAULT_CONNECTOR_POST_TIMEOUT_MS;
 }
 async function isEndpointHealthy(input) {
   const nowMs = Date.now();
-  const cacheEntry = endpointHealthCache.get(input.endpoint.statusUrl);
-  if (cacheEntry !== void 0 && nowMs - cacheEntry.checkedAtMs < input.healthCacheTtlMs) {
-    return cacheEntry.healthy;
+  const cached2 = readEndpointHealthCache({
+    statusUrl: input.endpoint.statusUrl,
+    nowMs,
+    healthCacheTtlMs: input.healthCacheTtlMs
+  });
+  if (cached2 !== void 0) {
+    return cached2;
   }
   let healthy = false;
   try {
@@ -14801,8 +14844,10 @@ async function isEndpointHealthy(input) {
   } catch {
     healthy = false;
   }
-  endpointHealthCache.set(input.endpoint.statusUrl, {
+  writeEndpointHealthCache({
+    statusUrl: input.endpoint.statusUrl,
     checkedAtMs: nowMs,
+    healthCacheTtlMs: input.healthCacheTtlMs,
     healthy
   });
   return healthy;
@@ -14930,19 +14975,25 @@ async function relayPayloadToPeer(payload, options = {}) {
         payload: relayPayload,
         timeoutMs: postTimeoutMs
       });
-      endpointHealthCache.set(endpoint.statusUrl, {
+      writeEndpointHealthCache({
+        statusUrl: endpoint.statusUrl,
         checkedAtMs: Date.now(),
+        healthCacheTtlMs,
         healthy: true
       });
       return null;
     } catch (error48) {
       lastError = error48;
-      endpointHealthCache.set(endpoint.statusUrl, {
+      const normalizedError = normalizeRelayError(error48);
+      const shouldMarkEndpointUnhealthy = normalizedError.category === "connector_unavailable" || normalizedError.category === "connector_timeout";
+      writeEndpointHealthCache({
+        statusUrl: endpoint.statusUrl,
         checkedAtMs: Date.now(),
-        healthy: false
+        healthCacheTtlMs,
+        healthy: !shouldMarkEndpointUnhealthy
       });
       if (!shouldTryNextConnectorEndpoint(error48)) {
-        throw normalizeRelayError(error48);
+        throw normalizedError;
       }
     }
   }

--- a/crates/clawdentity-core/assets/openclaw-skill/transform/relay-to-peer.mjs
+++ b/crates/clawdentity-core/assets/openclaw-skill/transform/relay-to-peer.mjs
@@ -14461,8 +14461,25 @@ async function loadPeersConfig(options = {}) {
 // src/transforms/relay-to-peer.ts
 var DEFAULT_CONNECTOR_BASE_URL = "http://127.0.0.1:19400";
 var DEFAULT_CONNECTOR_OUTBOUND_PATH = "/v1/outbound";
+var DEFAULT_CONNECTOR_STATUS_PATH = "/v1/status";
+var DEFAULT_CONNECTOR_HEALTH_CACHE_TTL_MS = 5e3;
+var DEFAULT_CONNECTOR_HEALTH_TIMEOUT_MS = 1500;
+var DEFAULT_CONNECTOR_POST_TIMEOUT_MS = 1e4;
 var RELAY_RUNTIME_FILE_NAME = "clawdentity-relay.json";
 var RELAY_PEERS_FILE_NAME = "clawdentity-peers.json";
+var RelayTransformError = class extends Error {
+  category;
+  retryable;
+  statusCode;
+  constructor(input) {
+    super(input.message);
+    this.name = "RelayTransformError";
+    this.category = input.category;
+    this.retryable = input.retryable;
+    this.statusCode = input.statusCode;
+  }
+};
+var endpointHealthCache = /* @__PURE__ */ new Map();
 function getErrorCode2(error48) {
   if (!isRecord(error48)) {
     return void 0;
@@ -14485,6 +14502,23 @@ function parseOptionalString(value) {
   }
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : void 0;
+}
+function parseOptionalPositiveInteger(value) {
+  if (typeof value === "number" && Number.isInteger(value) && value > 0) {
+    return value;
+  }
+  if (typeof value !== "string") {
+    return void 0;
+  }
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    return void 0;
+  }
+  const parsed = Number.parseInt(trimmed, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error("Relay runtime config timeout values must be positive integers");
+  }
+  return parsed;
 }
 function removePeerField(payload) {
   const outbound = {};
@@ -14520,7 +14554,7 @@ function parseConnectorBaseUrl(value) {
 function normalizeConnectorPath(value) {
   const trimmed = value.trim();
   if (trimmed.length === 0) {
-    throw new Error("Connector outbound path is invalid");
+    throw new Error("Connector path is invalid");
   }
   return trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
 }
@@ -14549,6 +14583,7 @@ function parseRelayRuntimeConfig(value) {
   }
   const connectorBaseUrl = typeof value.connectorBaseUrl === "string" && value.connectorBaseUrl.trim().length > 0 ? parseConnectorBaseUrl(value.connectorBaseUrl.trim()) : void 0;
   const connectorPath = typeof value.connectorPath === "string" && value.connectorPath.trim().length > 0 ? normalizeConnectorPath(value.connectorPath) : void 0;
+  const connectorStatusPath = typeof value.connectorStatusPath === "string" && value.connectorStatusPath.trim().length > 0 ? normalizeConnectorPath(value.connectorStatusPath) : void 0;
   const peersConfigPath = typeof value.peersConfigPath === "string" && value.peersConfigPath.trim().length > 0 ? value.peersConfigPath.trim() : void 0;
   const localAgentDid = parseOptionalString(value.localAgentDid);
   if (localAgentDid) {
@@ -14559,10 +14594,23 @@ function parseRelayRuntimeConfig(value) {
     }
   }
   const connectorBaseUrls = Array.isArray(value.connectorBaseUrls) ? value.connectorBaseUrls.filter((item) => typeof item === "string").map((item) => item.trim()).filter((item) => item.length > 0).map(parseConnectorBaseUrl) : void 0;
+  const connectorHealthCacheTtlMs = parseOptionalPositiveInteger(
+    value.connectorHealthCacheTtlMs
+  );
+  const connectorHealthTimeoutMs = parseOptionalPositiveInteger(
+    value.connectorHealthTimeoutMs
+  );
+  const connectorPostTimeoutMs = parseOptionalPositiveInteger(
+    value.connectorPostTimeoutMs
+  );
   return {
     connectorBaseUrl,
     connectorBaseUrls,
+    connectorHealthCacheTtlMs,
+    connectorHealthTimeoutMs,
     connectorPath,
+    connectorPostTimeoutMs,
+    connectorStatusPath,
     localAgentDid,
     peersConfigPath
   };
@@ -14614,8 +14662,10 @@ async function resolveLinuxDockerGatewayHost() {
 }
 async function resolveConnectorEndpoints(options) {
   const runtimeConfig = await loadRelayRuntimeConfig(options);
-  const pathInput = options.connectorPath ?? runtimeConfig.connectorPath ?? process.env.CLAWDENTITY_CONNECTOR_OUTBOUND_PATH ?? DEFAULT_CONNECTOR_OUTBOUND_PATH;
-  const path = normalizeConnectorPath(pathInput.trim());
+  const outboundPathInput = options.connectorPath ?? runtimeConfig.connectorPath ?? process.env.CLAWDENTITY_CONNECTOR_OUTBOUND_PATH ?? DEFAULT_CONNECTOR_OUTBOUND_PATH;
+  const outboundPath = normalizeConnectorPath(outboundPathInput.trim());
+  const statusPathInput = options.connectorStatusPath ?? runtimeConfig.connectorStatusPath ?? process.env.CLAWDENTITY_CONNECTOR_STATUS_PATH ?? DEFAULT_CONNECTOR_STATUS_PATH;
+  const statusPath = normalizeConnectorPath(statusPathInput.trim());
   const candidates = [];
   if (options.connectorBaseUrl) {
     candidates.push(parseConnectorBaseUrl(options.connectorBaseUrl.trim()));
@@ -14646,42 +14696,142 @@ async function resolveConnectorEndpoints(options) {
     }
   }
   const deduped = Array.from(new Set(candidates.map((candidate) => candidate)));
-  return deduped.map((baseUrl) => new URL(path, baseUrl).toString());
+  return deduped.map((baseUrl) => ({
+    outboundUrl: new URL(outboundPath, baseUrl).toString(),
+    statusUrl: new URL(statusPath, baseUrl).toString()
+  }));
 }
-function mapConnectorFailure(status) {
+function mapConnectorFailure(input) {
+  const status = input.status;
   if (status === 404) {
-    return new Error("Local connector outbound endpoint is unavailable");
-  }
-  if (status === 409) {
-    return new Error("Peer alias is not configured");
+    return new RelayTransformError({
+      category: "connector_unavailable",
+      message: "Local connector outbound endpoint is unavailable",
+      retryable: true,
+      statusCode: status
+    });
   }
   if (status === 400 || status === 422) {
-    return new Error("Local connector rejected outbound relay payload");
+    return new RelayTransformError({
+      category: "connector_request_rejected",
+      message: input.connectorMessage ?? "Local connector rejected outbound relay payload",
+      retryable: false,
+      statusCode: status
+    });
   }
-  return new Error("Local connector outbound relay request failed");
+  if (status === 507) {
+    return new RelayTransformError({
+      category: "connector_queue_full",
+      message: input.connectorMessage ?? "Local connector outbound queue is full",
+      retryable: true,
+      statusCode: status
+    });
+  }
+  return new RelayTransformError({
+    category: "connector_request_failed",
+    message: input.connectorMessage ?? "Local connector outbound relay request failed",
+    retryable: status >= 500,
+    statusCode: status
+  });
 }
-async function postToConnector(endpoint, payload, fetchImpl) {
+function isTimeoutLike(error48) {
+  if (!isRecord(error48)) {
+    return false;
+  }
+  return error48.name === "TimeoutError" || error48.name === "AbortError";
+}
+function normalizeRelayError(error48) {
+  if (error48 instanceof RelayTransformError) {
+    return error48;
+  }
+  if (isTimeoutLike(error48)) {
+    return new RelayTransformError({
+      category: "connector_timeout",
+      message: "Local connector outbound relay request timed out",
+      retryable: true
+    });
+  }
+  return new RelayTransformError({
+    category: "connector_unavailable",
+    message: "Local connector outbound relay request failed",
+    retryable: true
+  });
+}
+async function parseConnectorErrorMessage(response) {
+  try {
+    const payload = await response.json();
+    if (!isRecord(payload)) {
+      return void 0;
+    }
+    const errorPayload = payload.error;
+    if (!isRecord(errorPayload)) {
+      return void 0;
+    }
+    return typeof errorPayload.message === "string" ? errorPayload.message : void 0;
+  } catch {
+    return void 0;
+  }
+}
+function computeHealthCacheTtlMs(options, runtimeConfig) {
+  return options.connectorHealthCacheTtlMs ?? runtimeConfig.connectorHealthCacheTtlMs ?? parseOptionalPositiveInteger(
+    process.env.CLAWDENTITY_CONNECTOR_HEALTH_CACHE_TTL_MS
+  ) ?? DEFAULT_CONNECTOR_HEALTH_CACHE_TTL_MS;
+}
+function computeHealthTimeoutMs(options, runtimeConfig) {
+  return options.connectorHealthTimeoutMs ?? runtimeConfig.connectorHealthTimeoutMs ?? parseOptionalPositiveInteger(
+    process.env.CLAWDENTITY_CONNECTOR_HEALTH_TIMEOUT_MS
+  ) ?? DEFAULT_CONNECTOR_HEALTH_TIMEOUT_MS;
+}
+function computePostTimeoutMs(options, runtimeConfig) {
+  return options.connectorPostTimeoutMs ?? runtimeConfig.connectorPostTimeoutMs ?? parseOptionalPositiveInteger(process.env.CLAWDENTITY_CONNECTOR_POST_TIMEOUT_MS) ?? DEFAULT_CONNECTOR_POST_TIMEOUT_MS;
+}
+async function isEndpointHealthy(input) {
+  const nowMs = Date.now();
+  const cacheEntry = endpointHealthCache.get(input.endpoint.statusUrl);
+  if (cacheEntry !== void 0 && nowMs - cacheEntry.checkedAtMs < input.healthCacheTtlMs) {
+    return cacheEntry.healthy;
+  }
+  let healthy = false;
+  try {
+    const response = await input.fetchImpl(input.endpoint.statusUrl, {
+      method: "GET",
+      signal: AbortSignal.timeout(input.healthTimeoutMs)
+    });
+    healthy = response.ok;
+  } catch {
+    healthy = false;
+  }
+  endpointHealthCache.set(input.endpoint.statusUrl, {
+    checkedAtMs: nowMs,
+    healthy
+  });
+  return healthy;
+}
+async function postToConnector(input) {
   let response;
   try {
-    response = await fetchImpl(endpoint, {
+    response = await input.fetchImpl(input.endpoint.outboundUrl, {
       method: "POST",
       headers: {
         "Content-Type": "application/json"
       },
-      body: JSON.stringify(payload)
+      body: JSON.stringify(input.payload),
+      signal: AbortSignal.timeout(input.timeoutMs)
     });
-  } catch {
-    throw new Error("Local connector outbound relay request failed");
+  } catch (error48) {
+    throw normalizeRelayError(error48);
   }
   if (!response.ok) {
-    throw mapConnectorFailure(response.status);
+    const connectorMessage = await parseConnectorErrorMessage(response);
+    throw mapConnectorFailure({
+      connectorMessage,
+      status: response.status
+    });
   }
 }
 function shouldTryNextConnectorEndpoint(error48) {
-  if (!(error48 instanceof Error)) {
-    return false;
-  }
-  return error48.message === "Local connector outbound relay request failed" || error48.message === "Local connector outbound endpoint is unavailable";
+  const normalized = normalizeRelayError(error48);
+  return normalized.retryable;
 }
 async function resolvePeersConfigPathOptions(options) {
   if (options.configPath !== void 0 || options.configDir !== void 0 || options.homeDir !== void 0) {
@@ -14746,32 +14896,70 @@ async function relayPayloadToPeer(payload, options = {}) {
   });
   const relayPayload = {
     conversationId,
-    peer: peerAlias,
-    peerDid: peerEntry.did,
-    peerProxyUrl: peerEntry.proxyUrl,
+    toAgentDid: peerEntry.did,
     payload: outboundPayload
   };
-  let lastError;
+  const runtimeConfig = await loadRelayRuntimeConfig(options);
+  const healthCacheTtlMs = computeHealthCacheTtlMs(options, runtimeConfig);
+  const healthTimeoutMs = computeHealthTimeoutMs(options, runtimeConfig);
+  const postTimeoutMs = computePostTimeoutMs(options, runtimeConfig);
+  const healthyEndpoints = [];
   for (const endpoint of connectorEndpoints) {
+    if (await isEndpointHealthy({
+      endpoint,
+      fetchImpl,
+      healthCacheTtlMs,
+      healthTimeoutMs
+    })) {
+      healthyEndpoints.push(endpoint);
+    }
+  }
+  if (healthyEndpoints.length === 0) {
+    throw new RelayTransformError({
+      category: "connector_unavailable",
+      message: "Local connector status endpoint is unavailable",
+      retryable: true
+    });
+  }
+  let lastError;
+  for (const endpoint of healthyEndpoints) {
     try {
-      await postToConnector(endpoint, relayPayload, fetchImpl);
+      await postToConnector({
+        endpoint,
+        fetchImpl,
+        payload: relayPayload,
+        timeoutMs: postTimeoutMs
+      });
+      endpointHealthCache.set(endpoint.statusUrl, {
+        checkedAtMs: Date.now(),
+        healthy: true
+      });
       return null;
     } catch (error48) {
       lastError = error48;
+      endpointHealthCache.set(endpoint.statusUrl, {
+        checkedAtMs: Date.now(),
+        healthy: false
+      });
       if (!shouldTryNextConnectorEndpoint(error48)) {
-        throw error48;
+        throw normalizeRelayError(error48);
       }
     }
   }
-  if (lastError instanceof Error) {
-    throw lastError;
+  if (lastError !== void 0) {
+    throw normalizeRelayError(lastError);
   }
-  throw new Error("Local connector outbound relay request failed");
+  throw new RelayTransformError({
+    category: "connector_request_failed",
+    message: "Local connector outbound relay request failed",
+    retryable: true
+  });
 }
 async function relayToPeer(ctx) {
   return relayPayloadToPeer(ctx?.payload);
 }
 export {
+  RelayTransformError,
   relayToPeer as default,
   relayPayloadToPeer
 };

--- a/crates/clawdentity-core/src/db/mod.rs
+++ b/crates/clawdentity-core/src/db/mod.rs
@@ -125,6 +125,24 @@ ALTER TABLE inbound_pending
 ALTER TABLE inbound_dead_letter
     ADD COLUMN delivery_source TEXT;
 "#;
+const MIGRATION_NAME_PHASE6: &str = "0004_outbound_retry_policy";
+const MIGRATION_SQL_PHASE6: &str = r#"
+ALTER TABLE outbound_queue
+    ADD COLUMN attempt_count INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE outbound_queue
+    ADD COLUMN next_attempt_at_ms INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE outbound_queue
+    ADD COLUMN last_attempt_at_ms INTEGER;
+
+ALTER TABLE outbound_queue
+    ADD COLUMN last_error TEXT;
+
+UPDATE outbound_queue
+SET next_attempt_at_ms = created_at_ms
+WHERE next_attempt_at_ms = 0;
+"#;
 
 #[derive(Clone)]
 pub struct SqliteStore {
@@ -199,6 +217,7 @@ fn apply_migrations(connection: &Connection) -> Result<()> {
     apply_migration_if_needed(connection, MIGRATION_NAME_PHASE3, MIGRATION_SQL_PHASE3)?;
     apply_migration_if_needed(connection, MIGRATION_NAME_PHASE4, MIGRATION_SQL_PHASE4)?;
     apply_migration_if_needed(connection, MIGRATION_NAME_PHASE5, MIGRATION_SQL_PHASE5)?;
+    apply_migration_if_needed(connection, MIGRATION_NAME_PHASE6, MIGRATION_SQL_PHASE6)?;
     Ok(())
 }
 

--- a/crates/clawdentity-core/src/db/outbound.rs
+++ b/crates/clawdentity-core/src/db/outbound.rs
@@ -13,6 +13,18 @@ pub struct OutboundQueueItem {
     pub conversation_id: Option<String>,
     pub reply_to: Option<String>,
     pub created_at_ms: i64,
+    pub attempt_count: i64,
+    pub next_attempt_at_ms: i64,
+    pub last_attempt_at_ms: Option<i64>,
+    pub last_error: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OutboundQueueStats {
+    pub pending_count: i64,
+    pub retrying_count: i64,
+    pub oldest_created_at_ms: Option<i64>,
+    pub next_retry_at_ms: Option<i64>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -61,6 +73,10 @@ fn map_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<OutboundQueueItem> {
         conversation_id: row.get(5)?,
         reply_to: row.get(6)?,
         created_at_ms: row.get(7)?,
+        attempt_count: row.get(8)?,
+        next_attempt_at_ms: row.get(9)?,
+        last_attempt_at_ms: row.get(10)?,
+        last_error: row.get(11)?,
     })
 }
 
@@ -111,8 +127,9 @@ pub fn enqueue_outbound(store: &SqliteStore, input: EnqueueOutboundInput) -> Res
     store.with_connection(|connection| {
         connection.execute(
             "INSERT INTO outbound_queue (
-                frame_id, frame_version, frame_type, to_agent_did, payload_json, conversation_id, reply_to, created_at_ms
-            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+                frame_id, frame_version, frame_type, to_agent_did, payload_json, conversation_id,
+                reply_to, created_at_ms, attempt_count, next_attempt_at_ms, last_attempt_at_ms, last_error
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, 0, ?8, NULL, NULL)",
             params![
                 frame_id,
                 input.frame_version,
@@ -133,9 +150,10 @@ pub fn list_outbound(store: &SqliteStore, limit: usize) -> Result<Vec<OutboundQu
     let limit = i64::try_from(limit).unwrap_or(i64::MAX);
     store.with_connection(|connection| {
         let mut statement = connection.prepare(
-            "SELECT frame_id, frame_version, frame_type, to_agent_did, payload_json, conversation_id, reply_to, created_at_ms
+            "SELECT frame_id, frame_version, frame_type, to_agent_did, payload_json, conversation_id,
+                    reply_to, created_at_ms, attempt_count, next_attempt_at_ms, last_attempt_at_ms, last_error
              FROM outbound_queue
-             ORDER BY created_at_ms ASC, frame_id ASC
+             ORDER BY next_attempt_at_ms ASC, created_at_ms ASC, frame_id ASC
              LIMIT ?1",
         )?;
         let rows = statement.query_map([limit], map_row)?;
@@ -144,21 +162,63 @@ pub fn list_outbound(store: &SqliteStore, limit: usize) -> Result<Vec<OutboundQu
     })
 }
 
-/// TODO(clawdentity): document `take_oldest_outbound`.
-pub fn take_oldest_outbound(store: &SqliteStore) -> Result<Option<OutboundQueueItem>> {
+/// TODO(clawdentity): document `take_due_outbound`.
+pub fn take_due_outbound(store: &SqliteStore, now_ms: i64) -> Result<Option<OutboundQueueItem>> {
     store.with_connection(|connection| {
         let mut statement = connection.prepare(
-            "SELECT frame_id, frame_version, frame_type, to_agent_did, payload_json, conversation_id, reply_to, created_at_ms
+            "SELECT frame_id, frame_version, frame_type, to_agent_did, payload_json, conversation_id,
+                    reply_to, created_at_ms, attempt_count, next_attempt_at_ms, last_attempt_at_ms, last_error
              FROM outbound_queue
-             ORDER BY created_at_ms ASC, frame_id ASC
+             WHERE next_attempt_at_ms <= ?1
+             ORDER BY next_attempt_at_ms ASC, created_at_ms ASC, frame_id ASC
              LIMIT 1",
         )?;
-        let item = statement.query_row([], map_row).ok();
+        let item = statement.query_row([now_ms], map_row).ok();
         let Some(item) = item else {
             return Ok(None);
         };
         connection.execute("DELETE FROM outbound_queue WHERE frame_id = ?1", [&item.frame_id])?;
         Ok(Some(item))
+    })
+}
+
+/// TODO(clawdentity): document `requeue_outbound_retry`.
+pub fn requeue_outbound_retry(
+    store: &SqliteStore,
+    item: &OutboundQueueItem,
+    next_attempt_at_ms: i64,
+    last_error: &str,
+) -> Result<()> {
+    let trimmed_error = last_error.trim();
+    if trimmed_error.is_empty() {
+        return Err(CoreError::InvalidInput(
+            "last_error is required".to_string(),
+        ));
+    }
+
+    let now_ms = now_utc_ms();
+    store.with_connection(|connection| {
+        connection.execute(
+            "INSERT INTO outbound_queue (
+                frame_id, frame_version, frame_type, to_agent_did, payload_json, conversation_id,
+                reply_to, created_at_ms, attempt_count, next_attempt_at_ms, last_attempt_at_ms, last_error
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+            params![
+                &item.frame_id,
+                item.frame_version,
+                &item.frame_type,
+                &item.to_agent_did,
+                &item.payload_json,
+                &item.conversation_id,
+                &item.reply_to,
+                item.created_at_ms,
+                item.attempt_count + 1,
+                next_attempt_at_ms,
+                now_ms,
+                trimmed_error
+            ],
+        )?;
+        Ok(())
     })
 }
 
@@ -231,6 +291,41 @@ pub fn outbound_count(store: &SqliteStore) -> Result<i64> {
     })
 }
 
+/// TODO(clawdentity): document `outbound_queue_stats`.
+pub fn outbound_queue_stats(store: &SqliteStore, now_ms: i64) -> Result<OutboundQueueStats> {
+    store.with_connection(|connection| {
+        let (pending_count, retrying_count, oldest_created_at_ms, next_retry_at_ms): (
+            i64,
+            i64,
+            Option<i64>,
+            Option<i64>,
+        ) = connection.query_row(
+            "SELECT
+                COUNT(*) AS pending_count,
+                COALESCE(SUM(CASE WHEN attempt_count > 0 THEN 1 ELSE 0 END), 0) AS retrying_count,
+                MIN(created_at_ms) AS oldest_created_at_ms,
+                MIN(CASE WHEN next_attempt_at_ms > ?1 THEN next_attempt_at_ms ELSE NULL END) AS next_retry_at_ms
+             FROM outbound_queue",
+            [now_ms],
+            |row| {
+                Ok((
+                    row.get(0)?,
+                    row.get(1)?,
+                    row.get(2)?,
+                    row.get(3)?,
+                ))
+            },
+        )?;
+
+        Ok(OutboundQueueStats {
+            pending_count,
+            retrying_count,
+            oldest_created_at_ms,
+            next_retry_at_ms,
+        })
+    })
+}
+
 /// TODO(clawdentity): document `list_outbound_dead_letter`.
 pub fn list_outbound_dead_letter(
     store: &SqliteStore,
@@ -271,7 +366,7 @@ mod tests {
     use super::{
         EnqueueOutboundInput, delete_outbound, enqueue_outbound, list_outbound,
         list_outbound_dead_letter, move_outbound_to_dead_letter, outbound_count,
-        outbound_dead_letter_count, take_oldest_outbound,
+        outbound_dead_letter_count, take_due_outbound,
     };
 
     #[test]
@@ -311,7 +406,9 @@ mod tests {
         assert_eq!(outbound_count(&store).expect("count"), 2);
         assert_eq!(list_outbound(&store, 10).expect("list").len(), 2);
 
-        let oldest = take_oldest_outbound(&store).expect("take").expect("oldest");
+        let oldest = take_due_outbound(&store, i64::MAX)
+            .expect("take")
+            .expect("oldest");
         assert_eq!(oldest.frame_id, "frame-1");
         assert_eq!(outbound_count(&store).expect("count after take"), 1);
 
@@ -339,7 +436,9 @@ mod tests {
             },
         )
         .expect("enqueue");
-        let item = take_oldest_outbound(&store).expect("take").expect("item");
+        let item = take_due_outbound(&store, i64::MAX)
+            .expect("take")
+            .expect("item");
         move_outbound_to_dead_letter(&store, &item, "malformed outbound payload").expect("move");
 
         assert_eq!(outbound_count(&store).expect("queue count"), 0);

--- a/crates/clawdentity-core/src/lib.rs
+++ b/crates/clawdentity-core/src/lib.rs
@@ -150,6 +150,7 @@ pub use runtime_auth::{RelayConnectHeaders, build_relay_connect_headers};
 pub use runtime_openclaw::{OpenclawRuntimeConfig, check_openclaw_gateway_health};
 pub use runtime_relay::{
     FlushOutboundResult, OutboundRetryPolicy, SentOutboundFrame, flush_outbound_queue_to_relay,
+    flush_outbound_queue_to_relay_with_sent_observer,
 };
 pub use runtime_replay::{
     PurgeResult, ReplayResult, purge_dead_letter_messages, replay_dead_letter_messages,

--- a/crates/clawdentity-core/src/lib.rs
+++ b/crates/clawdentity-core/src/lib.rs
@@ -83,7 +83,8 @@ pub use db_inbound::{
 pub use db_outbound::{
     EnqueueOutboundInput, OutboundDeadLetterItem, OutboundQueueItem, delete_outbound,
     enqueue_outbound, list_outbound, list_outbound_dead_letter, move_outbound_to_dead_letter,
-    outbound_count, outbound_dead_letter_count, take_oldest_outbound,
+    outbound_count, outbound_dead_letter_count, outbound_queue_stats, requeue_outbound_retry,
+    take_due_outbound,
 };
 pub use db_peers::{
     PeerRecord, UpsertPeerInput, delete_peer, get_peer_by_alias, get_peer_by_did, list_peers,
@@ -147,7 +148,9 @@ pub use registry::{
 };
 pub use runtime_auth::{RelayConnectHeaders, build_relay_connect_headers};
 pub use runtime_openclaw::{OpenclawRuntimeConfig, check_openclaw_gateway_health};
-pub use runtime_relay::{FlushOutboundResult, flush_outbound_queue_to_relay};
+pub use runtime_relay::{
+    FlushOutboundResult, OutboundRetryPolicy, SentOutboundFrame, flush_outbound_queue_to_relay,
+};
 pub use runtime_replay::{
     PurgeResult, ReplayResult, purge_dead_letter_messages, replay_dead_letter_messages,
 };

--- a/crates/clawdentity-core/src/lib.rs
+++ b/crates/clawdentity-core/src/lib.rs
@@ -149,7 +149,8 @@ pub use registry::{
 pub use runtime_auth::{RelayConnectHeaders, build_relay_connect_headers};
 pub use runtime_openclaw::{OpenclawRuntimeConfig, check_openclaw_gateway_health};
 pub use runtime_relay::{
-    FlushOutboundResult, OutboundRetryPolicy, SentOutboundFrame, flush_outbound_queue_to_relay,
+    FlushOutboundResult, OutboundRetryPolicy, OutboundSendObservation, SentOutboundFrame,
+    flush_outbound_queue_to_relay, flush_outbound_queue_to_relay_with_send_observer,
     flush_outbound_queue_to_relay_with_sent_observer,
 };
 pub use runtime_replay::{

--- a/crates/clawdentity-core/src/providers/openclaw/asset_bundle.rs
+++ b/crates/clawdentity-core/src/providers/openclaw/asset_bundle.rs
@@ -100,7 +100,10 @@ fn render_skill_markdown(site_base_url: &str) -> String {
             "https://clawdentity.com/install.ps1",
             format!("{site_base_url}/install.ps1"),
         ),
-        ("<skill-origin>/install.sh", format!("{site_base_url}/install.sh")),
+        (
+            "<skill-origin>/install.sh",
+            format!("{site_base_url}/install.sh"),
+        ),
         (
             "<skill-origin>/install.ps1",
             format!("{site_base_url}/install.ps1"),

--- a/crates/clawdentity-core/src/runtime/AGENTS.md
+++ b/crates/clawdentity-core/src/runtime/AGENTS.md
@@ -8,5 +8,6 @@
 - Keep outbound enqueue path durable-first: persist before relay send, then flush due frames using retry metadata and bounded exponential backoff.
 - Keep outbound retry policy env-driven (`CONNECTOR_OUTBOUND_RETRY_*`, `CONNECTOR_OUTBOUND_MAX_AGE_MS`) with dead-letter on expiry/exhaustion.
 - Enforce outbound queue backpressure via configurable max pending (`CONNECTOR_OUTBOUND_MAX_PENDING`) and return explicit `507` queue-full errors.
+- Keep runtime state testable without process-global env mutation; use state-level queue-limit overrides in tests instead of shared `set_var/remove_var`.
 - Keep status and dead-letter endpoints machine-readable and stable for doctor/relay-test automation.
 - `/v1/status` outbound queue payload must include pending, retrying, dead-letter, oldest-age, and next-retry visibility for operator troubleshooting.

--- a/crates/clawdentity-core/src/runtime/AGENTS.md
+++ b/crates/clawdentity-core/src/runtime/AGENTS.md
@@ -4,6 +4,9 @@
 - Guard the embedded local runtime HTTP/WebSocket surfaces used by connector mode.
 
 ## Rules
-- Runtime request handlers must accept the currently published OpenClaw relay envelope contract until a coordinated asset release changes it.
-- Additive compatibility is preferred over breaking runtime request-shape changes.
+- Runtime `/v1/outbound` request contract is canonical `toAgentDid + payload` (optional `conversationId`, `replyTo`); do not maintain legacy `peerDid` / `peerProxyUrl` acceptance paths.
+- Keep outbound enqueue path durable-first: persist before relay send, then flush due frames using retry metadata and bounded exponential backoff.
+- Keep outbound retry policy env-driven (`CONNECTOR_OUTBOUND_RETRY_*`, `CONNECTOR_OUTBOUND_MAX_AGE_MS`) with dead-letter on expiry/exhaustion.
+- Enforce outbound queue backpressure via configurable max pending (`CONNECTOR_OUTBOUND_MAX_PENDING`) and return explicit `507` queue-full errors.
 - Keep status and dead-letter endpoints machine-readable and stable for doctor/relay-test automation.
+- `/v1/status` outbound queue payload must include pending, retrying, dead-letter, oldest-age, and next-retry visibility for operator troubleshooting.

--- a/crates/clawdentity-core/src/runtime/AGENTS.md
+++ b/crates/clawdentity-core/src/runtime/AGENTS.md
@@ -7,6 +7,7 @@
 - Runtime `/v1/outbound` request contract is canonical `toAgentDid + payload` (optional `conversationId`, `replyTo`); do not maintain legacy `peerDid` / `peerProxyUrl` acceptance paths.
 - Keep outbound enqueue path durable-first: persist before relay send, then flush due frames using retry metadata and bounded exponential backoff.
 - Keep outbound retry policy env-driven (`CONNECTOR_OUTBOUND_RETRY_*`, `CONNECTOR_OUTBOUND_MAX_AGE_MS`) with dead-letter on expiry/exhaustion.
+- Keep public runtime functions documented with `///` comments so structural documentation gates stay green in CI.
 - Enforce outbound queue backpressure via configurable max pending (`CONNECTOR_OUTBOUND_MAX_PENDING`) and return explicit `507` queue-full errors.
 - Keep runtime state testable without process-global env mutation; use state-level queue-limit overrides in tests instead of shared `set_var/remove_var`.
 - Keep status and dead-letter endpoints machine-readable and stable for doctor/relay-test automation.

--- a/crates/clawdentity-core/src/runtime/relay.rs
+++ b/crates/clawdentity-core/src/runtime/relay.rs
@@ -1,17 +1,91 @@
 use crate::connector_client::ConnectorClientSender;
 use crate::connector_frames::{CONNECTOR_FRAME_VERSION, ConnectorFrame, EnqueueFrame, now_iso};
-use crate::db::SqliteStore;
+use crate::db::{SqliteStore, now_utc_ms};
 use crate::db_outbound::{
-    EnqueueOutboundInput, OutboundQueueItem, enqueue_outbound, move_outbound_to_dead_letter,
-    take_oldest_outbound,
+    OutboundQueueItem, move_outbound_to_dead_letter, requeue_outbound_retry, take_due_outbound,
 };
 use crate::error::Result;
 use crate::runtime_trusted_receipts::TrustedReceiptsStore;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SentOutboundFrame {
+    pub frame_id: String,
+    pub to_agent_did: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FlushOutboundResult {
+    pub sent_frames: Vec<SentOutboundFrame>,
     pub sent_count: usize,
     pub failed_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct OutboundRetryPolicy {
+    pub initial_delay_ms: i64,
+    pub max_delay_ms: i64,
+    pub backoff_factor: f64,
+    pub max_attempts: i64,
+    pub max_age_ms: i64,
+}
+
+impl Default for OutboundRetryPolicy {
+    fn default() -> Self {
+        Self {
+            initial_delay_ms: 1_000,
+            max_delay_ms: 60_000,
+            backoff_factor: 2.0,
+            max_attempts: 30,
+            max_age_ms: 24 * 60 * 60 * 1_000,
+        }
+    }
+}
+
+impl OutboundRetryPolicy {
+    pub fn from_env() -> Self {
+        let default = Self::default();
+        Self {
+            initial_delay_ms: parse_env_i64(
+                "CONNECTOR_OUTBOUND_RETRY_INITIAL_DELAY_MS",
+                default.initial_delay_ms,
+            ),
+            max_delay_ms: parse_env_i64(
+                "CONNECTOR_OUTBOUND_RETRY_MAX_DELAY_MS",
+                default.max_delay_ms,
+            ),
+            backoff_factor: parse_env_f64(
+                "CONNECTOR_OUTBOUND_RETRY_BACKOFF_FACTOR",
+                default.backoff_factor,
+            ),
+            max_attempts: parse_env_i64(
+                "CONNECTOR_OUTBOUND_RETRY_MAX_ATTEMPTS",
+                default.max_attempts,
+            ),
+            max_age_ms: parse_env_i64("CONNECTOR_OUTBOUND_MAX_AGE_MS", default.max_age_ms),
+        }
+    }
+}
+
+fn parse_env_i64(name: &str, default: i64) -> i64 {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.trim().parse::<i64>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(default)
+}
+
+fn parse_env_f64(name: &str, default: f64) -> f64 {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.trim().parse::<f64>().ok())
+        .filter(|value| *value >= 1.0)
+        .unwrap_or(default)
+}
+
+fn compute_retry_delay_ms(attempt_count: i64, policy: &OutboundRetryPolicy) -> i64 {
+    let exponent = (attempt_count.saturating_sub(1)) as i32;
+    let backoff = (policy.initial_delay_ms as f64) * policy.backoff_factor.powi(exponent);
+    (backoff.floor() as i64).clamp(1, policy.max_delay_ms)
 }
 
 /// TODO(clawdentity): document `flush_outbound_queue_to_relay`.
@@ -22,6 +96,8 @@ pub async fn flush_outbound_queue_to_relay(
     max_items: usize,
     trusted_receipts: Option<&TrustedReceiptsStore>,
 ) -> Result<FlushOutboundResult> {
+    let policy = OutboundRetryPolicy::from_env();
+    let mut sent_frames: Vec<SentOutboundFrame> = Vec::new();
     let mut sent_count = 0_usize;
     let mut failed_count = 0_usize;
 
@@ -30,9 +106,21 @@ pub async fn flush_outbound_queue_to_relay(
             break;
         }
 
-        let Some(item) = take_oldest_outbound(store)? else {
+        let now_ms = now_utc_ms();
+        let Some(item) = take_due_outbound(store, now_ms)? else {
             break;
         };
+
+        let age_ms = now_ms.saturating_sub(item.created_at_ms);
+        if age_ms > policy.max_age_ms {
+            move_outbound_to_dead_letter(
+                store,
+                &item,
+                "outbound message expired before relay delivery",
+            )?;
+            failed_count += 1;
+            continue;
+        }
 
         let payload = match serde_json::from_str::<serde_json::Value>(&item.payload_json) {
             Ok(payload) => payload,
@@ -69,30 +157,39 @@ pub async fn flush_outbound_queue_to_relay(
         });
 
         if relay.send_frame(frame).await.is_err() {
-            // Requeue on best effort if the relay connection failed.
-            enqueue_outbound(
+            if item.attempt_count + 1 >= policy.max_attempts {
+                move_outbound_to_dead_letter(
+                    store,
+                    &item,
+                    "outbound relay delivery failed after max retry attempts",
+                )?;
+                failed_count += 1;
+                continue;
+            }
+
+            let retry_delay_ms = compute_retry_delay_ms(item.attempt_count + 1, &policy);
+            requeue_outbound_retry(
                 store,
-                EnqueueOutboundInput {
-                    frame_id: item.frame_id,
-                    frame_version: item.frame_version,
-                    frame_type: item.frame_type,
-                    to_agent_did: item.to_agent_did,
-                    payload_json: item.payload_json,
-                    conversation_id: item.conversation_id,
-                    reply_to: item.reply_to,
-                },
+                &item,
+                now_ms + retry_delay_ms,
+                "relay websocket send failed",
             )?;
             failed_count += 1;
             break;
         }
 
         if let Some(receipts) = trusted_receipts {
-            receipts.mark_trusted(item.frame_id);
+            receipts.mark_trusted(item.frame_id.clone());
         }
+        sent_frames.push(SentOutboundFrame {
+            frame_id: item.frame_id,
+            to_agent_did: item.to_agent_did,
+        });
         sent_count += 1;
     }
 
     Ok(FlushOutboundResult {
+        sent_frames,
         sent_count,
         failed_count,
     })
@@ -120,7 +217,7 @@ mod tests {
     use crate::db::SqliteStore;
     use crate::db_outbound::{
         EnqueueOutboundInput, enqueue_outbound, list_outbound_dead_letter, outbound_count,
-        take_oldest_outbound,
+        take_due_outbound,
     };
     use crate::runtime_trusted_receipts::TrustedReceiptsStore;
 
@@ -179,7 +276,9 @@ mod tests {
             },
         )
         .expect("enqueue");
-        let item = take_oldest_outbound(&store).expect("take").expect("item");
+        let item = take_due_outbound(&store, i64::MAX)
+            .expect("take")
+            .expect("item");
         let parse_error =
             serde_json::from_str::<serde_json::Value>(&item.payload_json).expect_err("invalid");
         dead_letter_malformed_outbound_payload(&store, &item, &parse_error).expect("dead letter");

--- a/crates/clawdentity-core/src/runtime/relay.rs
+++ b/crates/clawdentity-core/src/runtime/relay.rs
@@ -49,6 +49,8 @@ impl Default for OutboundRetryPolicy {
 }
 
 impl OutboundRetryPolicy {
+    /// Loads outbound retry policy from connector runtime environment variables,
+    /// falling back to `Default` values when variables are missing or invalid.
     pub fn from_env() -> Self {
         let default = Self::default();
         Self {

--- a/crates/clawdentity-core/src/runtime/relay.rs
+++ b/crates/clawdentity-core/src/runtime/relay.rs
@@ -13,6 +13,13 @@ pub struct SentOutboundFrame {
     pub to_agent_did: String,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutboundSendObservation {
+    Queued,
+    Sent,
+    SendFailed,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FlushOutboundResult {
     pub sent_frames: Vec<SentOutboundFrame>,
@@ -90,15 +97,15 @@ fn compute_retry_delay_ms(attempt_count: i64, policy: &OutboundRetryPolicy) -> i
 
 /// TODO(clawdentity): document `flush_outbound_queue_to_relay_with_sent_observer`.
 #[allow(clippy::too_many_lines)]
-pub async fn flush_outbound_queue_to_relay_with_sent_observer<F>(
+pub async fn flush_outbound_queue_to_relay_with_send_observer<F>(
     store: &SqliteStore,
     relay: &ConnectorClientSender,
     max_items: usize,
     trusted_receipts: Option<&TrustedReceiptsStore>,
-    mut observe_sent: F,
+    mut observe_send: F,
 ) -> Result<FlushOutboundResult>
 where
-    F: FnMut(&SentOutboundFrame),
+    F: FnMut(&SentOutboundFrame, OutboundSendObservation),
 {
     let policy = OutboundRetryPolicy::from_env();
     let mut sent_frames: Vec<SentOutboundFrame> = Vec::new();
@@ -165,7 +172,9 @@ where
             reply_to: item.reply_to.clone(),
         });
 
+        observe_send(&sent_frame, OutboundSendObservation::Queued);
         if relay.send_frame(frame).await.is_err() {
+            observe_send(&sent_frame, OutboundSendObservation::SendFailed);
             if item.attempt_count + 1 >= policy.max_attempts {
                 move_outbound_to_dead_letter(
                     store,
@@ -187,7 +196,7 @@ where
             break;
         }
 
-        observe_sent(&sent_frame);
+        observe_send(&sent_frame, OutboundSendObservation::Sent);
         if let Some(receipts) = trusted_receipts {
             receipts.mark_trusted(item.frame_id.clone());
         }
@@ -200,6 +209,31 @@ where
         sent_count,
         failed_count,
     })
+}
+
+/// TODO(clawdentity): document `flush_outbound_queue_to_relay_with_sent_observer`.
+pub async fn flush_outbound_queue_to_relay_with_sent_observer<F>(
+    store: &SqliteStore,
+    relay: &ConnectorClientSender,
+    max_items: usize,
+    trusted_receipts: Option<&TrustedReceiptsStore>,
+    mut observe_sent: F,
+) -> Result<FlushOutboundResult>
+where
+    F: FnMut(&SentOutboundFrame),
+{
+    flush_outbound_queue_to_relay_with_send_observer(
+        store,
+        relay,
+        max_items,
+        trusted_receipts,
+        |sent, observation| {
+            if observation == OutboundSendObservation::Sent {
+                observe_sent(sent);
+            }
+        },
+    )
+    .await
 }
 
 /// TODO(clawdentity): document `flush_outbound_queue_to_relay`.

--- a/crates/clawdentity-core/src/runtime/relay.rs
+++ b/crates/clawdentity-core/src/runtime/relay.rs
@@ -88,14 +88,18 @@ fn compute_retry_delay_ms(attempt_count: i64, policy: &OutboundRetryPolicy) -> i
     (backoff.floor() as i64).clamp(1, policy.max_delay_ms)
 }
 
-/// TODO(clawdentity): document `flush_outbound_queue_to_relay`.
+/// TODO(clawdentity): document `flush_outbound_queue_to_relay_with_sent_observer`.
 #[allow(clippy::too_many_lines)]
-pub async fn flush_outbound_queue_to_relay(
+pub async fn flush_outbound_queue_to_relay_with_sent_observer<F>(
     store: &SqliteStore,
     relay: &ConnectorClientSender,
     max_items: usize,
     trusted_receipts: Option<&TrustedReceiptsStore>,
-) -> Result<FlushOutboundResult> {
+    mut observe_sent: F,
+) -> Result<FlushOutboundResult>
+where
+    F: FnMut(&SentOutboundFrame),
+{
     let policy = OutboundRetryPolicy::from_env();
     let mut sent_frames: Vec<SentOutboundFrame> = Vec::new();
     let mut sent_count = 0_usize;
@@ -146,6 +150,11 @@ pub async fn flush_outbound_queue_to_relay(
             }
         };
 
+        let sent_frame = SentOutboundFrame {
+            frame_id: item.frame_id.clone(),
+            to_agent_did: item.to_agent_did.clone(),
+        };
+
         let frame = ConnectorFrame::Enqueue(EnqueueFrame {
             v: CONNECTOR_FRAME_VERSION,
             id: item.frame_id.clone(),
@@ -178,13 +187,11 @@ pub async fn flush_outbound_queue_to_relay(
             break;
         }
 
+        observe_sent(&sent_frame);
         if let Some(receipts) = trusted_receipts {
             receipts.mark_trusted(item.frame_id.clone());
         }
-        sent_frames.push(SentOutboundFrame {
-            frame_id: item.frame_id,
-            to_agent_did: item.to_agent_did,
-        });
+        sent_frames.push(sent_frame);
         sent_count += 1;
     }
 
@@ -193,6 +200,23 @@ pub async fn flush_outbound_queue_to_relay(
         sent_count,
         failed_count,
     })
+}
+
+/// TODO(clawdentity): document `flush_outbound_queue_to_relay`.
+pub async fn flush_outbound_queue_to_relay(
+    store: &SqliteStore,
+    relay: &ConnectorClientSender,
+    max_items: usize,
+    trusted_receipts: Option<&TrustedReceiptsStore>,
+) -> Result<FlushOutboundResult> {
+    flush_outbound_queue_to_relay_with_sent_observer(
+        store,
+        relay,
+        max_items,
+        trusted_receipts,
+        |_| {},
+    )
+    .await
 }
 
 fn dead_letter_malformed_outbound_payload(

--- a/crates/clawdentity-core/src/runtime/server.rs
+++ b/crates/clawdentity-core/src/runtime/server.rs
@@ -80,7 +80,7 @@ pub async fn run_runtime_server(
 
 async fn status_handler(State(state): State<RuntimeServerState>) -> impl IntoResponse {
     let now_ms = now_utc_ms();
-    let outbound_stats = outbound_queue_stats(&state.store, now_ms).unwrap_or_else(|_| {
+    let outbound_stats = outbound_queue_stats(&state.store, now_ms).unwrap_or({
         crate::db_outbound::OutboundQueueStats {
             pending_count: 0,
             retrying_count: 0,

--- a/crates/clawdentity-core/src/runtime/server.rs
+++ b/crates/clawdentity-core/src/runtime/server.rs
@@ -25,6 +25,7 @@ const DEFAULT_OUTBOUND_MAX_PENDING: i64 = 10_000;
 pub struct RuntimeServerState {
     pub store: SqliteStore,
     pub relay_sender: Option<ConnectorClientSender>,
+    pub outbound_max_pending_override: Option<i64>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -149,11 +150,7 @@ async fn outbound_handler(
         );
     }
 
-    let max_pending = std::env::var("CONNECTOR_OUTBOUND_MAX_PENDING")
-        .ok()
-        .and_then(|value| value.trim().parse::<i64>().ok())
-        .filter(|value| *value > 0)
-        .unwrap_or(DEFAULT_OUTBOUND_MAX_PENDING);
+    let max_pending = resolve_outbound_max_pending(&state);
     let current_pending = outbound_queue_stats(&state.store, now_utc_ms())
         .map(|stats| stats.pending_count)
         .unwrap_or(0);
@@ -205,6 +202,18 @@ async fn outbound_handler(
             "frameId": frame_id,
         })),
     )
+}
+
+fn resolve_outbound_max_pending(state: &RuntimeServerState) -> i64 {
+    if let Some(override_limit) = state.outbound_max_pending_override {
+        return override_limit.max(1);
+    }
+
+    std::env::var("CONNECTOR_OUTBOUND_MAX_PENDING")
+        .ok()
+        .and_then(|value| value.trim().parse::<i64>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(DEFAULT_OUTBOUND_MAX_PENDING)
 }
 
 async fn dead_letter_list_handler(State(state): State<RuntimeServerState>) -> impl IntoResponse {
@@ -317,6 +326,7 @@ mod tests {
         let app = create_runtime_router(RuntimeServerState {
             store,
             relay_sender: None,
+            outbound_max_pending_override: None,
         });
 
         let response = app
@@ -346,6 +356,7 @@ mod tests {
         let app = create_runtime_router(RuntimeServerState {
             store: store.clone(),
             relay_sender: None,
+            outbound_max_pending_override: None,
         });
 
         let response = app
@@ -372,6 +383,7 @@ mod tests {
         let app = create_runtime_router(RuntimeServerState {
             store: store.clone(),
             relay_sender: None,
+            outbound_max_pending_override: None,
         });
 
         let response = app
@@ -404,6 +416,7 @@ mod tests {
         let app = create_runtime_router(RuntimeServerState {
             store: store.clone(),
             relay_sender: None,
+            outbound_max_pending_override: None,
         });
 
         let response = app
@@ -425,14 +438,12 @@ mod tests {
 
     #[tokio::test]
     async fn outbound_endpoint_returns_507_when_queue_limit_reached() {
-        unsafe {
-            std::env::set_var("CONNECTOR_OUTBOUND_MAX_PENDING", "1");
-        }
         let temp = TempDir::new().expect("temp dir");
         let store = SqliteStore::open_path(temp.path().join("db.sqlite3")).expect("open db");
         let app = create_runtime_router(RuntimeServerState {
             store: store.clone(),
             relay_sender: None,
+            outbound_max_pending_override: Some(1),
         });
 
         let first = app
@@ -465,8 +476,5 @@ mod tests {
             .await
             .expect("response");
         assert_eq!(second.status(), StatusCode::INSUFFICIENT_STORAGE);
-        unsafe {
-            std::env::remove_var("CONNECTOR_OUTBOUND_MAX_PENDING");
-        }
     }
 }

--- a/crates/clawdentity-core/src/runtime/server.rs
+++ b/crates/clawdentity-core/src/runtime/server.rs
@@ -9,13 +9,17 @@ use serde::Deserialize;
 use serde_json::json;
 
 use crate::connector_client::ConnectorClientSender;
-use crate::db::SqliteStore;
+use crate::db::{SqliteStore, now_utc_ms};
 use crate::db_inbound::{dead_letter_count, list_dead_letter, pending_count};
-use crate::db_outbound::{EnqueueOutboundInput, enqueue_outbound, outbound_count};
+use crate::db_outbound::{
+    EnqueueOutboundInput, enqueue_outbound, outbound_dead_letter_count, outbound_queue_stats,
+};
 use crate::did::parse_agent_did;
 use crate::error::{CoreError, Result};
 use crate::runtime_relay::flush_outbound_queue_to_relay;
 use crate::runtime_replay::{purge_dead_letter_messages, replay_dead_letter_messages};
+
+const DEFAULT_OUTBOUND_MAX_PENDING: i64 = 10_000;
 
 #[derive(Clone)]
 pub struct RuntimeServerState {
@@ -26,10 +30,7 @@ pub struct RuntimeServerState {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct OutboundRequest {
-    #[serde(default)]
-    to_agent_did: Option<String>,
-    #[serde(default)]
-    peer_did: Option<String>,
+    to_agent_did: String,
     payload: serde_json::Value,
     #[serde(default)]
     conversation_id: Option<String>,
@@ -78,7 +79,16 @@ pub async fn run_runtime_server(
 }
 
 async fn status_handler(State(state): State<RuntimeServerState>) -> impl IntoResponse {
-    let outbound_pending = outbound_count(&state.store).unwrap_or(0);
+    let now_ms = now_utc_ms();
+    let outbound_stats = outbound_queue_stats(&state.store, now_ms).unwrap_or_else(|_| {
+        crate::db_outbound::OutboundQueueStats {
+            pending_count: 0,
+            retrying_count: 0,
+            oldest_created_at_ms: None,
+            next_retry_at_ms: None,
+        }
+    });
+    let outbound_dead_letter = outbound_dead_letter_count(&state.store).unwrap_or(0);
     let inbound_pending = pending_count(&state.store).unwrap_or(0);
     let inbound_dead_letter = dead_letter_count(&state.store).unwrap_or(0);
     let relay = state.relay_sender.as_ref();
@@ -93,7 +103,13 @@ async fn status_handler(State(state): State<RuntimeServerState>) -> impl IntoRes
             },
             "outbound": {
                 "queue": {
-                    "pendingCount": outbound_pending,
+                    "pendingCount": outbound_stats.pending_count,
+                    "retryingCount": outbound_stats.retrying_count,
+                    "deadLetterCount": outbound_dead_letter,
+                    "oldestAgeMs": outbound_stats
+                        .oldest_created_at_ms
+                        .map(|created_at_ms| now_ms.saturating_sub(created_at_ms)),
+                    "nextRetryAtMs": outbound_stats.next_retry_at_ms,
                 },
             },
             "inbound": {
@@ -109,24 +125,45 @@ async fn outbound_handler(
     State(state): State<RuntimeServerState>,
     Json(request): Json<OutboundRequest>,
 ) -> impl IntoResponse {
-    let Some(normalized_to_agent_did) = request.normalized_to_agent_did() else {
+    let normalized_to_agent_did = request.to_agent_did.trim().to_string();
+    if normalized_to_agent_did.is_empty() {
         return (
             StatusCode::BAD_REQUEST,
             Json(json!({
                 "error": {
                     "code": "INVALID_TO_AGENT_DID",
-                    "message": "toAgentDid or peerDid must be a valid agent DID",
+                    "message": "toAgentDid must be a valid agent DID",
                 }
             })),
         );
-    };
+    }
     if parse_agent_did(&normalized_to_agent_did).is_err() {
         return (
             StatusCode::BAD_REQUEST,
             Json(json!({
                 "error": {
                     "code": "INVALID_TO_AGENT_DID",
-                    "message": "toAgentDid or peerDid must be a valid agent DID",
+                    "message": "toAgentDid must be a valid agent DID",
+                }
+            })),
+        );
+    }
+
+    let max_pending = std::env::var("CONNECTOR_OUTBOUND_MAX_PENDING")
+        .ok()
+        .and_then(|value| value.trim().parse::<i64>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(DEFAULT_OUTBOUND_MAX_PENDING);
+    let current_pending = outbound_queue_stats(&state.store, now_utc_ms())
+        .map(|stats| stats.pending_count)
+        .unwrap_or(0);
+    if current_pending >= max_pending {
+        return (
+            StatusCode::INSUFFICIENT_STORAGE,
+            Json(json!({
+                "error": {
+                    "code": "CONNECTOR_OUTBOUND_QUEUE_FULL",
+                    "message": "Connector outbound queue is full",
                 }
             })),
         );
@@ -260,17 +297,6 @@ fn normalize_request_ids(request_ids: Vec<String>) -> Vec<String> {
         .collect()
 }
 
-impl OutboundRequest {
-    fn normalized_to_agent_did(&self) -> Option<String> {
-        self.to_agent_did
-            .as_deref()
-            .or(self.peer_did.as_deref())
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .map(ToOwned::to_owned)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use axum::body::{Body, to_bytes};
@@ -372,7 +398,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn outbound_endpoint_accepts_legacy_peer_did_payload() {
+    async fn outbound_endpoint_rejects_legacy_peer_did_payload() {
         let temp = TempDir::new().expect("temp dir");
         let store = SqliteStore::open_path(temp.path().join("db.sqlite3")).expect("open db");
         let app = create_runtime_router(RuntimeServerState {
@@ -393,7 +419,54 @@ mod tests {
             )
             .await
             .expect("response");
-        assert_eq!(response.status(), StatusCode::ACCEPTED);
-        assert_eq!(outbound_count(&store).expect("count"), 1);
+        assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        assert_eq!(outbound_count(&store).expect("count"), 0);
+    }
+
+    #[tokio::test]
+    async fn outbound_endpoint_returns_507_when_queue_limit_reached() {
+        unsafe {
+            std::env::set_var("CONNECTOR_OUTBOUND_MAX_PENDING", "1");
+        }
+        let temp = TempDir::new().expect("temp dir");
+        let store = SqliteStore::open_path(temp.path().join("db.sqlite3")).expect("open db");
+        let app = create_runtime_router(RuntimeServerState {
+            store: store.clone(),
+            relay_sender: None,
+        });
+
+        let first = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/outbound")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        "{\"toAgentDid\":\"did:cdi:registry.clawdentity.com:agent:01HF7YAT00W6W7CM7N3W5FDXT4\",\"payload\":{\"hello\":\"world\"}}",
+                    ))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(first.status(), StatusCode::ACCEPTED);
+
+        let second = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/outbound")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        "{\"toAgentDid\":\"did:cdi:registry.clawdentity.com:agent:01HF7YAT00W6W7CM7N3W5FDXT4\",\"payload\":{\"hello\":\"again\"}}",
+                    ))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(second.status(), StatusCode::INSUFFICIENT_STORAGE);
+        unsafe {
+            std::env::remove_var("CONNECTOR_OUTBOUND_MAX_PENDING");
+        }
     }
 }


### PR DESCRIPTION
## Summary
Implements the Issue #146 rebaseline and fixes for outbound reliability in the Rust runtime + OpenClaw transform, with explicit **no legacy payload path** handling.

### What changed
- Rebaselined GitHub issue #146 to current Rust runtime reality (and overlap boundaries with #119 and #148).
- Hardened OpenClaw relay transform with:
  - `/v1/status` preflight probe before `/v1/outbound`
  - short health cache + explicit probe timeout
  - explicit outbound POST timeout
  - structured transform error categories with retry hint semantics
  - canonical outbound envelope only (`toAgentDid`, `payload`, `conversationId?`)
- Added outbound retry policy + queue guardrails in core runtime:
  - DB migration for retry metadata (`attempt_count`, `next_attempt_at_ms`, `last_attempt_at_ms`, `last_error`)
  - due-item retry scheduling with exponential backoff
  - queue max pending protection and explicit `507` on `/v1/outbound`
  - TTL / retry exhaustion dead-lettering behavior
  - richer `/v1/status` outbound queue visibility (`pendingCount`, `retryingCount`, `deadLetterCount`, `oldestAgeMs`, `nextRetryAtMs`)
- Improved connector delivery visibility:
  - `enqueue_ack.accepted=false` now treated as failure path (not log-only)
  - failure path emits receipt-style notification behavior
  - retry-safe local buffering for forwarding receipts to OpenClaw hook
- Updated AGENTS guidance in touched folders.

## Scope notes
- This PR intentionally removes legacy outbound request assumptions for this flow and uses canonical runtime contract only.
- Correlation/circuit-breaker work remains under #148.
- Queue pressure policy overlap with #119 is documented in #146 rebaseline text.

## Validation
- `pnpm -F @clawdentity/openclaw-skill test`
- `pnpm -F @clawdentity/openclaw-skill build`
- `pnpm -F @clawdentity/openclaw-skill run sync:rust-assets`
- `cargo check` (workspace)
- `cargo test -p clawdentity-core runtime::server::tests`
- `cargo test -p clawdentity-core runtime::relay::tests`
- `cargo test -p clawdentity-core db::outbound::tests`
- `cargo test -p clawdentity-cli commands::connector`
- Pre-push hook: `nx affected -t lint,format,typecheck,test --base=origin/main --head=HEAD` passed.

Closes #146
