### PR TITLE
docs: add relay messaging and group docs

### DIFF
--- a/apps/landing/AGENTS.md
+++ b/apps/landing/AGENTS.md
@@ -97,3 +97,11 @@
 - Keep CLI docs aligned with the current Rust binary command surface (`init`, `whoami`, `register`, `agent`, `config`, `api-key`, `invite`, `admin`, `connector`, `provider`, `install`).
 - Do not document unsupported CLI subcommands; if a flow is API-only (for example pairing), document it under proxy API routes instead of inventing CLI syntax.
 - DID examples in landing docs must use `did:cdi:<authority>:<entity>:<ulid>`; never use `did:claw:*` format.
+- Guide-level relay docs must use the current connector request contract:
+  - direct routing uses `toAgentDid`
+  - group routing uses `groupId`
+  - never document legacy connector request fields such as `peerDid` or `peerProxyUrl`
+- When guide docs mention OpenClaw delivery payloads, keep `/hooks/wake` and `/hooks/agent` contracts separate:
+  - `/hooks/wake` is text-first
+  - `/hooks/agent` is structured JSON with sender and optional group metadata
+- Do not place `AGENTS.md` inside `src/content/**`; Astro content collections may try to ingest it as published documentation.

--- a/apps/landing/AGENTS.md
+++ b/apps/landing/AGENTS.md
@@ -97,10 +97,10 @@
 - Keep CLI docs aligned with the current Rust binary command surface (`init`, `whoami`, `register`, `agent`, `config`, `api-key`, `invite`, `admin`, `connector`, `provider`, `install`).
 - Do not document unsupported CLI subcommands; if a flow is API-only (for example pairing), document it under proxy API routes instead of inventing CLI syntax.
 - DID examples in landing docs must use `did:cdi:<authority>:<entity>:<ulid>`; never use `did:claw:*` format.
-- Guide-level relay docs must use the current connector request contract:
-  - direct routing uses `toAgentDid`
-  - group routing uses `groupId`
-  - never document legacy connector request fields such as `peerDid` or `peerProxyUrl`
+- Guide-level relay docs must clearly scope runtime contracts:
+  - Rust connector runtime (`clawdentity connector start`) uses direct `toAgentDid` or group `groupId` routing
+  - TypeScript package runtime (`packages/connector/src/runtime/*`) currently uses legacy outbound fields (`peer`, `peerDid`, `peerProxyUrl`)
+  - when both are documented, label each contract explicitly and avoid mixing examples
 - When guide docs mention OpenClaw delivery payloads, keep `/hooks/wake` and `/hooks/agent` contracts separate:
   - `/hooks/wake` is text-first
   - `/hooks/agent` is structured JSON with sender and optional group metadata

--- a/apps/landing/public/skill.md
+++ b/apps/landing/public/skill.md
@@ -273,31 +273,244 @@ Optional:
 
 ## Sending Messages
 
-Canonical routing contract for OpenClaw relay payloads:
-- direct message: use `payload.peer`
-- group message: use `payload.groupId`
-- do not send both `payload.peer` and `payload.groupId` in the same outbound payload
+The OpenClaw `send-to-peer` hook reads `ctx.payload`.
+
+Routing rules:
+- Use `peer` for a direct message to one paired peer alias from the projected peers snapshot configured by `hooks/transforms/clawdentity-relay.json` (`peersConfigPath`; default `hooks/transforms/clawdentity-peers.json`).
+- Use `groupId` for a group send. `group` is still accepted as a compatibility alias, but `groupId` is the canonical field to document and send.
+- Send exactly one routing target. Do not send both `peer` and `groupId`/`group` in the same payload.
+- If no routing field is present, the transform returns the payload unchanged and OpenClaw handles it locally.
+
+Direct-message example:
+
+```json
+{
+  "peer": "alice",
+  "message": "Hi Alice",
+  "conversationId": "optional-direct-thread",
+  "topic": "handoff"
+}
+```
+
+What the transform does for a direct message:
+- resolves `peer` to a peer DID from the projected peers snapshot (`peersConfigPath`; default `hooks/transforms/clawdentity-peers.json`)
+- removes routing-only fields before forwarding
+- posts this envelope to the local connector:
+
+```json
+{
+  "toAgentDid": "did:cdi:<authority>:agent:01H...",
+  "conversationId": "optional-direct-thread",
+  "payload": {
+    "message": "Hi Alice",
+    "conversationId": "optional-direct-thread",
+    "topic": "handoff"
+  }
+}
+```
+
+Group-message example:
+
+```json
+{
+  "groupId": "grp_01HF7YAT31JZHSMW1CG6Q6MHB7",
+  "message": "Standup in 10 minutes",
+  "conversationId": "optional-group-thread"
+}
+```
+
+What the transform does for a group message:
+- validates `groupId` as `grp_<ULID>`
+- removes `groupId`/`group` from the forwarded application payload
+- posts this envelope to the local connector:
+
+```json
+{
+  "groupId": "grp_01HF7YAT31JZHSMW1CG6Q6MHB7",
+  "conversationId": "optional-group-thread",
+  "payload": {
+    "message": "Standup in 10 minutes",
+    "conversationId": "optional-group-thread"
+  }
+}
+```
+
+Notes:
+- The transform returns `null` after a successful relay so OpenClaw does not process the same payload twice.
+- `conversationId` is optional. If you include it in the top-level payload, the transform also forwards it as the connector envelope field.
 
 ## Receiving Messages
 
-Inbound payload identity is always DID-first, name-first for display:
-- canonical IDs: `senderDid`, `recipientDid`, and `groupId` (group traffic)
-- expected runtime metadata: `senderAgentName`, `senderDisplayName`, `groupName`
-- read friendly fields first for display; use DID/group IDs as fallback identity
-- friendly fields are runtime-resolved metadata (trusted local/registry refresh), not sender-authored authority
+Inbound delivery uses one of two OpenClaw hook payload shapes.
+
+### `/hooks/wake` path
+
+This path receives a human-readable text envelope, not a structured Clawdentity JSON object:
+
+```json
+{
+  "message": "Message in research-crew from alpha (Ravi)\n\nhello\n\nRequest ID: 01H...\nConversation ID: pair:...\nReply To: https://proxy.example.com/v1/relay/delivery-receipts",
+  "text": "Message in research-crew from alpha (Ravi)\n\nhello\n\nRequest ID: 01H...\nConversation ID: pair:...\nReply To: https://proxy.example.com/v1/relay/delivery-receipts",
+  "mode": "now"
+}
+```
+
+Wake-path notes:
+- This is the default `send-to-peer` hook mapping because it keeps the outbound trigger payload simple.
+- If the sender included `sessionId`, the wake payload also carries `sessionId`.
+- Group context is readable in the first line and machine-readable in headers, but not broken out into a nested JSON metadata object.
+
+### `/hooks/agent` path
+
+This path receives the structured delivery payload:
+
+```json
+{
+  "message": "hello",
+  "senderDid": "did:cdi:<authority>:agent:01H...",
+  "senderAgentName": "alpha",
+  "senderDisplayName": "Ravi",
+  "recipientDid": "did:cdi:<authority>:agent:01H...",
+  "groupId": "grp_01HF7YAT31JZHSMW1CG6Q6MHB7",
+  "groupName": "research-crew",
+  "isGroupMessage": true,
+  "requestId": "01H...",
+  "metadata": {
+    "conversationId": "pair:...",
+    "replyTo": "https://proxy.example.com/v1/relay/delivery-receipts",
+    "payload": {
+      "message": "hello"
+    }
+  }
+}
+```
+
+Inbound headers from the connector:
+
+| Header | When present | Meaning |
+|---|---|---|
+| `x-clawdentity-agent-did` | Always | Sender agent DID |
+| `x-clawdentity-to-agent-did` | Always | Recipient agent DID |
+| `x-clawdentity-verified` | Always | Connector already treated the relay as verified |
+| `x-request-id` | Always | Delivery request ID |
+| `x-clawdentity-agent-name` | When known | Sender agent name |
+| `x-clawdentity-display-name` | When known | Sender human display name |
+| `x-clawdentity-group-id` | Group messages only | Group ID |
+
+Use `/hooks/agent` when the receiver needs machine-readable metadata like `senderDid`, `groupId`, `metadata.conversationId`, or the original application payload.
 
 ## Groups
 
-- Group routing uses `payload.groupId` (`grp_<ULID>`).
-- Inbound payload keeps both `groupId` and `groupName` when name resolution is available.
-- If group-name lookup is unavailable, delivery still succeeds with `groupId` and missing `groupName`.
+There are no dedicated group CLI commands yet. Use the registry HTTP API as the advanced/manual path.
+
+Create a group:
+
+```bash
+api_key="$(clawdentity config get apiKey)"
+registry_url="${CLAWDENTITY_REGISTRY_URL:-https://registry.clawdentity.com}"
+
+curl -fsSL -X POST "${registry_url}/v1/groups" \
+  -H "authorization: Bearer ${api_key}" \
+  -H "content-type: application/json" \
+  -d '{"name":"research-crew"}'
+```
+
+Important:
+- `POST /v1/groups` creates only the group record.
+- It does not auto-insert any `group_members` row for your local sending agent.
+- If sender or recipient agents are not active group members, first group send can fail with `403 PROXY_AUTH_FORBIDDEN`.
+
+Issue a group join token:
+
+```bash
+api_key="$(clawdentity config get apiKey)"
+registry_url="${CLAWDENTITY_REGISTRY_URL:-https://registry.clawdentity.com}"
+group_id="grp_01HF7YAT31JZHSMW1CG6Q6MHB7"
+
+curl -fsSL -X POST "${registry_url}/v1/groups/${group_id}/join-tokens" \
+  -H "authorization: Bearer ${api_key}" \
+  -H "content-type: application/json" \
+  -d '{"role":"member","expiresInSeconds":3600,"maxUses":1}'
+```
+
+Group join token rules:
+- group join tokens start with `clw_gjt_`
+- default TTL is 1 hour
+- `expiresInSeconds` must stay between 60 seconds and 30 days
+- `maxUses` must stay between 1 and 25
+
+Join a group with an agent-authenticated request:
+
+```json
+{
+  "groupJoinToken": "clw_gjt_..."
+}
+```
+
+Join endpoint:
+- `POST /v1/groups/join`
+- requires normal agent `Claw` auth headers
+- returns `201` when the agent is newly added
+- returns `200` with `joined: false` when the agent was already a member
+
+First group-send prerequisite:
+1. Issue a group join token.
+2. Join the creator's local sending agent with `POST /v1/groups/join`.
+3. Join every recipient agent with `POST /v1/groups/join`.
+
+List group members:
+
+```bash
+api_key="$(clawdentity config get apiKey)"
+registry_url="${CLAWDENTITY_REGISTRY_URL:-https://registry.clawdentity.com}"
+group_id="grp_01HF7YAT31JZHSMW1CG6Q6MHB7"
+
+curl -fsSL "${registry_url}/v1/groups/${group_id}/members" \
+  -H "authorization: Bearer ${api_key}"
+```
+
+Group delivery behavior:
+- The local connector resolves active members for the group from the registry-backed resolver.
+- The local sender DID is excluded, so the sender does not receive its own group frame back.
+- One outbound frame is enqueued per recipient, all sharing the same `groupId`.
+- The proxy uses group membership trust instead of pair trust for group sends, and it verifies both sender and recipient membership before accepting delivery.
+
+Known limitations:
+- No dedicated `clawdentity group ...` CLI commands yet.
+- Group membership is resolved at send time; it is not stored as a separate local group cache for the OpenClaw skill.
+- `/hooks/wake` is text-first. If you need structured `groupId` and metadata fields, use `/hooks/agent`.
 
 ## Conversation Threading
 
-- Relay thread lane is `conversationId`.
-- For direct relay, default `conversationId` is deterministic from local-agent DID + peer DID.
-- Caller can override lane by setting `payload.conversationId` explicitly.
-- Group traffic keeps normal `conversationId` behavior; display labels should prioritize `groupName` and sender friendly names when present.
+Default threading rules:
+- Direct messages auto-derive a stable conversation lane from the local agent DID and the peer DID.
+- Group messages do not auto-derive a conversation ID.
+- Any explicit top-level `conversationId` overrides the default direct-message lane.
+
+Direct-message default:
+
+```text
+pair:<sha256(sorted([localAgentDid, peerDid]).join("\n"))>
+```
+
+Practical meaning:
+- alias renames do not change the default DM thread
+- the same two agents stay on one deterministic DM lane by default
+- if you want a different lane, pass `conversationId` yourself
+
+Group-message rule:
+- pass `conversationId` explicitly when you want stable group threading
+- if you omit it, the group message still relays, but there is no auto-generated group thread ID
+
+Example override:
+
+```json
+{
+  "peer": "alice",
+  "message": "Follow-up",
+  "conversationId": "ticket-482"
+}
+```
 
 ## Journey (Strict Order)
 
@@ -538,7 +751,9 @@ and `message` fields before local handling is skipped.
 - If `payload.groupId` exists:
   - validate it as `grp_<ULID>`
   - forward it as top-level `groupId` to the local connector outbound endpoint
+  - do not auto-derive a group `conversationId`
   - remove routing-only fields from the forwarded application payload
+- Do not send `peer` and `group`/`groupId` together in one payload.
 
 Routing exclusivity rule:
 - direct routing uses `payload.peer`
@@ -598,13 +813,11 @@ The transform does not send directly to the peer proxy. It posts to the local co
 - `provider setup --for openclaw --agent-name <agent-name>` is the primary self-setup path after OpenClaw itself is healthy.
 - `connector start <agent-name>` is advanced/manual recovery; it resolves bind URL from `~/.clawdentity/openclaw-connectors.json` when explicit env override is absent.
 
-Outbound JSON body sent by transform:
+Outbound JSON body sent by transform for direct routing:
 
 ```json
 {
-  "peer": "beta",
-  "peerDid": "did:cdi:<authority>:agent:01H...",
-  "peerProxyUrl": "https://beta-proxy.example.com/hooks/agent",
+  "toAgentDid": "did:cdi:<authority>:agent:01H...",
   "conversationId": "<explicit-or-derived-relay-lane>",
   "payload": {
     "event": "agent.message"
@@ -612,8 +825,20 @@ Outbound JSON body sent by transform:
 }
 ```
 
+Outbound JSON body sent by transform for group routing:
+
+```json
+{
+  "groupId": "grp_<ULID>",
+  "conversationId": "<optional-explicit-group-lane>",
+  "payload": {
+    "event": "agent.message"
+  }
+}
+```
+
 Rules:
-- `payload.peer` is removed before creating the `payload` object above.
+- `payload.peer`, `payload.group`, and `payload.groupId` are removed before creating the forwarded `payload` object.
 - direct routing uses `toAgentDid`
 - group routing uses `groupId`
 - do not send both direct and group routing in one outbound request
@@ -621,11 +846,27 @@ Rules:
 - Default relay `conversationId` is deterministic per local-agent/peer-agent pair so one peer relationship stays on one replay lane by default.
 - Default relay `conversationId` must be derived from sorted `localAgentDid` + peer DID so alias renames do not change replay lanes.
 - `payload.conversationId` may override the default relay lane when the caller intentionally wants a different lane.
-- Only `peer` is stripped from the forwarded application payload for compatibility; `conversationId` may still remain inside the application payload if the caller included it there.
+- Group routing never invents a default `conversationId`; callers must pass one explicitly when they want a stable group thread.
+- `conversationId` may still remain inside the application payload if the caller included it there.
 - Transform sends `Content-Type: application/json` only.
 - Connector runtime is responsible for Clawdentity auth headers and request signing when calling peer proxy.
 
 ## OpenClaw Inbound Metadata Contract
+
+For `/hooks/wake`, the connector delivers a rendered text envelope:
+
+```json
+{
+  "message": "Message in research-crew from alpha (Ravi)\n\nhello\n\nRequest ID: 01H...\nConversation ID: pair:...\nReply To: https://proxy.example.com/v1/relay/delivery-receipts",
+  "text": "Message in research-crew from alpha (Ravi)\n\nhello\n\nRequest ID: 01H...\nConversation ID: pair:...\nReply To: https://proxy.example.com/v1/relay/delivery-receipts",
+  "mode": "now"
+}
+```
+
+Rules:
+- `/hooks/wake` is text-first and optimized for immediate OpenClaw wake handling.
+- `sessionId` is copied through when the original payload carried it.
+- Machine-readable sender/group metadata for the wake path is carried by headers, not by a nested JSON metadata object.
 
 After proxy verification and connector shaping, the canonical OpenClaw-facing delivery payload is:
 
@@ -667,6 +908,7 @@ Canonical OpenClaw-facing headers:
 Note:
 - proxy relay routing still uses `x-claw-group-id`
 - the `x-clawdentity-*` headers above are the post-verification inbound metadata contract for local OpenClaw delivery
+- `/hooks/agent` includes structured `groupId`, `groupName`, and `isGroupMessage`; `/hooks/wake` does not.
 
 ## Error Conditions
 

--- a/apps/landing/src/content/docs/guides/agent-to-agent.mdx
+++ b/apps/landing/src/content/docs/guides/agent-to-agent.mdx
@@ -198,9 +198,10 @@ Bob's OpenClaw triggers the relay through the connector. Every request is crypto
 1. Bob's OpenClaw fires a hook: `{ peer: "alice", message: "Hi!" }`
 
 2. The relay transform (`relay-to-peer.mjs`):
-   - Looks up "alice" in `peers.json` to get the DID and proxy URL
-   - Removes the `peer` field from the payload
-   - POSTs `{ payload, peer, peerDid, peerProxyUrl }` to Bob's connector at `http://127.0.0.1:19400/v1/outbound`
+   - Looks up "alice" in `peers.json` to get Alice's DID
+   - Removes the `peer` field from the forwarded payload
+   - Derives a deterministic direct-message `conversationId` unless Bob already supplied one
+   - POSTs `{ toAgentDid, conversationId, payload }` to Bob's connector at `http://127.0.0.1:19400/v1/outbound`
 
 3. Bob's connector signs the HTTP request with PoP headers:
    - `Authorization: Claw <ait>`

--- a/apps/landing/src/content/docs/guides/connector.mdx
+++ b/apps/landing/src/content/docs/guides/connector.mdx
@@ -194,11 +194,15 @@ Returns connector health information:
 When OpenClaw triggers an outbound message:
 
 1. OpenClaw hook transform POSTs to the connector at `http://127.0.0.1:19400/v1/outbound`
-2. Request body: `{ payload, peer, peerDid, peerProxyUrl, conversationId?, replyTo? }`
+2. Request body must include exactly one route:
+   - direct: `{ toAgentDid, payload, conversationId?, replyTo? }`
+   - group: `{ groupId, payload, conversationId?, replyTo? }`
 3. Connector signs the HTTP request with the agent's Ed25519 key (PoP headers)
 4. Connector adds `x-claw-conversation-id` and `x-claw-delivery-receipt-url` headers when present
-5. Connector forwards the signed request to the recipient's proxy URL
-6. On success, returns `202 Accepted` with `{ accepted: true, peer: "<alias>" }`
+5. Connector forwards the signed request to the recipient's proxy URL. For groups, it fans out one recipient at a time after resolving membership.
+6. On success, returns `202 Accepted`:
+   - direct: `{ accepted: true, frameId: "<ulid>" }`
+   - group: `{ accepted: true, groupId: "grp_<ULID>", frameIds: ["<ulid>"], enqueuedRecipients: <count> }`
 
 The outbound relay body is limited to 1 MB. On `401` responses, the connector refreshes the access token atomically (temp file + rename to `registry-auth.json`) and retries once.
 
@@ -221,9 +225,9 @@ All WebSocket messages use JSON frames with version `v: 1`. Every frame includes
 |-------|-----------|--------|---------|
 | `heartbeat` | Both | `v`, `type`, `id`, `ts` | Keepalive ping (default: every 30s) |
 | `heartbeat_ack` | Both | `v`, `type`, `id`, `ts`, `ackId` | Keepalive response |
-| `deliver` | Proxy to Connector | `v`, `type`, `id`, `ts`, `fromAgentDid`, `toAgentDid`, `payload`, `contentType?`, `conversationId?`, `replyTo?` | Inbound message delivery |
+| `deliver` | Proxy to Connector | `v`, `type`, `id`, `ts`, `fromAgentDid`, `toAgentDid`, `payload`, `contentType?`, `groupId?`, `conversationId?`, `replyTo?` | Inbound message delivery |
 | `deliver_ack` | Connector to Proxy | `v`, `type`, `id`, `ts`, `ackId`, `accepted`, `reason?` | Delivery acknowledgment |
-| `enqueue` | Connector to Proxy | `v`, `type`, `id`, `ts`, `toAgentDid`, `payload`, `conversationId?`, `replyTo?` | Outbound message via WebSocket |
+| `enqueue` | Connector to Proxy | `v`, `type`, `id`, `ts`, `toAgentDid`, `groupId?`, `payload`, `conversationId?`, `replyTo?` | Outbound message via WebSocket |
 | `enqueue_ack` | Proxy to Connector | `v`, `type`, `id`, `ts`, `ackId`, `accepted`, `reason?` | Enqueue acknowledgment |
 
 ## Reconnection

--- a/apps/landing/src/content/docs/guides/connector.mdx
+++ b/apps/landing/src/content/docs/guides/connector.mdx
@@ -191,7 +191,13 @@ Returns connector health information:
 
 ## Outbound relay
 
-When OpenClaw triggers an outbound message:
+The contract below is for the Rust connector runtime started by:
+
+```bash
+clawdentity connector start <agent-name>
+```
+
+When OpenClaw triggers an outbound message to that runtime:
 
 1. OpenClaw hook transform POSTs to the connector at `http://127.0.0.1:19400/v1/outbound`
 2. Request body must include exactly one route:
@@ -205,6 +211,11 @@ When OpenClaw triggers an outbound message:
    - group: `{ accepted: true, groupId: "grp_<ULID>", frameIds: ["<ulid>"], enqueuedRecipients: <count> }`
 
 The outbound relay body is limited to 1 MB. On `401` responses, the connector refreshes the access token atomically (temp file + rename to `registry-auth.json`) and retries once.
+
+TypeScript package runtime note:
+- `packages/connector/src/runtime/http.ts` currently requires legacy outbound input fields: `{ peer, peerDid, peerProxyUrl, payload, conversationId?, replyTo? }`.
+- `packages/connector/src/runtime/server.ts` currently returns `{ accepted: true, peer }` on success.
+- Use that legacy contract only when integrating directly with the TypeScript package runtime.
 
 ### Conversation tracking
 

--- a/apps/landing/src/content/docs/guides/openclaw-skill.mdx
+++ b/apps/landing/src/content/docs/guides/openclaw-skill.mdx
@@ -159,37 +159,38 @@ Override with environment variables:
 
 ### Relay payload processing
 
-Canonical send contract:
+When the hook transform receives a payload with a routing field:
 
-- Direct send uses `payload.peer`
-- Group send uses `payload.groupId`
-- Do not send both `payload.peer` and `payload.groupId` in the same payload
+1. If `peer` is present, it looks up the alias in `peers.json` and resolves the peer DID
+2. If `groupId` or `group` is present, it validates the group ID as `grp_<ULID>`
+3. Removes routing-only fields (`peer`, `group`, `groupId`) from the forwarded application payload
+4. Sends one of these envelopes to the local connector:
 
-When the hook transform receives `payload.peer`:
+```json
+{ "toAgentDid": "<peer-did>", "conversationId": "<optional>", "payload": { ... } }
+```
 
-1. Looks up the alias in `peers.json` to resolve `did` and `proxyUrl`
-2. Removes the `peer` field from the payload
-3. Sends `{ payload, peer, peerDid, peerProxyUrl }` to the connector
-4. Returns `null` to signal that OpenClaw should not process the payload further
+```json
+{ "groupId": "grp_<ULID>", "conversationId": "<optional>", "payload": { ... } }
+```
 
-When the hook transform receives `payload.groupId`:
+5. Returns `null` to signal that OpenClaw should not process the payload further
 
-1. Validates `groupId` as `grp_<ULID>`
-2. Forwards the payload to the local connector with top-level `groupId`
-3. Returns `null` so relay delivery is handled by the connector path
+Rules:
 
-If neither direct nor group routing fields are present, the transform passes payload through unchanged.
+- Send exactly one routing target. Do not send both `peer` and `groupId`/`group`.
+- If the payload has no routing field, the transform passes it through unchanged.
+- Direct messages auto-derive a deterministic `conversationId` when the caller does not provide one.
+- Group messages do not auto-derive `conversationId`; pass one explicitly if you need a stable group thread.
 
-### Inbound receive metadata
+### Inbound delivery shapes
 
-Incoming payloads keep canonical ID fields and add friendly metadata when available:
+Inbound delivery uses two different OpenClaw hook shapes:
 
-- Canonical IDs: `senderDid`, `recipientDid`, `groupId`
-- Friendly metadata: `senderAgentName`, `senderDisplayName`, `groupName`
+- `/hooks/agent` is the structured JSON path and includes fields like `senderDid`, `groupId`, `groupName`, `isGroupMessage`, and `metadata.payload`
+- `/hooks/wake` is the text-first path and carries the same Clawdentity headers, but the request body is a rendered text envelope instead of structured metadata
 
-Read friendly metadata first for display. Use IDs as fallback identity.
-Friendly metadata is resolved from trusted local/registry state; sender-supplied names are not authoritative.
-When connector delivery is configured to `/hooks/wake`, the wake headline also prefers friendly sender/group names before ID fallback.
+Use `/hooks/agent` when the receiver needs machine-readable sender, group, or conversation metadata.
 
 ## Registry auth file lock
 

--- a/apps/openclaw-skill/skill/AGENTS.md
+++ b/apps/openclaw-skill/skill/AGENTS.md
@@ -9,6 +9,13 @@
 - Keep `SKILL.md` onboarding prompt-first with a single canonical quick prompt block near the top.
 - Keep immutable fallback mirrors pinned to released artifacts only; never point fallback guidance at mutable branch URLs.
 - `SKILL.md` and `references/*.md` must use command-first remediation with executable Rust CLI commands.
+- Keep `SKILL.md` operator-facing messaging coverage explicit:
+  - `Sending Messages`
+  - `Receiving Messages`
+  - `Groups`
+  - `Conversation Threading`
+- When relay payload or inbound delivery contracts change, update those sections together with `references/clawdentity-protocol.md` in the same change.
+- Verify documented limitations against the current source before publishing them; do not copy stale GitHub issue text into the skill docs unchanged.
 - Treat Rust CLI command surfaces as the source of truth for this skill. Do not add npm or TS-only execution steps.
 - Provider workflows must use `clawdentity install` and `clawdentity provider {status|setup|doctor}`.
 - Prompt-first onboarding should prioritize `clawdentity onboarding run --for <platform>` as the default install/setup/pairing/messaging flow, with manual command groups documented as advanced fallback.

--- a/apps/openclaw-skill/skill/AGENTS.md
+++ b/apps/openclaw-skill/skill/AGENTS.md
@@ -16,6 +16,12 @@
   - `Conversation Threading`
 - When relay payload or inbound delivery contracts change, update those sections together with `references/clawdentity-protocol.md` in the same change.
 - Verify documented limitations against the current source before publishing them; do not copy stale GitHub issue text into the skill docs unchanged.
+- Keep peer-alias path guidance runtime-accurate:
+  - default OpenClaw runtime reads projected `hooks/transforms/clawdentity-peers.json` via `hooks/transforms/clawdentity-relay.json` (`peersConfigPath`)
+  - `~/.clawdentity/peers.json` is legacy/manual fallback only, not the default projected path
+- Group docs must call out first-send membership prerequisites explicitly:
+  - `POST /v1/groups` creates only the group record
+  - sending/receiving agents must join via `POST /v1/groups/join` before first group relay
 - Treat Rust CLI command surfaces as the source of truth for this skill. Do not add npm or TS-only execution steps.
 - Provider workflows must use `clawdentity install` and `clawdentity provider {status|setup|doctor}`.
 - Prompt-first onboarding should prioritize `clawdentity onboarding run --for <platform>` as the default install/setup/pairing/messaging flow, with manual command groups documented as advanced fallback.

--- a/apps/openclaw-skill/skill/SKILL.md
+++ b/apps/openclaw-skill/skill/SKILL.md
@@ -273,31 +273,244 @@ Optional:
 
 ## Sending Messages
 
-Canonical routing contract for OpenClaw relay payloads:
-- direct message: use `payload.peer`
-- group message: use `payload.groupId`
-- do not send both `payload.peer` and `payload.groupId` in the same outbound payload
+The OpenClaw `send-to-peer` hook reads `ctx.payload`.
+
+Routing rules:
+- Use `peer` for a direct message to one paired peer alias from the projected peers snapshot configured by `hooks/transforms/clawdentity-relay.json` (`peersConfigPath`; default `hooks/transforms/clawdentity-peers.json`).
+- Use `groupId` for a group send. `group` is still accepted as a compatibility alias, but `groupId` is the canonical field to document and send.
+- Send exactly one routing target. Do not send both `peer` and `groupId`/`group` in the same payload.
+- If no routing field is present, the transform returns the payload unchanged and OpenClaw handles it locally.
+
+Direct-message example:
+
+```json
+{
+  "peer": "alice",
+  "message": "Hi Alice",
+  "conversationId": "optional-direct-thread",
+  "topic": "handoff"
+}
+```
+
+What the transform does for a direct message:
+- resolves `peer` to a peer DID from the projected peers snapshot (`peersConfigPath`; default `hooks/transforms/clawdentity-peers.json`)
+- removes routing-only fields before forwarding
+- posts this envelope to the local connector:
+
+```json
+{
+  "toAgentDid": "did:cdi:<authority>:agent:01H...",
+  "conversationId": "optional-direct-thread",
+  "payload": {
+    "message": "Hi Alice",
+    "conversationId": "optional-direct-thread",
+    "topic": "handoff"
+  }
+}
+```
+
+Group-message example:
+
+```json
+{
+  "groupId": "grp_01HF7YAT31JZHSMW1CG6Q6MHB7",
+  "message": "Standup in 10 minutes",
+  "conversationId": "optional-group-thread"
+}
+```
+
+What the transform does for a group message:
+- validates `groupId` as `grp_<ULID>`
+- removes `groupId`/`group` from the forwarded application payload
+- posts this envelope to the local connector:
+
+```json
+{
+  "groupId": "grp_01HF7YAT31JZHSMW1CG6Q6MHB7",
+  "conversationId": "optional-group-thread",
+  "payload": {
+    "message": "Standup in 10 minutes",
+    "conversationId": "optional-group-thread"
+  }
+}
+```
+
+Notes:
+- The transform returns `null` after a successful relay so OpenClaw does not process the same payload twice.
+- `conversationId` is optional. If you include it in the top-level payload, the transform also forwards it as the connector envelope field.
 
 ## Receiving Messages
 
-Inbound payload identity is always DID-first, name-first for display:
-- canonical IDs: `senderDid`, `recipientDid`, and `groupId` (group traffic)
-- expected runtime metadata: `senderAgentName`, `senderDisplayName`, `groupName`
-- read friendly fields first for display; use DID/group IDs as fallback identity
-- friendly fields are runtime-resolved metadata (trusted local/registry refresh), not sender-authored authority
+Inbound delivery uses one of two OpenClaw hook payload shapes.
+
+### `/hooks/wake` path
+
+This path receives a human-readable text envelope, not a structured Clawdentity JSON object:
+
+```json
+{
+  "message": "Message in research-crew from alpha (Ravi)\n\nhello\n\nRequest ID: 01H...\nConversation ID: pair:...\nReply To: https://proxy.example.com/v1/relay/delivery-receipts",
+  "text": "Message in research-crew from alpha (Ravi)\n\nhello\n\nRequest ID: 01H...\nConversation ID: pair:...\nReply To: https://proxy.example.com/v1/relay/delivery-receipts",
+  "mode": "now"
+}
+```
+
+Wake-path notes:
+- This is the default `send-to-peer` hook mapping because it keeps the outbound trigger payload simple.
+- If the sender included `sessionId`, the wake payload also carries `sessionId`.
+- Group context is readable in the first line and machine-readable in headers, but not broken out into a nested JSON metadata object.
+
+### `/hooks/agent` path
+
+This path receives the structured delivery payload:
+
+```json
+{
+  "message": "hello",
+  "senderDid": "did:cdi:<authority>:agent:01H...",
+  "senderAgentName": "alpha",
+  "senderDisplayName": "Ravi",
+  "recipientDid": "did:cdi:<authority>:agent:01H...",
+  "groupId": "grp_01HF7YAT31JZHSMW1CG6Q6MHB7",
+  "groupName": "research-crew",
+  "isGroupMessage": true,
+  "requestId": "01H...",
+  "metadata": {
+    "conversationId": "pair:...",
+    "replyTo": "https://proxy.example.com/v1/relay/delivery-receipts",
+    "payload": {
+      "message": "hello"
+    }
+  }
+}
+```
+
+Inbound headers from the connector:
+
+| Header | When present | Meaning |
+|---|---|---|
+| `x-clawdentity-agent-did` | Always | Sender agent DID |
+| `x-clawdentity-to-agent-did` | Always | Recipient agent DID |
+| `x-clawdentity-verified` | Always | Connector already treated the relay as verified |
+| `x-request-id` | Always | Delivery request ID |
+| `x-clawdentity-agent-name` | When known | Sender agent name |
+| `x-clawdentity-display-name` | When known | Sender human display name |
+| `x-clawdentity-group-id` | Group messages only | Group ID |
+
+Use `/hooks/agent` when the receiver needs machine-readable metadata like `senderDid`, `groupId`, `metadata.conversationId`, or the original application payload.
 
 ## Groups
 
-- Group routing uses `payload.groupId` (`grp_<ULID>`).
-- Inbound payload keeps both `groupId` and `groupName` when name resolution is available.
-- If group-name lookup is unavailable, delivery still succeeds with `groupId` and missing `groupName`.
+There are no dedicated group CLI commands yet. Use the registry HTTP API as the advanced/manual path.
+
+Create a group:
+
+```bash
+api_key="$(clawdentity config get apiKey)"
+registry_url="${CLAWDENTITY_REGISTRY_URL:-https://registry.clawdentity.com}"
+
+curl -fsSL -X POST "${registry_url}/v1/groups" \
+  -H "authorization: Bearer ${api_key}" \
+  -H "content-type: application/json" \
+  -d '{"name":"research-crew"}'
+```
+
+Important:
+- `POST /v1/groups` creates only the group record.
+- It does not auto-insert any `group_members` row for your local sending agent.
+- If sender or recipient agents are not active group members, first group send can fail with `403 PROXY_AUTH_FORBIDDEN`.
+
+Issue a group join token:
+
+```bash
+api_key="$(clawdentity config get apiKey)"
+registry_url="${CLAWDENTITY_REGISTRY_URL:-https://registry.clawdentity.com}"
+group_id="grp_01HF7YAT31JZHSMW1CG6Q6MHB7"
+
+curl -fsSL -X POST "${registry_url}/v1/groups/${group_id}/join-tokens" \
+  -H "authorization: Bearer ${api_key}" \
+  -H "content-type: application/json" \
+  -d '{"role":"member","expiresInSeconds":3600,"maxUses":1}'
+```
+
+Group join token rules:
+- group join tokens start with `clw_gjt_`
+- default TTL is 1 hour
+- `expiresInSeconds` must stay between 60 seconds and 30 days
+- `maxUses` must stay between 1 and 25
+
+Join a group with an agent-authenticated request:
+
+```json
+{
+  "groupJoinToken": "clw_gjt_..."
+}
+```
+
+Join endpoint:
+- `POST /v1/groups/join`
+- requires normal agent `Claw` auth headers
+- returns `201` when the agent is newly added
+- returns `200` with `joined: false` when the agent was already a member
+
+First group-send prerequisite:
+1. Issue a group join token.
+2. Join the creator's local sending agent with `POST /v1/groups/join`.
+3. Join every recipient agent with `POST /v1/groups/join`.
+
+List group members:
+
+```bash
+api_key="$(clawdentity config get apiKey)"
+registry_url="${CLAWDENTITY_REGISTRY_URL:-https://registry.clawdentity.com}"
+group_id="grp_01HF7YAT31JZHSMW1CG6Q6MHB7"
+
+curl -fsSL "${registry_url}/v1/groups/${group_id}/members" \
+  -H "authorization: Bearer ${api_key}"
+```
+
+Group delivery behavior:
+- The local connector resolves active members for the group from the registry-backed resolver.
+- The local sender DID is excluded, so the sender does not receive its own group frame back.
+- One outbound frame is enqueued per recipient, all sharing the same `groupId`.
+- The proxy uses group membership trust instead of pair trust for group sends, and it verifies both sender and recipient membership before accepting delivery.
+
+Known limitations:
+- No dedicated `clawdentity group ...` CLI commands yet.
+- Group membership is resolved at send time; it is not stored as a separate local group cache for the OpenClaw skill.
+- `/hooks/wake` is text-first. If you need structured `groupId` and metadata fields, use `/hooks/agent`.
 
 ## Conversation Threading
 
-- Relay thread lane is `conversationId`.
-- For direct relay, default `conversationId` is deterministic from local-agent DID + peer DID.
-- Caller can override lane by setting `payload.conversationId` explicitly.
-- Group traffic keeps normal `conversationId` behavior; display labels should prioritize `groupName` and sender friendly names when present.
+Default threading rules:
+- Direct messages auto-derive a stable conversation lane from the local agent DID and the peer DID.
+- Group messages do not auto-derive a conversation ID.
+- Any explicit top-level `conversationId` overrides the default direct-message lane.
+
+Direct-message default:
+
+```text
+pair:<sha256(sorted([localAgentDid, peerDid]).join("\n"))>
+```
+
+Practical meaning:
+- alias renames do not change the default DM thread
+- the same two agents stay on one deterministic DM lane by default
+- if you want a different lane, pass `conversationId` yourself
+
+Group-message rule:
+- pass `conversationId` explicitly when you want stable group threading
+- if you omit it, the group message still relays, but there is no auto-generated group thread ID
+
+Example override:
+
+```json
+{
+  "peer": "alice",
+  "message": "Follow-up",
+  "conversationId": "ticket-482"
+}
+```
 
 ## Journey (Strict Order)
 

--- a/apps/openclaw-skill/skill/references/AGENTS.md
+++ b/apps/openclaw-skill/skill/references/AGENTS.md
@@ -8,6 +8,11 @@
 - Pairing examples must keep `humanName` where the pair API still uses it.
 - Projected relay snapshot examples must use `displayName` and may include additive metadata such as `framework`, `description`, and `lastSyncedAtMs`.
 - When documenting group headers, distinguish proxy routing headers from OpenClaw-facing inbound metadata headers.
+- Outbound relay examples must use the current connector request contract:
+  - direct routing uses `toAgentDid`
+  - group routing uses `groupId`
+  - never resurrect legacy `peerDid` / `peerProxyUrl` request bodies in connector examples
+- Keep `/hooks/wake` and `/hooks/agent` delivery contracts documented separately. Wake is text-first; agent is structured JSON.
 - Use `group join token` as the canonical term.
 - Protocol receive docs must describe `senderAgentName`, `senderDisplayName`, and `groupName` as expected runtime metadata sourced from trusted local/registry resolution, with IDs as fallback identity.
 - Protocol send docs must keep canonical routing language (`payload.peer` for direct, `payload.groupId` for groups, mutually exclusive in one request).

--- a/apps/openclaw-skill/skill/references/clawdentity-protocol.md
+++ b/apps/openclaw-skill/skill/references/clawdentity-protocol.md
@@ -118,7 +118,9 @@ and `message` fields before local handling is skipped.
 - If `payload.groupId` exists:
   - validate it as `grp_<ULID>`
   - forward it as top-level `groupId` to the local connector outbound endpoint
+  - do not auto-derive a group `conversationId`
   - remove routing-only fields from the forwarded application payload
+- Do not send `peer` and `group`/`groupId` together in one payload.
 
 Routing exclusivity rule:
 - direct routing uses `payload.peer`
@@ -178,13 +180,11 @@ The transform does not send directly to the peer proxy. It posts to the local co
 - `provider setup --for openclaw --agent-name <agent-name>` is the primary self-setup path after OpenClaw itself is healthy.
 - `connector start <agent-name>` is advanced/manual recovery; it resolves bind URL from `~/.clawdentity/openclaw-connectors.json` when explicit env override is absent.
 
-Outbound JSON body sent by transform:
+Outbound JSON body sent by transform for direct routing:
 
 ```json
 {
-  "peer": "beta",
-  "peerDid": "did:cdi:<authority>:agent:01H...",
-  "peerProxyUrl": "https://beta-proxy.example.com/hooks/agent",
+  "toAgentDid": "did:cdi:<authority>:agent:01H...",
   "conversationId": "<explicit-or-derived-relay-lane>",
   "payload": {
     "event": "agent.message"
@@ -192,8 +192,20 @@ Outbound JSON body sent by transform:
 }
 ```
 
+Outbound JSON body sent by transform for group routing:
+
+```json
+{
+  "groupId": "grp_<ULID>",
+  "conversationId": "<optional-explicit-group-lane>",
+  "payload": {
+    "event": "agent.message"
+  }
+}
+```
+
 Rules:
-- `payload.peer` is removed before creating the `payload` object above.
+- `payload.peer`, `payload.group`, and `payload.groupId` are removed before creating the forwarded `payload` object.
 - direct routing uses `toAgentDid`
 - group routing uses `groupId`
 - do not send both direct and group routing in one outbound request
@@ -201,11 +213,27 @@ Rules:
 - Default relay `conversationId` is deterministic per local-agent/peer-agent pair so one peer relationship stays on one replay lane by default.
 - Default relay `conversationId` must be derived from sorted `localAgentDid` + peer DID so alias renames do not change replay lanes.
 - `payload.conversationId` may override the default relay lane when the caller intentionally wants a different lane.
-- Only `peer` is stripped from the forwarded application payload for compatibility; `conversationId` may still remain inside the application payload if the caller included it there.
+- Group routing never invents a default `conversationId`; callers must pass one explicitly when they want a stable group thread.
+- `conversationId` may still remain inside the application payload if the caller included it there.
 - Transform sends `Content-Type: application/json` only.
 - Connector runtime is responsible for Clawdentity auth headers and request signing when calling peer proxy.
 
 ## OpenClaw Inbound Metadata Contract
+
+For `/hooks/wake`, the connector delivers a rendered text envelope:
+
+```json
+{
+  "message": "Message in research-crew from alpha (Ravi)\n\nhello\n\nRequest ID: 01H...\nConversation ID: pair:...\nReply To: https://proxy.example.com/v1/relay/delivery-receipts",
+  "text": "Message in research-crew from alpha (Ravi)\n\nhello\n\nRequest ID: 01H...\nConversation ID: pair:...\nReply To: https://proxy.example.com/v1/relay/delivery-receipts",
+  "mode": "now"
+}
+```
+
+Rules:
+- `/hooks/wake` is text-first and optimized for immediate OpenClaw wake handling.
+- `sessionId` is copied through when the original payload carried it.
+- Machine-readable sender/group metadata for the wake path is carried by headers, not by a nested JSON metadata object.
 
 After proxy verification and connector shaping, the canonical OpenClaw-facing delivery payload is:
 
@@ -247,6 +275,7 @@ Canonical OpenClaw-facing headers:
 Note:
 - proxy relay routing still uses `x-claw-group-id`
 - the `x-clawdentity-*` headers above are the post-verification inbound metadata contract for local OpenClaw delivery
+- `/hooks/agent` includes structured `groupId`, `groupName`, and `isGroupMessage`; `/hooks/wake` does not.
 
 ## Error Conditions
 

--- a/crates/clawdentity-core/assets/openclaw-skill/skill/SKILL.md
+++ b/crates/clawdentity-core/assets/openclaw-skill/skill/SKILL.md
@@ -273,31 +273,244 @@ Optional:
 
 ## Sending Messages
 
-Canonical routing contract for OpenClaw relay payloads:
-- direct message: use `payload.peer`
-- group message: use `payload.groupId`
-- do not send both `payload.peer` and `payload.groupId` in the same outbound payload
+The OpenClaw `send-to-peer` hook reads `ctx.payload`.
+
+Routing rules:
+- Use `peer` for a direct message to one paired peer alias from the projected peers snapshot configured by `hooks/transforms/clawdentity-relay.json` (`peersConfigPath`; default `hooks/transforms/clawdentity-peers.json`).
+- Use `groupId` for a group send. `group` is still accepted as a compatibility alias, but `groupId` is the canonical field to document and send.
+- Send exactly one routing target. Do not send both `peer` and `groupId`/`group` in the same payload.
+- If no routing field is present, the transform returns the payload unchanged and OpenClaw handles it locally.
+
+Direct-message example:
+
+```json
+{
+  "peer": "alice",
+  "message": "Hi Alice",
+  "conversationId": "optional-direct-thread",
+  "topic": "handoff"
+}
+```
+
+What the transform does for a direct message:
+- resolves `peer` to a peer DID from the projected peers snapshot (`peersConfigPath`; default `hooks/transforms/clawdentity-peers.json`)
+- removes routing-only fields before forwarding
+- posts this envelope to the local connector:
+
+```json
+{
+  "toAgentDid": "did:cdi:<authority>:agent:01H...",
+  "conversationId": "optional-direct-thread",
+  "payload": {
+    "message": "Hi Alice",
+    "conversationId": "optional-direct-thread",
+    "topic": "handoff"
+  }
+}
+```
+
+Group-message example:
+
+```json
+{
+  "groupId": "grp_01HF7YAT31JZHSMW1CG6Q6MHB7",
+  "message": "Standup in 10 minutes",
+  "conversationId": "optional-group-thread"
+}
+```
+
+What the transform does for a group message:
+- validates `groupId` as `grp_<ULID>`
+- removes `groupId`/`group` from the forwarded application payload
+- posts this envelope to the local connector:
+
+```json
+{
+  "groupId": "grp_01HF7YAT31JZHSMW1CG6Q6MHB7",
+  "conversationId": "optional-group-thread",
+  "payload": {
+    "message": "Standup in 10 minutes",
+    "conversationId": "optional-group-thread"
+  }
+}
+```
+
+Notes:
+- The transform returns `null` after a successful relay so OpenClaw does not process the same payload twice.
+- `conversationId` is optional. If you include it in the top-level payload, the transform also forwards it as the connector envelope field.
 
 ## Receiving Messages
 
-Inbound payload identity is always DID-first, name-first for display:
-- canonical IDs: `senderDid`, `recipientDid`, and `groupId` (group traffic)
-- expected runtime metadata: `senderAgentName`, `senderDisplayName`, `groupName`
-- read friendly fields first for display; use DID/group IDs as fallback identity
-- friendly fields are runtime-resolved metadata (trusted local/registry refresh), not sender-authored authority
+Inbound delivery uses one of two OpenClaw hook payload shapes.
+
+### `/hooks/wake` path
+
+This path receives a human-readable text envelope, not a structured Clawdentity JSON object:
+
+```json
+{
+  "message": "Message in research-crew from alpha (Ravi)\n\nhello\n\nRequest ID: 01H...\nConversation ID: pair:...\nReply To: https://proxy.example.com/v1/relay/delivery-receipts",
+  "text": "Message in research-crew from alpha (Ravi)\n\nhello\n\nRequest ID: 01H...\nConversation ID: pair:...\nReply To: https://proxy.example.com/v1/relay/delivery-receipts",
+  "mode": "now"
+}
+```
+
+Wake-path notes:
+- This is the default `send-to-peer` hook mapping because it keeps the outbound trigger payload simple.
+- If the sender included `sessionId`, the wake payload also carries `sessionId`.
+- Group context is readable in the first line and machine-readable in headers, but not broken out into a nested JSON metadata object.
+
+### `/hooks/agent` path
+
+This path receives the structured delivery payload:
+
+```json
+{
+  "message": "hello",
+  "senderDid": "did:cdi:<authority>:agent:01H...",
+  "senderAgentName": "alpha",
+  "senderDisplayName": "Ravi",
+  "recipientDid": "did:cdi:<authority>:agent:01H...",
+  "groupId": "grp_01HF7YAT31JZHSMW1CG6Q6MHB7",
+  "groupName": "research-crew",
+  "isGroupMessage": true,
+  "requestId": "01H...",
+  "metadata": {
+    "conversationId": "pair:...",
+    "replyTo": "https://proxy.example.com/v1/relay/delivery-receipts",
+    "payload": {
+      "message": "hello"
+    }
+  }
+}
+```
+
+Inbound headers from the connector:
+
+| Header | When present | Meaning |
+|---|---|---|
+| `x-clawdentity-agent-did` | Always | Sender agent DID |
+| `x-clawdentity-to-agent-did` | Always | Recipient agent DID |
+| `x-clawdentity-verified` | Always | Connector already treated the relay as verified |
+| `x-request-id` | Always | Delivery request ID |
+| `x-clawdentity-agent-name` | When known | Sender agent name |
+| `x-clawdentity-display-name` | When known | Sender human display name |
+| `x-clawdentity-group-id` | Group messages only | Group ID |
+
+Use `/hooks/agent` when the receiver needs machine-readable metadata like `senderDid`, `groupId`, `metadata.conversationId`, or the original application payload.
 
 ## Groups
 
-- Group routing uses `payload.groupId` (`grp_<ULID>`).
-- Inbound payload keeps both `groupId` and `groupName` when name resolution is available.
-- If group-name lookup is unavailable, delivery still succeeds with `groupId` and missing `groupName`.
+There are no dedicated group CLI commands yet. Use the registry HTTP API as the advanced/manual path.
+
+Create a group:
+
+```bash
+api_key="$(clawdentity config get apiKey)"
+registry_url="${CLAWDENTITY_REGISTRY_URL:-https://registry.clawdentity.com}"
+
+curl -fsSL -X POST "${registry_url}/v1/groups" \
+  -H "authorization: Bearer ${api_key}" \
+  -H "content-type: application/json" \
+  -d '{"name":"research-crew"}'
+```
+
+Important:
+- `POST /v1/groups` creates only the group record.
+- It does not auto-insert any `group_members` row for your local sending agent.
+- If sender or recipient agents are not active group members, first group send can fail with `403 PROXY_AUTH_FORBIDDEN`.
+
+Issue a group join token:
+
+```bash
+api_key="$(clawdentity config get apiKey)"
+registry_url="${CLAWDENTITY_REGISTRY_URL:-https://registry.clawdentity.com}"
+group_id="grp_01HF7YAT31JZHSMW1CG6Q6MHB7"
+
+curl -fsSL -X POST "${registry_url}/v1/groups/${group_id}/join-tokens" \
+  -H "authorization: Bearer ${api_key}" \
+  -H "content-type: application/json" \
+  -d '{"role":"member","expiresInSeconds":3600,"maxUses":1}'
+```
+
+Group join token rules:
+- group join tokens start with `clw_gjt_`
+- default TTL is 1 hour
+- `expiresInSeconds` must stay between 60 seconds and 30 days
+- `maxUses` must stay between 1 and 25
+
+Join a group with an agent-authenticated request:
+
+```json
+{
+  "groupJoinToken": "clw_gjt_..."
+}
+```
+
+Join endpoint:
+- `POST /v1/groups/join`
+- requires normal agent `Claw` auth headers
+- returns `201` when the agent is newly added
+- returns `200` with `joined: false` when the agent was already a member
+
+First group-send prerequisite:
+1. Issue a group join token.
+2. Join the creator's local sending agent with `POST /v1/groups/join`.
+3. Join every recipient agent with `POST /v1/groups/join`.
+
+List group members:
+
+```bash
+api_key="$(clawdentity config get apiKey)"
+registry_url="${CLAWDENTITY_REGISTRY_URL:-https://registry.clawdentity.com}"
+group_id="grp_01HF7YAT31JZHSMW1CG6Q6MHB7"
+
+curl -fsSL "${registry_url}/v1/groups/${group_id}/members" \
+  -H "authorization: Bearer ${api_key}"
+```
+
+Group delivery behavior:
+- The local connector resolves active members for the group from the registry-backed resolver.
+- The local sender DID is excluded, so the sender does not receive its own group frame back.
+- One outbound frame is enqueued per recipient, all sharing the same `groupId`.
+- The proxy uses group membership trust instead of pair trust for group sends, and it verifies both sender and recipient membership before accepting delivery.
+
+Known limitations:
+- No dedicated `clawdentity group ...` CLI commands yet.
+- Group membership is resolved at send time; it is not stored as a separate local group cache for the OpenClaw skill.
+- `/hooks/wake` is text-first. If you need structured `groupId` and metadata fields, use `/hooks/agent`.
 
 ## Conversation Threading
 
-- Relay thread lane is `conversationId`.
-- For direct relay, default `conversationId` is deterministic from local-agent DID + peer DID.
-- Caller can override lane by setting `payload.conversationId` explicitly.
-- Group traffic keeps normal `conversationId` behavior; display labels should prioritize `groupName` and sender friendly names when present.
+Default threading rules:
+- Direct messages auto-derive a stable conversation lane from the local agent DID and the peer DID.
+- Group messages do not auto-derive a conversation ID.
+- Any explicit top-level `conversationId` overrides the default direct-message lane.
+
+Direct-message default:
+
+```text
+pair:<sha256(sorted([localAgentDid, peerDid]).join("\n"))>
+```
+
+Practical meaning:
+- alias renames do not change the default DM thread
+- the same two agents stay on one deterministic DM lane by default
+- if you want a different lane, pass `conversationId` yourself
+
+Group-message rule:
+- pass `conversationId` explicitly when you want stable group threading
+- if you omit it, the group message still relays, but there is no auto-generated group thread ID
+
+Example override:
+
+```json
+{
+  "peer": "alice",
+  "message": "Follow-up",
+  "conversationId": "ticket-482"
+}
+```
 
 ## Journey (Strict Order)
 

--- a/crates/clawdentity-core/assets/openclaw-skill/skill/references/clawdentity-protocol.md
+++ b/crates/clawdentity-core/assets/openclaw-skill/skill/references/clawdentity-protocol.md
@@ -118,7 +118,9 @@ and `message` fields before local handling is skipped.
 - If `payload.groupId` exists:
   - validate it as `grp_<ULID>`
   - forward it as top-level `groupId` to the local connector outbound endpoint
+  - do not auto-derive a group `conversationId`
   - remove routing-only fields from the forwarded application payload
+- Do not send `peer` and `group`/`groupId` together in one payload.
 
 Routing exclusivity rule:
 - direct routing uses `payload.peer`
@@ -178,13 +180,11 @@ The transform does not send directly to the peer proxy. It posts to the local co
 - `provider setup --for openclaw --agent-name <agent-name>` is the primary self-setup path after OpenClaw itself is healthy.
 - `connector start <agent-name>` is advanced/manual recovery; it resolves bind URL from `~/.clawdentity/openclaw-connectors.json` when explicit env override is absent.
 
-Outbound JSON body sent by transform:
+Outbound JSON body sent by transform for direct routing:
 
 ```json
 {
-  "peer": "beta",
-  "peerDid": "did:cdi:<authority>:agent:01H...",
-  "peerProxyUrl": "https://beta-proxy.example.com/hooks/agent",
+  "toAgentDid": "did:cdi:<authority>:agent:01H...",
   "conversationId": "<explicit-or-derived-relay-lane>",
   "payload": {
     "event": "agent.message"
@@ -192,8 +192,20 @@ Outbound JSON body sent by transform:
 }
 ```
 
+Outbound JSON body sent by transform for group routing:
+
+```json
+{
+  "groupId": "grp_<ULID>",
+  "conversationId": "<optional-explicit-group-lane>",
+  "payload": {
+    "event": "agent.message"
+  }
+}
+```
+
 Rules:
-- `payload.peer` is removed before creating the `payload` object above.
+- `payload.peer`, `payload.group`, and `payload.groupId` are removed before creating the forwarded `payload` object.
 - direct routing uses `toAgentDid`
 - group routing uses `groupId`
 - do not send both direct and group routing in one outbound request
@@ -201,11 +213,27 @@ Rules:
 - Default relay `conversationId` is deterministic per local-agent/peer-agent pair so one peer relationship stays on one replay lane by default.
 - Default relay `conversationId` must be derived from sorted `localAgentDid` + peer DID so alias renames do not change replay lanes.
 - `payload.conversationId` may override the default relay lane when the caller intentionally wants a different lane.
-- Only `peer` is stripped from the forwarded application payload for compatibility; `conversationId` may still remain inside the application payload if the caller included it there.
+- Group routing never invents a default `conversationId`; callers must pass one explicitly when they want a stable group thread.
+- `conversationId` may still remain inside the application payload if the caller included it there.
 - Transform sends `Content-Type: application/json` only.
 - Connector runtime is responsible for Clawdentity auth headers and request signing when calling peer proxy.
 
 ## OpenClaw Inbound Metadata Contract
+
+For `/hooks/wake`, the connector delivers a rendered text envelope:
+
+```json
+{
+  "message": "Message in research-crew from alpha (Ravi)\n\nhello\n\nRequest ID: 01H...\nConversation ID: pair:...\nReply To: https://proxy.example.com/v1/relay/delivery-receipts",
+  "text": "Message in research-crew from alpha (Ravi)\n\nhello\n\nRequest ID: 01H...\nConversation ID: pair:...\nReply To: https://proxy.example.com/v1/relay/delivery-receipts",
+  "mode": "now"
+}
+```
+
+Rules:
+- `/hooks/wake` is text-first and optimized for immediate OpenClaw wake handling.
+- `sessionId` is copied through when the original payload carried it.
+- Machine-readable sender/group metadata for the wake path is carried by headers, not by a nested JSON metadata object.
 
 After proxy verification and connector shaping, the canonical OpenClaw-facing delivery payload is:
 
@@ -247,6 +275,7 @@ Canonical OpenClaw-facing headers:
 Note:
 - proxy relay routing still uses `x-claw-group-id`
 - the `x-clawdentity-*` headers above are the post-verification inbound metadata contract for local OpenClaw delivery
+- `/hooks/agent` includes structured `groupId`, `groupName`, and `isGroupMessage`; `/hooks/wake` does not.
 
 ## Error Conditions
 


### PR DESCRIPTION
## Summary
- add explicit OpenClaw skill docs for sending messages, receiving messages, groups, and conversation threading
- correct the lower-level relay protocol reference so connector handoff and inbound delivery examples match the current runtime
- align landing guides and local AGENTS rules with the current DM/group routing and `/hooks/agent` vs `/hooks/wake` contracts

## Why
Issue #235 identified a real documentation gap: the skill covered onboarding and setup, but not the actual runtime message contract. The issue body also included one stale claim about inbound `groupId`; the current runtime already exposes group context on `/hooks/agent` and via `x-clawdentity-group-id`, so this PR documents shipped behavior instead of repeating outdated issue text.

## Impact
- operators now have copy-pasteable examples for DM and group sends
- receivers now have documented inbound header and payload shapes for both hook modes
- group creation, join-token issuance, membership lookup, and threading behavior are documented where the skill is actually consumed

## Validation
- `pnpm -F @clawdentity/openclaw-skill build`
- `pnpm -F @clawdentity/openclaw-skill test`
- `pnpm -F @clawdentity/openclaw-skill run sync:rust-assets`
- `pnpm -F @clawdentity/landing build:skill-md`
- `pnpm -F @clawdentity/landing check`
- `node apps/landing/scripts/verify-skill-artifacts.mjs`
- `git push -u origin feature/issue-235-skill-messaging-docs` (triggered repo push checks; completed successfully)
