### PR TITLE
fix(registry): enforce strict D1 mutation row counts

### DIFF
--- a/apps/registry/src/server.test/AGENTS.md
+++ b/apps/registry/src/server.test/AGENTS.md
@@ -7,3 +7,4 @@
 - Add a regression test for every onboarding state transition change (`active`, `expired`, `redeemed`) so GitHub starter-pass behavior cannot silently drift.
 - Cover both HTTPS and plain-HTTP cookie behavior when route logic depends on cookie flags or callback state validation.
 - Prefer asserting redirect fragment fields (`code`, `displayName`, `providerLogin`, `expiresAt`) in onboarding tests, because that fragment is the public contract consumed by landing.
+- When DB mutation-shape handling changes, include at least one route-level regression test that proves the API returns a controlled `500` envelope instead of leaking raw failures.

--- a/apps/registry/src/server.test/health-metadata-admin.test.ts
+++ b/apps/registry/src/server.test/health-metadata-admin.test.ts
@@ -350,6 +350,44 @@ describe(`POST ${ADMIN_BOOTSTRAP_PATH}`, () => {
     expect(body.error.code).toBe("ADMIN_BOOTSTRAP_ALREADY_COMPLETED");
   });
 
+  it("returns controlled 500 when mutation result shape is invalid", async () => {
+    const { database } = createFakeDb([], [], {
+      invalidMutationResultQueryIncludes: ['insert into "humans"'],
+    });
+    const response = await createRegistryApp().request(
+      ADMIN_BOOTSTRAP_PATH,
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-bootstrap-secret": "bootstrap-secret",
+        },
+        body: JSON.stringify({
+          displayName: "Primary Admin",
+          apiKeyName: "prod-admin-key",
+        }),
+      },
+      {
+        DB: database,
+        ENVIRONMENT: "local",
+        BOOTSTRAP_INTERNAL_SERVICE_ID: "proxy-pairing",
+        BOOTSTRAP_INTERNAL_SERVICE_SECRET:
+          TEST_BOOTSTRAP_INTERNAL_SERVICE_SECRET,
+        BOOTSTRAP_SECRET: "bootstrap-secret",
+      },
+    );
+
+    expect(response.status).toBe(500);
+    const body = (await response.json()) as {
+      error: {
+        code: string;
+        details?: unknown;
+      };
+    };
+    expect(body.error.code).toBe("DB_MUTATION_RESULT_INVALID");
+    expect(body.error.details).toBeUndefined();
+  });
+
   it("creates admin human and PAT token once", async () => {
     const { database, humanInserts, apiKeyInserts, internalServiceInserts } =
       createFakeDb([]);

--- a/apps/registry/src/server.test/helpers/db/AGENTS.md
+++ b/apps/registry/src/server.test/helpers/db/AGENTS.md
@@ -12,3 +12,4 @@
 - Keep rollback-sensitive tables (`api_keys`, `internal_services`) modeled in run handlers so fallback compensation tests can assert row cleanup deterministically.
 - Avoid embedding clock/random side effects in resolver functions.
 - Keep `all()` and `raw()` result shapes in sync for joined auth queries and new tables, otherwise Drizzle-backed tests can silently miss fields that production routes depend on.
+- Keep targeted fault-injection knobs (for example invalid mutation result shapes) explicit and query-scoped so route-level failure tests stay deterministic.

--- a/apps/registry/src/server.test/helpers/db/run-handlers.ts
+++ b/apps/registry/src/server.test/helpers/db/run-handlers.ts
@@ -17,6 +17,16 @@ export function handleRunQuery(input: {
     throw new Error("Failed query: begin");
   }
 
+  const invalidMutationQueryIncludes =
+    state.options.invalidMutationResultQueryIncludes ?? [];
+  if (
+    invalidMutationQueryIncludes.some((needle) =>
+      normalizedQuery.includes(needle.toLowerCase()),
+    )
+  ) {
+    return { success: true } as D1Result;
+  }
+
   let changes = 0;
 
   changes = applyRunHandlersPhaseOne({

--- a/apps/registry/src/server.test/helpers/db/types.ts
+++ b/apps/registry/src/server.test/helpers/db/types.ts
@@ -177,6 +177,7 @@ export type FakeDbOptions = {
   failApiKeyInsertCount?: number;
   failInternalServiceInsertCount?: number;
   failBeginTransaction?: boolean;
+  invalidMutationResultQueryIncludes?: string[];
   internalServiceRows?: FakeInternalServiceRow[];
   inviteRows?: FakeInviteRow[];
   starterPassRows?: FakeStarterPassRow[];

--- a/apps/registry/src/server/helpers/AGENTS.md
+++ b/apps/registry/src/server/helpers/AGENTS.md
@@ -12,3 +12,4 @@
 - Registry-facing loopback URLs may adopt the forwarded origin's port semantics, but sibling service URLs such as the proxy must keep their own configured service port when only the hostname/protocol are being remapped.
 - Treat bracketed IPv6 loopback hosts (`[::1]`) the same as bare `::1` so local IPv6 setups follow the same caller-facing origin remap path.
 - When proxy and registry share loopback/origin helpers, keep the implementation in `@clawdentity/common` instead of maintaining app-local copies.
+- Mutation row-count helpers must use strict D1 semantics (`result.meta.changes`) and fail closed with an explicit internal error when the shape is unsupported; do not reintroduce legacy `.changes`/`.rowsAffected` fallbacks.

--- a/apps/registry/src/server/helpers/AGENTS.md
+++ b/apps/registry/src/server/helpers/AGENTS.md
@@ -13,3 +13,5 @@
 - Treat bracketed IPv6 loopback hosts (`[::1]`) the same as bare `::1` so local IPv6 setups follow the same caller-facing origin remap path.
 - When proxy and registry share loopback/origin helpers, keep the implementation in `@clawdentity/common` instead of maintaining app-local copies.
 - Mutation row-count helpers must use strict D1 semantics (`result.meta.changes`) and fail closed with an explicit internal error when the shape is unsupported; do not reintroduce legacy `.changes`/`.rowsAffected` fallbacks.
+- Mutation operation names must come from shared constants (`db-mutation-operations.ts`) so route/helper operation IDs cannot drift by typo.
+- When mutation shape validation fails, emit a structured log payload (including operation + shape metadata) so production diagnosis is fast.

--- a/apps/registry/src/server/helpers/db-mutation-operations.ts
+++ b/apps/registry/src/server/helpers/db-mutation-operations.ts
@@ -1,0 +1,12 @@
+export const DB_MUTATION_OPERATION = {
+  AGENT_REGISTRATION_CHALLENGE_UPDATE: "agents.register.challenge.update",
+  AGENT_REISSUE_UPDATE: "agents.reissue.update",
+  INVITE_REDEEM_UPDATE: "invites.redeem.update",
+  AGENT_AUTH_REFRESH_SESSION_UPDATE: "agentAuth.refresh.session.update",
+  AGENT_AUTH_VALIDATE_SESSION_TOUCH: "agentAuth.validate.session.touch",
+  ADMIN_BOOTSTRAP_HUMAN_INSERT: "admin.bootstrap.human.insert",
+  ONBOARDING_STARTER_PASS_REDEEM_UPDATE: "onboarding.starterPass.redeem.update",
+} as const;
+
+export type DbMutationOperation =
+  (typeof DB_MUTATION_OPERATION)[keyof typeof DB_MUTATION_OPERATION];

--- a/apps/registry/src/server/helpers/db-queries.test.ts
+++ b/apps/registry/src/server/helpers/db-queries.test.ts
@@ -1,0 +1,70 @@
+import { AppError } from "@clawdentity/sdk";
+import { describe, expect, it } from "vitest";
+import { getMutationRowCount } from "./db-queries.js";
+
+describe("getMutationRowCount", () => {
+  it("returns the row count from the d1 meta.changes field", () => {
+    expect(
+      getMutationRowCount({
+        result: {
+          meta: {
+            changes: 1,
+          },
+        },
+        operation: "test.mutation",
+      }),
+    ).toBe(1);
+  });
+
+  it("returns zero when the d1 mutation updates zero rows", () => {
+    expect(
+      getMutationRowCount({
+        result: {
+          meta: {
+            changes: 0,
+          },
+        },
+        operation: "test.noop",
+      }),
+    ).toBe(0);
+  });
+
+  it.each([
+    {
+      label: "legacy changes shape",
+      result: {
+        changes: 1,
+      },
+    },
+    {
+      label: "legacy rowsAffected shape",
+      result: {
+        rowsAffected: 1,
+      },
+    },
+    {
+      label: "unknown object shape",
+      result: {},
+    },
+    {
+      label: "null result",
+      result: null,
+    },
+    {
+      label: "non-object result",
+      result: 42,
+    },
+  ])("throws for unsupported mutation result shape: $label", ({ result }) => {
+    try {
+      getMutationRowCount({
+        result,
+        operation: "test.invalid",
+      });
+      throw new Error("Expected getMutationRowCount to throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(AppError);
+      expect((error as AppError).code).toBe("DB_MUTATION_RESULT_INVALID");
+      expect((error as AppError).status).toBe(500);
+    }
+  });
+});

--- a/apps/registry/src/server/helpers/db-queries.test.ts
+++ b/apps/registry/src/server/helpers/db-queries.test.ts
@@ -48,6 +48,20 @@ describe("getMutationRowCount", () => {
       result: {},
     },
     {
+      label: "meta present, changes absent",
+      result: {
+        meta: {},
+      },
+    },
+    {
+      label: "meta.changes is a string",
+      result: {
+        meta: {
+          changes: "1",
+        },
+      },
+    },
+    {
       label: "null result",
       result: null,
     },

--- a/apps/registry/src/server/helpers/db-queries.test.ts
+++ b/apps/registry/src/server/helpers/db-queries.test.ts
@@ -1,5 +1,6 @@
 import { AppError } from "@clawdentity/sdk";
 import { describe, expect, it } from "vitest";
+import { DB_MUTATION_OPERATION } from "./db-mutation-operations.js";
 import { getMutationRowCount } from "./db-queries.js";
 
 describe("getMutationRowCount", () => {
@@ -11,7 +12,7 @@ describe("getMutationRowCount", () => {
             changes: 1,
           },
         },
-        operation: "test.mutation",
+        operation: DB_MUTATION_OPERATION.ADMIN_BOOTSTRAP_HUMAN_INSERT,
       }),
     ).toBe(1);
   });
@@ -24,7 +25,7 @@ describe("getMutationRowCount", () => {
             changes: 0,
           },
         },
-        operation: "test.noop",
+        operation: DB_MUTATION_OPERATION.INVITE_REDEEM_UPDATE,
       }),
     ).toBe(0);
   });
@@ -58,7 +59,7 @@ describe("getMutationRowCount", () => {
     try {
       getMutationRowCount({
         result,
-        operation: "test.invalid",
+        operation: DB_MUTATION_OPERATION.AGENT_REISSUE_UPDATE,
       });
       throw new Error("Expected getMutationRowCount to throw");
     } catch (error) {

--- a/apps/registry/src/server/helpers/db-queries.ts
+++ b/apps/registry/src/server/helpers/db-queries.ts
@@ -1,3 +1,4 @@
+import { AppError } from "@clawdentity/sdk";
 import { and, eq } from "drizzle-orm";
 import type { createDb } from "../../db/client.js";
 import {
@@ -330,19 +331,35 @@ export function isUnsupportedLocalTransactionError(error: unknown): boolean {
   );
 }
 
-export function getMutationRowCount(result: unknown): number | undefined {
+function invalidMutationResultShapeError(input: {
+  operation: string;
+  result: unknown;
+}): AppError {
+  const keys =
+    input.result && typeof input.result === "object"
+      ? Object.keys(input.result as Record<string, unknown>)
+      : [];
+
+  return new AppError({
+    code: "DB_MUTATION_RESULT_INVALID",
+    message: `Database mutation result must include meta.changes (${input.operation})`,
+    status: 500,
+    expose: false,
+    details: {
+      operation: input.operation,
+      resultType: input.result === null ? "null" : typeof input.result,
+      keys,
+    },
+  });
+}
+
+export function getMutationRowCount(input: {
+  result: unknown;
+  operation: string;
+}): number {
+  const { result, operation } = input;
   if (!result || typeof result !== "object") {
-    return undefined;
-  }
-
-  const directChanges = (result as { changes?: unknown }).changes;
-  if (typeof directChanges === "number") {
-    return directChanges;
-  }
-
-  const rowsAffected = (result as { rowsAffected?: unknown }).rowsAffected;
-  if (typeof rowsAffected === "number") {
-    return rowsAffected;
+    throw invalidMutationResultShapeError({ operation, result });
   }
 
   const metaChanges = (result as { meta?: { changes?: unknown } }).meta
@@ -351,5 +368,5 @@ export function getMutationRowCount(result: unknown): number | undefined {
     return metaChanges;
   }
 
-  return undefined;
+  throw invalidMutationResultShapeError({ operation, result });
 }

--- a/apps/registry/src/server/helpers/db-queries.ts
+++ b/apps/registry/src/server/helpers/db-queries.ts
@@ -25,6 +25,8 @@ import type {
   OwnedAgentRegistrationChallenge,
   StarterPassRow,
 } from "../constants.js";
+import { logger } from "../constants.js";
+import type { DbMutationOperation } from "./db-mutation-operations.js";
 
 export async function findOwnedAgent(input: {
   db: ReturnType<typeof createDb>;
@@ -332,13 +334,28 @@ export function isUnsupportedLocalTransactionError(error: unknown): boolean {
 }
 
 function invalidMutationResultShapeError(input: {
-  operation: string;
+  operation: DbMutationOperation;
   result: unknown;
 }): AppError {
   const keys =
     input.result && typeof input.result === "object"
       ? Object.keys(input.result as Record<string, unknown>)
       : [];
+  const resultType = input.result === null ? "null" : typeof input.result;
+  const hasMetaObject =
+    Boolean(input.result) &&
+    typeof input.result === "object" &&
+    (input.result as { meta?: unknown }).meta !== undefined;
+
+  logger.error("registry.db_mutation_result_invalid", {
+    code: "DB_MUTATION_RESULT_INVALID",
+    metric: "registry.db_mutation_result_invalid.count",
+    value: 1,
+    operation: input.operation,
+    resultType,
+    hasMetaObject,
+    keys,
+  });
 
   return new AppError({
     code: "DB_MUTATION_RESULT_INVALID",
@@ -347,7 +364,7 @@ function invalidMutationResultShapeError(input: {
     expose: false,
     details: {
       operation: input.operation,
-      resultType: input.result === null ? "null" : typeof input.result,
+      resultType,
       keys,
     },
   });
@@ -355,7 +372,7 @@ function invalidMutationResultShapeError(input: {
 
 export function getMutationRowCount(input: {
   result: unknown;
-  operation: string;
+  operation: DbMutationOperation;
 }): number {
   const { result, operation } = input;
   if (!result || typeof result !== "object") {

--- a/apps/registry/src/server/routes/AGENTS.md
+++ b/apps/registry/src/server/routes/AGENTS.md
@@ -17,3 +17,4 @@
 - Enforce starter-pass agent quotas inside the guarded registration mutation itself so parallel `/v1/agents` requests cannot bypass the cap between challenge verification and insert.
 - Reissued AITs must stay aligned with the stored agent/human DID authority; do not switch issuer authority just because the current request arrived through a different hostname alias.
 - Agent auth revoke events that proxy consumes must use shared protocol constants/helpers for event name/reason/metadata shape (`agent.auth.revoked`, `agent_revoked`, `metadata.agentDid`) rather than ad-hoc inline literals.
+- Any mutation guarded by row-count checks must call `getMutationRowCount` with an explicit operation identifier and rely on strict D1 `meta.changes` handling; do not add route-local fallback parsing for legacy mutation shapes.

--- a/apps/registry/src/server/routes/AGENTS.md
+++ b/apps/registry/src/server/routes/AGENTS.md
@@ -18,3 +18,4 @@
 - Reissued AITs must stay aligned with the stored agent/human DID authority; do not switch issuer authority just because the current request arrived through a different hostname alias.
 - Agent auth revoke events that proxy consumes must use shared protocol constants/helpers for event name/reason/metadata shape (`agent.auth.revoked`, `agent_revoked`, `metadata.agentDid`) rather than ad-hoc inline literals.
 - Any mutation guarded by row-count checks must call `getMutationRowCount` with an explicit operation identifier and rely on strict D1 `meta.changes` handling; do not add route-local fallback parsing for legacy mutation shapes.
+- Route modules must reference shared mutation-operation constants rather than inline operation strings when calling mutation row-count helpers.

--- a/apps/registry/src/server/routes/admin.ts
+++ b/apps/registry/src/server/routes/admin.ts
@@ -23,6 +23,7 @@ import {
   logger,
   type RegistryRouteDependencies,
 } from "../constants.js";
+import { DB_MUTATION_OPERATION } from "../helpers/db-mutation-operations.js";
 import {
   getMutationRowCount,
   isUnsupportedLocalTransactionError,
@@ -206,7 +207,7 @@ export function registerAdminRoutes(input: RegistryRouteDependencies): void {
 
       const insertedRows = getMutationRowCount({
         result: insertAdminResult,
-        operation: "admin.bootstrap.human.insert",
+        operation: DB_MUTATION_OPERATION.ADMIN_BOOTSTRAP_HUMAN_INSERT,
       });
       if (insertedRows === 0) {
         throw adminBootstrapAlreadyCompletedError();

--- a/apps/registry/src/server/routes/admin.ts
+++ b/apps/registry/src/server/routes/admin.ts
@@ -204,7 +204,10 @@ export function registerAdminRoutes(input: RegistryRouteDependencies): void {
           target: humans.id,
         });
 
-      const insertedRows = getMutationRowCount(insertAdminResult);
+      const insertedRows = getMutationRowCount({
+        result: insertAdminResult,
+        operation: "admin.bootstrap.human.insert",
+      });
       if (insertedRows === 0) {
         throw adminBootstrapAlreadyCompletedError();
       }

--- a/apps/registry/src/server/routes/agent-auth.ts
+++ b/apps/registry/src/server/routes/agent-auth.ts
@@ -32,6 +32,7 @@ import { constantTimeEqual } from "../../auth/api-key-token.js";
 import { createDb } from "../../db/client.js";
 import { agent_auth_sessions } from "../../db/schema.js";
 import type { RegistryRouteDependencies } from "../constants.js";
+import { DB_MUTATION_OPERATION } from "../helpers/db-mutation-operations.js";
 import {
   findAgentAuthSessionByAgentId,
   findOwnedAgent,
@@ -211,7 +212,7 @@ export function registerAgentAuthRoutes(
 
       const updatedRows = getMutationRowCount({
         result: updateResult,
-        operation: "agentAuth.refresh.session.update",
+        operation: DB_MUTATION_OPERATION.AGENT_AUTH_REFRESH_SESSION_UPDATE,
       });
       if (updatedRows === 0) {
         throw agentAuthRefreshConflictError();
@@ -340,7 +341,7 @@ export function registerAgentAuthRoutes(
 
     const updatedRows = getMutationRowCount({
       result: updateResult,
-      operation: "agentAuth.validate.session.touch",
+      operation: DB_MUTATION_OPERATION.AGENT_AUTH_VALIDATE_SESSION_TOUCH,
     });
     if (updatedRows === 0) {
       throw new AppError({

--- a/apps/registry/src/server/routes/agent-auth.ts
+++ b/apps/registry/src/server/routes/agent-auth.ts
@@ -209,7 +209,10 @@ export function registerAgentAuthRoutes(
           ),
         );
 
-      const updatedRows = getMutationRowCount(updateResult);
+      const updatedRows = getMutationRowCount({
+        result: updateResult,
+        operation: "agentAuth.refresh.session.update",
+      });
       if (updatedRows === 0) {
         throw agentAuthRefreshConflictError();
       }
@@ -335,7 +338,10 @@ export function registerAgentAuthRoutes(
         ),
       );
 
-    const updatedRows = getMutationRowCount(updateResult);
+    const updatedRows = getMutationRowCount({
+      result: updateResult,
+      operation: "agentAuth.validate.session.touch",
+    });
     if (updatedRows === 0) {
       throw new AppError({
         code: "AGENT_AUTH_VALIDATE_UNAUTHORIZED",

--- a/apps/registry/src/server/routes/agents.ts
+++ b/apps/registry/src/server/routes/agents.ts
@@ -261,7 +261,10 @@ export function registerAgentRoutes(input: RegistryRouteDependencies): void {
             ),
           );
 
-        const updatedRows = getMutationRowCount(challengeUpdateResult);
+        const updatedRows = getMutationRowCount({
+          result: challengeUpdateResult,
+          operation: "agents.register.challenge.update",
+        });
         if (updatedRows === 0) {
           throw new AppError({
             code: "AGENT_REGISTRATION_CHALLENGE_REPLAYED",
@@ -588,7 +591,10 @@ export function registerAgentRoutes(input: RegistryRouteDependencies): void {
           ),
         );
 
-      const updatedRows = getMutationRowCount(updateResult);
+      const updatedRows = getMutationRowCount({
+        result: updateResult,
+        operation: "agents.reissue.update",
+      });
       if (updatedRows === 0) {
         throw invalidAgentReissueStateError({
           environment: config.ENVIRONMENT,

--- a/apps/registry/src/server/routes/agents.ts
+++ b/apps/registry/src/server/routes/agents.ts
@@ -42,6 +42,7 @@ import {
 } from "../../db/schema.js";
 import { resolveRegistrySigner } from "../../registry-signer.js";
 import { logger, type RegistryRouteDependencies } from "../constants.js";
+import { DB_MUTATION_OPERATION } from "../helpers/db-mutation-operations.js";
 import {
   countAgentsByOwner,
   findAgentAuthSessionByAgentId,
@@ -263,7 +264,7 @@ export function registerAgentRoutes(input: RegistryRouteDependencies): void {
 
         const updatedRows = getMutationRowCount({
           result: challengeUpdateResult,
-          operation: "agents.register.challenge.update",
+          operation: DB_MUTATION_OPERATION.AGENT_REGISTRATION_CHALLENGE_UPDATE,
         });
         if (updatedRows === 0) {
           throw new AppError({
@@ -593,7 +594,7 @@ export function registerAgentRoutes(input: RegistryRouteDependencies): void {
 
       const updatedRows = getMutationRowCount({
         result: updateResult,
-        operation: "agents.reissue.update",
+        operation: DB_MUTATION_OPERATION.AGENT_REISSUE_UPDATE,
       });
       if (updatedRows === 0) {
         throw invalidAgentReissueStateError({

--- a/apps/registry/src/server/routes/invites.ts
+++ b/apps/registry/src/server/routes/invites.ts
@@ -187,7 +187,10 @@ export function registerInviteRoutes(input: RegistryRouteDependencies): void {
           })
           .where(and(eq(invites.id, invite.id), isNull(invites.redeemed_by)));
 
-        const updatedRows = getMutationRowCount(inviteUpdateResult);
+        const updatedRows = getMutationRowCount({
+          result: inviteUpdateResult,
+          operation: "invites.redeem.update",
+        });
         if (updatedRows === 0) {
           throw await resolveInviteRedeemStateError({
             db: executor,

--- a/apps/registry/src/server/routes/invites.ts
+++ b/apps/registry/src/server/routes/invites.ts
@@ -30,6 +30,7 @@ import {
   parseInviteRedeemPayload,
 } from "../../invite-lifecycle.js";
 import { logger, type RegistryRouteDependencies } from "../constants.js";
+import { DB_MUTATION_OPERATION } from "../helpers/db-mutation-operations.js";
 import {
   findInviteByCode,
   getMutationRowCount,
@@ -189,7 +190,7 @@ export function registerInviteRoutes(input: RegistryRouteDependencies): void {
 
         const updatedRows = getMutationRowCount({
           result: inviteUpdateResult,
-          operation: "invites.redeem.update",
+          operation: DB_MUTATION_OPERATION.INVITE_REDEEM_UPDATE,
         });
         if (updatedRows === 0) {
           throw await resolveInviteRedeemStateError({

--- a/apps/registry/src/server/routes/onboarding.ts
+++ b/apps/registry/src/server/routes/onboarding.ts
@@ -43,6 +43,7 @@ import {
   starterPassExpiredError,
 } from "../../starter-pass-lifecycle.js";
 import type { RegistryRouteDependencies } from "../constants.js";
+import { DB_MUTATION_OPERATION } from "../helpers/db-mutation-operations.js";
 import {
   findStarterPassByCode,
   findStarterPassByProviderSubject,
@@ -377,7 +378,8 @@ export function registerOnboardingRoutes(
 
         const updatedRows = getMutationRowCount({
           result: starterPassUpdateResult,
-          operation: "onboarding.starterPass.redeem.update",
+          operation:
+            DB_MUTATION_OPERATION.ONBOARDING_STARTER_PASS_REDEEM_UPDATE,
         });
         if (updatedRows === 0) {
           throw await resolveStarterPassRedeemStateError({

--- a/apps/registry/src/server/routes/onboarding.ts
+++ b/apps/registry/src/server/routes/onboarding.ts
@@ -375,7 +375,10 @@ export function registerOnboardingRoutes(
             ),
           );
 
-        const updatedRows = getMutationRowCount(starterPassUpdateResult);
+        const updatedRows = getMutationRowCount({
+          result: starterPassUpdateResult,
+          operation: "onboarding.starterPass.redeem.update",
+        });
         if (updatedRows === 0) {
           throw await resolveStarterPassRedeemStateError({
             db: executor,


### PR DESCRIPTION
## Summary
- make getMutationRowCount strict D1-only (result.meta.changes)
- remove legacy .changes and .rowsAffected fallbacks
- fail closed with DB_MUTATION_RESULT_INVALID for unsupported result shapes
- pass explicit operation identifiers from all route call sites
- add focused helper tests for valid and invalid mutation shapes
- update helper + routes AGENTS guidance to prevent legacy fallback regressions

## Validation
- pnpm --filter @clawdentity/registry test
- pnpm --filter @clawdentity/registry typecheck
- push hook suite (nx affected -t lint,format,typecheck,test) passed during git push

Closes #115
